### PR TITLE
ci: trigger terminal invariant repair

### DIFF
--- a/.github/ai-error-terminal-invariant-trigger
+++ b/.github/ai-error-terminal-invariant-trigger
@@ -1,1 +1,1 @@
-trigger terminal invariant repair
+trigger final error contract verification

--- a/.github/ai-error-terminal-invariant-trigger
+++ b/.github/ai-error-terminal-invariant-trigger
@@ -1,0 +1,1 @@
+trigger terminal invariant repair


### PR DESCRIPTION
Temporary same-repository trigger for the one-shot terminal invariant repair on `fix/ai-error-contract-closure`. Close after the workflow applies the repair and removes itself.