### PR TITLE
fix(ai): preserve durable truth across cancellation

### DIFF
--- a/linktools-ai/AGENTS.md
+++ b/linktools-ai/AGENTS.md
@@ -161,6 +161,7 @@ Apply these during design, not after implementation:
 - Integrity checks validate stored bytes and structure. Never require a dependency upgrade to re-encode old data byte-for-byte identically.
 - Stable hashes and idempotency identities must not change because a dependency adds optional/default fields.
 - If codec, version, or provenance changes semantics, include that discriminator in stable hashes and idempotency identities; never hash only the opaque payload.
+- Caller cancellation does not determine durable truth. Keep shielded commits owned until operation/readback settles; use `STORAGE_COMMIT_UNKNOWN` only when final readback cannot resolve the outcome.
 - Internal transport encoders, durable wire types, and implementation protocols stay private unless they are intentional extension points.
 - A public Protocol change is an API change. Keep runtime-only bridges private instead of leaking internal policy parameters downstream.
 - Serializable provider references are not automatically durable. Define lifetime/recovery semantics before persisting remote file IDs, URLs, handles, or tokens.

--- a/linktools-ai/AGENTS.md
+++ b/linktools-ai/AGENTS.md
@@ -162,6 +162,7 @@ Apply these during design, not after implementation:
 - Stable hashes and idempotency identities must not change because a dependency adds optional/default fields.
 - If codec, version, or provenance changes semantics, include that discriminator in stable hashes and idempotency identities; never hash only the opaque payload.
 - Caller cancellation does not determine durable truth. Keep shielded commits owned until operation/readback settles; use `STORAGE_COMMIT_UNKNOWN` only when final readback cannot resolve the outcome.
+- Per-request model observations belong at the model-response boundary. Persist them before aggregation and derive run totals from the same request facts; never reconstruct single-call data from cumulative usage.
 - Internal transport encoders, durable wire types, and implementation protocols stay private unless they are intentional extension points.
 - A public Protocol change is an API change. Keep runtime-only bridges private instead of leaking internal policy parameters downstream.
 - Serializable provider references are not automatically durable. Define lifetime/recovery semantics before persisting remote file IDs, URLs, handles, or tokens.

--- a/linktools-ai/src/linktools/ai/adapter/_history.py
+++ b/linktools-ai/src/linktools/ai/adapter/_history.py
@@ -49,6 +49,18 @@ from ..runtime.state import (
 )
 
 _logger = environ.get_logger("ai.adapter.history")
+_MODEL_USAGE_INPUT_METADATA_KEY = "linktools.ai.model_usage.input_tokens"
+_MODEL_USAGE_OUTPUT_METADATA_KEY = "linktools.ai.model_usage.output_tokens"
+_MODEL_USAGE_CACHE_READ_METADATA_KEY = "linktools.ai.model_usage.cache_read_tokens"
+_MODEL_USAGE_CACHE_WRITE_METADATA_KEY = "linktools.ai.model_usage.cache_write_tokens"
+_MODEL_USAGE_METADATA_KEYS = frozenset(
+    {
+        _MODEL_USAGE_INPUT_METADATA_KEY,
+        _MODEL_USAGE_OUTPUT_METADATA_KEY,
+        _MODEL_USAGE_CACHE_READ_METADATA_KEY,
+        _MODEL_USAGE_CACHE_WRITE_METADATA_KEY,
+    }
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -527,7 +539,7 @@ class StepExecutionHistoryReader:
             )
         source_digest = canonical_sha256(
             {
-                "model_version": 2,
+                "model_version": 3,
                 "root_execution_id": root.execution_id,
                 "seals": seals,
             }
@@ -787,6 +799,8 @@ def _trace_item(record: ExecutionRecord, segment_sequence: int, depth: int, ordi
         return None
     kind, status = value
     payload = {"kind": kind, "status": status, "step_index": event.step_index, "segment_sequence": segment_sequence, "scope": "root" if depth == 0 else "subagent", "depth": depth}
+    if kind == "MODEL_RESPONSE":
+        payload["token_usage"] = _model_token_usage(event) if status == "SUCCEEDED" else None
     if event.agent_name is not None:
         payload["agent_name"] = event.agent_name
     if event.tool_call_id is not None:
@@ -796,6 +810,48 @@ def _trace_item(record: ExecutionRecord, segment_sequence: int, depth: int, ordi
     if depth > 0:
         payload["child_execution_id"] = record.execution_id
     return ExecutionTraceItem(record.execution_id, ordinal, payload)
+
+
+def _model_token_usage(event: StepEvent) -> "dict[str, JsonValue] | None":
+    metadata = event.metadata
+    present = _MODEL_USAGE_METADATA_KEYS.intersection(metadata)
+    if not present:
+        return None
+    if (
+        _MODEL_USAGE_INPUT_METADATA_KEY not in metadata
+        or _MODEL_USAGE_OUTPUT_METADATA_KEY not in metadata
+    ):
+        raise AIError(ErrorCode.STORAGE_INTEGRITY_ERROR)
+    return {
+        "input_tokens": _metadata_token(metadata, _MODEL_USAGE_INPUT_METADATA_KEY),
+        "output_tokens": _metadata_token(metadata, _MODEL_USAGE_OUTPUT_METADATA_KEY),
+        "cache_read_tokens": _metadata_token(
+            metadata,
+            _MODEL_USAGE_CACHE_READ_METADATA_KEY,
+            required=False,
+        ),
+        "cache_write_tokens": _metadata_token(
+            metadata,
+            _MODEL_USAGE_CACHE_WRITE_METADATA_KEY,
+            required=False,
+        ),
+    }
+
+
+def _metadata_token(
+    metadata: Mapping[str, str],
+    key: str,
+    *,
+    required: bool = True,
+) -> "int | None":
+    raw = metadata.get(key)
+    if raw is None:
+        if required:
+            raise AIError(ErrorCode.STORAGE_INTEGRITY_ERROR)
+        return None
+    if not raw.isdigit():
+        raise AIError(ErrorCode.STORAGE_INTEGRITY_ERROR)
+    return int(raw)
 
 
 def _merge_history_refs(

--- a/linktools-ai/src/linktools/ai/agent/_capabilities.py
+++ b/linktools-ai/src/linktools/ai/agent/_capabilities.py
@@ -891,21 +891,12 @@ def _workspace_file_key(part: ToolCallPart) -> "str | None":
 
 def _model_usage_metadata(response: ModelResponse) -> dict[str, str]:
     usage = response.usage
-    values = {
+    return {
         _MODEL_USAGE_INPUT_METADATA_KEY: _model_usage_token(usage.input_tokens),
         _MODEL_USAGE_OUTPUT_METADATA_KEY: _model_usage_token(usage.output_tokens),
+        _MODEL_USAGE_CACHE_READ_METADATA_KEY: _model_usage_token(usage.cache_read_tokens),
+        _MODEL_USAGE_CACHE_WRITE_METADATA_KEY: _model_usage_token(usage.cache_write_tokens),
     }
-    # RequestUsage class defaults collapse a provider-omitted cache field to zero.
-    # Pydantic AI 2.27+ preserves actual provider field presence on the instance.
-    # Keep this compatibility-sensitive check here and pin it with regression tests.
-    present = usage.__dict__
-    for field_name, metadata_key in (
-        ("cache_read_tokens", _MODEL_USAGE_CACHE_READ_METADATA_KEY),
-        ("cache_write_tokens", _MODEL_USAGE_CACHE_WRITE_METADATA_KEY),
-    ):
-        if field_name in present:
-            values[metadata_key] = _model_usage_token(present[field_name])
-    return values
 
 
 def _model_usage_token(value: object) -> str:

--- a/linktools-ai/src/linktools/ai/agent/_capabilities.py
+++ b/linktools-ai/src/linktools/ai/agent/_capabilities.py
@@ -21,7 +21,7 @@ from pydantic_ai.exceptions import (
     ToolFailedError,
     ToolRetryError,
 )
-from pydantic_ai.messages import RetryPromptPart, ToolCallPart, ToolReturnPart
+from pydantic_ai.messages import ModelResponse, RetryPromptPart, ToolCallPart, ToolReturnPart
 from pydantic_ai.models import Model, ModelRequestContext
 from pydantic_ai.tools import RunContext, ToolDefinition
 from pydantic_ai.toolsets import AbstractToolset, FunctionToolset
@@ -33,7 +33,7 @@ from pydantic_ai_harness.compaction import (
 )
 from pydantic_ai_harness.memory import Memory, SearchableMemoryStore
 from pydantic_ai_harness.planning import Planning
-from pydantic_ai_harness.step_persistence import StepPersistence, StepStore
+from pydantic_ai_harness.step_persistence import StepEvent, StepPersistence, StepStore
 
 from ..capability import SKILL_TOOL_NAMES
 from ..core import JsonValue
@@ -65,6 +65,10 @@ WORKSPACE_FILESYSTEM_READ_TOOL_NAMES = (
 WORKSPACE_SHELL_TOOL_NAMES = ("check_command", "run_command", "start_command", "stop_command")
 PLAN_SAFE_METADATA_KEY = "linktools.ai.plan_safe"
 _REPLAY_SAFE_METADATA_KEY = "linktools.ai.replay_safe"
+_MODEL_USAGE_INPUT_METADATA_KEY = "linktools.ai.model_usage.input_tokens"
+_MODEL_USAGE_OUTPUT_METADATA_KEY = "linktools.ai.model_usage.output_tokens"
+_MODEL_USAGE_CACHE_READ_METADATA_KEY = "linktools.ai.model_usage.cache_read_tokens"
+_MODEL_USAGE_CACHE_WRITE_METADATA_KEY = "linktools.ai.model_usage.cache_write_tokens"
 _TRUSTED_TOOL_CLASSES = frozenset(
     {
         "control",
@@ -184,6 +188,32 @@ class _RuntimeStepPersistence(StepPersistence[None]):
         self._trusted_mcp_selectors = trusted_mcp_selectors
         self._calls: dict[tuple[str, str], _ToolCallState] = {}
         self._background_tasks = set() if background_tasks is None else background_tasks
+
+    async def after_model_request(
+        self,
+        ctx: "RunContext[None]",
+        *,
+        request_context: ModelRequestContext,
+        response: ModelResponse,
+    ) -> ModelResponse:
+        del request_context
+        run_id = self.run_id or ctx.run_id
+        if not run_id:
+            raise AIError(ErrorCode.RUNTIME_DEPENDENCY_NOT_READY)
+        metadata = dict(self.metadata)
+        metadata.update(_model_usage_metadata(response))
+        await self.store.append_event(
+            StepEvent(
+                run_id=run_id,
+                kind="model_request_completed",
+                step_index=ctx.run_step,
+                conversation_id=ctx.conversation_id,
+                parent_run_id=self.parent_run_id,
+                agent_name=self.agent_name,
+                metadata=metadata,
+            )
+        )
+        return response
 
     async def before_tool_execute(
         self,
@@ -857,6 +887,31 @@ def _workspace_file_key(part: ToolCallPart) -> "str | None":
         return None
     path = arguments.get("path")
     return path if isinstance(path, str) else None
+
+
+def _model_usage_metadata(response: ModelResponse) -> dict[str, str]:
+    usage = response.usage
+    values = {
+        _MODEL_USAGE_INPUT_METADATA_KEY: _model_usage_token(usage.input_tokens),
+        _MODEL_USAGE_OUTPUT_METADATA_KEY: _model_usage_token(usage.output_tokens),
+    }
+    # RequestUsage class defaults collapse a provider-omitted cache field to zero.
+    # Pydantic AI 2.27+ preserves actual provider field presence on the instance.
+    # Keep this compatibility-sensitive check here and pin it with regression tests.
+    present = usage.__dict__
+    for field_name, metadata_key in (
+        ("cache_read_tokens", _MODEL_USAGE_CACHE_READ_METADATA_KEY),
+        ("cache_write_tokens", _MODEL_USAGE_CACHE_WRITE_METADATA_KEY),
+    ):
+        if field_name in present:
+            values[metadata_key] = _model_usage_token(present[field_name])
+    return values
+
+
+def _model_usage_token(value: object) -> str:
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise AIError(ErrorCode.MODEL_RESPONSE_INVALID)
+    return str(value)
 
 
 def _validate_compaction_target(value: "int | None") -> None:

--- a/linktools-ai/src/linktools/ai/core/_usage.py
+++ b/linktools-ai/src/linktools/ai/core/_usage.py
@@ -4,19 +4,6 @@
 
 from dataclasses import dataclass
 
-MODEL_USAGE_INPUT_METADATA_KEY = "linktools.ai.model_usage.input_tokens"
-MODEL_USAGE_OUTPUT_METADATA_KEY = "linktools.ai.model_usage.output_tokens"
-MODEL_USAGE_CACHE_READ_METADATA_KEY = "linktools.ai.model_usage.cache_read_tokens"
-MODEL_USAGE_CACHE_WRITE_METADATA_KEY = "linktools.ai.model_usage.cache_write_tokens"
-MODEL_USAGE_METADATA_KEYS = frozenset(
-    {
-        MODEL_USAGE_INPUT_METADATA_KEY,
-        MODEL_USAGE_OUTPUT_METADATA_KEY,
-        MODEL_USAGE_CACHE_READ_METADATA_KEY,
-        MODEL_USAGE_CACHE_WRITE_METADATA_KEY,
-    }
-)
-
 
 @dataclass(frozen=True, slots=True)
 class UsageMetrics:
@@ -44,11 +31,4 @@ class UsageMetrics:
         return self.input_tokens + self.output_tokens
 
 
-__all__ = [
-    "MODEL_USAGE_CACHE_READ_METADATA_KEY",
-    "MODEL_USAGE_CACHE_WRITE_METADATA_KEY",
-    "MODEL_USAGE_INPUT_METADATA_KEY",
-    "MODEL_USAGE_METADATA_KEYS",
-    "MODEL_USAGE_OUTPUT_METADATA_KEY",
-    "UsageMetrics",
-]
+__all__ = ["UsageMetrics"]

--- a/linktools-ai/src/linktools/ai/core/_usage.py
+++ b/linktools-ai/src/linktools/ai/core/_usage.py
@@ -4,6 +4,19 @@
 
 from dataclasses import dataclass
 
+MODEL_USAGE_INPUT_METADATA_KEY = "linktools.ai.model_usage.input_tokens"
+MODEL_USAGE_OUTPUT_METADATA_KEY = "linktools.ai.model_usage.output_tokens"
+MODEL_USAGE_CACHE_READ_METADATA_KEY = "linktools.ai.model_usage.cache_read_tokens"
+MODEL_USAGE_CACHE_WRITE_METADATA_KEY = "linktools.ai.model_usage.cache_write_tokens"
+MODEL_USAGE_METADATA_KEYS = frozenset(
+    {
+        MODEL_USAGE_INPUT_METADATA_KEY,
+        MODEL_USAGE_OUTPUT_METADATA_KEY,
+        MODEL_USAGE_CACHE_READ_METADATA_KEY,
+        MODEL_USAGE_CACHE_WRITE_METADATA_KEY,
+    }
+)
+
 
 @dataclass(frozen=True, slots=True)
 class UsageMetrics:
@@ -31,4 +44,11 @@ class UsageMetrics:
         return self.input_tokens + self.output_tokens
 
 
-__all__ = ["UsageMetrics"]
+__all__ = [
+    "MODEL_USAGE_CACHE_READ_METADATA_KEY",
+    "MODEL_USAGE_CACHE_WRITE_METADATA_KEY",
+    "MODEL_USAGE_INPUT_METADATA_KEY",
+    "MODEL_USAGE_METADATA_KEYS",
+    "MODEL_USAGE_OUTPUT_METADATA_KEY",
+    "UsageMetrics",
+]

--- a/linktools-ai/src/linktools/ai/runtime/service_api.py
+++ b/linktools-ai/src/linktools/ai/runtime/service_api.py
@@ -160,6 +160,12 @@ class ExecutionTraceItem:
     sequence: int
     payload: JsonValue
 
+    def __post_init__(self) -> None:
+        if isinstance(self.payload, dict) and self.payload.get("kind") == "MODEL_RESPONSE" and "token_usage" not in self.payload:
+            payload = dict(self.payload)
+            payload["token_usage"] = None
+            object.__setattr__(self, "payload", payload)
+
 
 @dataclass(frozen=True, slots=True)
 class TranscriptItem:

--- a/linktools-ai/src/linktools/ai/runtime/state/_durability.py
+++ b/linktools-ai/src/linktools/ai/runtime/state/_durability.py
@@ -8,12 +8,9 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Generic, TypeVar, cast
 
-from linktools.core import environ
-
 from ...errors import AIError, ErrorCode
 
 ValueT = TypeVar("ValueT")
-_logger = environ.get_logger("ai.runtime.state.durability")
 
 
 class DurableCommitState(str, Enum):
@@ -50,32 +47,13 @@ async def run_durable_commit(
     *,
     background_tasks: "set[asyncio.Task[object]]",
 ) -> DurableCommitResult[ValueT]:
-    """Resolve a durable commit without waiting indefinitely after cancellation."""
+    """Resolve durable truth before propagating caller cancellation."""
     task = asyncio.create_task(operation())
-    cancellation_requested = False
-    operation_error: BaseException | None = None
-    value: ValueT | None = None
-    try:
-        value = await asyncio.shield(task)
-    except asyncio.CancelledError as error:
-        cancellation_requested = True
-        if not task.done():
-            _detach_task(
-                cast("asyncio.Task[object]", task),
-                background_tasks,
-                "durable commit",
-            )
-            return DurableCommitResult(
-                DurableCommitState.UNRESOLVED,
-                error=error,
-                cancelled=True,
-            )
-        try:
-            value = task.result()
-        except BaseException as task_error:  # noqa: BLE001
-            operation_error = task_error
-    except BaseException as error:  # noqa: BLE001
-        operation_error = error
+    value, operation_error, operation_cancelled = await _await_owned_task(
+        task,
+        background_tasks,
+    )
+    cancellation_requested = operation_cancelled
 
     if operation_error is None:
         return DurableCommitResult(
@@ -85,46 +63,22 @@ async def run_durable_commit(
         )
 
     readback_task = asyncio.create_task(readback())
-    try:
-        observation = await asyncio.shield(readback_task)
-    except asyncio.CancelledError as error:
-        cancellation_requested = True
-        if not readback_task.done():
-            _detach_task(
-                cast("asyncio.Task[object]", readback_task),
-                background_tasks,
-                "durable commit readback",
-            )
-            return DurableCommitResult(
-                DurableCommitState.UNRESOLVED,
-                error=error,
-                cancelled=True,
-            )
-        try:
-            observation = readback_task.result()
-        except AIError as readback_error:
+    observation, readback_error, readback_cancelled = await _await_owned_task(
+        readback_task,
+        background_tasks,
+    )
+    cancellation_requested = cancellation_requested or readback_cancelled
+    if readback_error is not None:
+        if isinstance(readback_error, AIError):
             return _readback_error_result(
                 readback_error,
-                cancelled=True,
+                cancelled=cancellation_requested,
             )
-        except BaseException as readback_error:  # noqa: BLE001
-            return DurableCommitResult(
-                DurableCommitState.UNRESOLVED,
-                error=readback_error,
-                cancelled=True,
-            )
-    except AIError as error:
-        return _readback_error_result(
-            error,
-            cancelled=cancellation_requested,
-        )
-    except BaseException as error:  # noqa: BLE001
         return DurableCommitResult(
             DurableCommitState.UNRESOLVED,
-            error=error,
+            error=readback_error,
             cancelled=cancellation_requested,
         )
-
     if not isinstance(observation, CommitObservation):
         raise TypeError("durable commit readback returned an invalid observation")
     return DurableCommitResult(
@@ -133,6 +87,39 @@ async def run_durable_commit(
         error=observation.error or operation_error,
         cancelled=cancellation_requested,
     )
+
+
+async def _await_owned_task(
+    task: "asyncio.Task[ValueT]",
+    background_tasks: "set[asyncio.Task[object]]",
+) -> "tuple[ValueT | None, BaseException | None, bool]":
+    """Keep a shielded durable task owned until its outcome is observable."""
+    cancelled = False
+    owned = False
+    current = asyncio.current_task()
+    tracked = cast("asyncio.Task[object]", task)
+    try:
+        while True:
+            try:
+                return await asyncio.shield(task), None, cancelled
+            except asyncio.CancelledError as error:
+                caller_cancelled = current is not None and current.cancelling() > 0
+                if task.done():
+                    try:
+                        return task.result(), None, cancelled or caller_cancelled
+                    except BaseException as task_error:  # noqa: BLE001
+                        return None, task_error, cancelled or caller_cancelled
+                if not caller_cancelled:
+                    return None, error, cancelled
+                cancelled = True
+                if not owned:
+                    background_tasks.add(tracked)
+                    owned = True
+            except BaseException as error:  # noqa: BLE001
+                return None, error, cancelled
+    finally:
+        if owned:
+            background_tasks.discard(tracked)
 
 
 def _readback_error_result(
@@ -147,26 +134,6 @@ def _readback_error_result(
         error=error,
         cancelled=cancelled,
     )
-
-
-def _detach_task(
-    task: "asyncio.Task[object]",
-    background_tasks: "set[asyncio.Task[object]]",
-    label: str,
-) -> None:
-    background_tasks.add(task)
-
-    def consume(done: "asyncio.Task[object]") -> None:
-        try:
-            done.result()
-        except asyncio.CancelledError:
-            pass
-        except BaseException:  # noqa: BLE001
-            _logger.exception("detached %s failed", label)
-        finally:
-            background_tasks.discard(done)
-
-    task.add_done_callback(consume)
 
 
 __all__ = [

--- a/linktools-ai/src/linktools/ai/runtime/state/_durability.py
+++ b/linktools-ai/src/linktools/ai/runtime/state/_durability.py
@@ -96,21 +96,26 @@ async def _await_owned_task(
     """Keep a shielded durable task owned until its outcome is observable."""
     cancelled = False
     owned = False
-    current = asyncio.current_task()
     tracked = cast("asyncio.Task[object]", task)
     try:
         while True:
             try:
                 return await asyncio.shield(task), None, cancelled
-            except asyncio.CancelledError as error:
-                caller_cancelled = current is not None and current.cancelling() > 0
+            except asyncio.CancelledError:
                 if task.done():
+                    caller_cancelled = not task.cancelled()
                     try:
-                        return task.result(), None, cancelled or caller_cancelled
+                        return (
+                            task.result(),
+                            None,
+                            cancelled or caller_cancelled,
+                        )
                     except BaseException as task_error:  # noqa: BLE001
-                        return None, task_error, cancelled or caller_cancelled
-                if not caller_cancelled:
-                    return None, error, cancelled
+                        return (
+                            None,
+                            task_error,
+                            cancelled or caller_cancelled,
+                        )
                 cancelled = True
                 if not owned:
                     background_tasks.add(tracked)

--- a/tests/ai/test_durable_cancellation_ownership.py
+++ b/tests/ai/test_durable_cancellation_ownership.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Regressions for cancellation ownership at durable StepStore boundaries."""
+
+import asyncio
+
+import pytest
+
+from linktools.ai.runtime.state._durability import CommitObservation, DurableCommitState
+from linktools.ai.runtime.state._steps import (
+    RuntimeStepStore,
+    _RunDurabilityFlight,
+    _RunDurabilityKind,
+    _RunHistoryLock,
+)
+
+
+@pytest.mark.asyncio
+async def test_cancelled_step_flight_finishes_before_waiters_resume() -> None:
+    store = object.__new__(RuntimeStepStore)
+    store._background_tasks = set()
+    store._durability_flights = {}
+    store._history_lock = _RunHistoryLock()
+
+    loop = asyncio.get_running_loop()
+    flight = _RunDurabilityFlight(
+        "run",
+        "token",
+        _RunDurabilityKind.TOOL_EFFECT,
+        loop.create_future(),
+    )
+    store._durability_flights[flight.run_id] = flight
+
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def operation() -> None:
+        started.set()
+        await release.wait()
+
+    async def readback() -> CommitObservation[None]:
+        raise AssertionError("readback is not used after a committed operation")
+
+    async def wait_for_flight() -> None:
+        await asyncio.shield(flight.completion)
+
+    settler = asyncio.create_task(
+        store._settle_durability_flight(flight, operation, readback)
+    )
+    await started.wait()
+    settler.cancel()
+    settler.cancel()
+    await asyncio.sleep(0)
+
+    assert not settler.done()
+    assert store._durability_flights[flight.run_id] is flight
+    assert not flight.completion.done()
+    assert len(store._background_tasks) == 1
+
+    waiter = asyncio.create_task(wait_for_flight())
+    await asyncio.sleep(0)
+    assert not waiter.done()
+
+    release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await settler
+    await waiter
+
+    assert flight.run_id not in store._durability_flights
+    assert flight.completion.done()
+    assert flight.completion.exception() is None
+    assert store._background_tasks == set()
+
+
+@pytest.mark.asyncio
+async def test_step_flight_fences_only_after_real_unresolved_readback() -> None:
+    store = object.__new__(RuntimeStepStore)
+    store._background_tasks = set()
+    store._durability_flights = {}
+    store._history_lock = _RunHistoryLock()
+
+    loop = asyncio.get_running_loop()
+    flight = _RunDurabilityFlight(
+        "run",
+        "token",
+        _RunDurabilityKind.TOOL_EFFECT,
+        loop.create_future(),
+    )
+    store._durability_flights[flight.run_id] = flight
+
+    async def operation() -> None:
+        raise RuntimeError("commit failed")
+
+    async def readback() -> CommitObservation[None]:
+        return CommitObservation(
+            DurableCommitState.UNRESOLVED,
+            error=RuntimeError("readback unavailable"),
+        )
+
+    with pytest.raises(Exception) as raised:
+        await store._settle_durability_flight(flight, operation, readback)
+
+    assert type(raised.value).__name__ == "AIError"
+    assert flight.run_id in store._durability_flights
+    assert flight.completion.done()
+    assert type(flight.completion.exception()).__name__ == "AIError"

--- a/tests/ai/test_durable_cancellation_ownership.py
+++ b/tests/ai/test_durable_cancellation_ownership.py
@@ -6,6 +6,7 @@ import asyncio
 
 import pytest
 
+from linktools.ai.errors import AIError, ErrorCode
 from linktools.ai.runtime.state._durability import CommitObservation, DurableCommitState
 from linktools.ai.runtime.state._steps import (
     RuntimeStepStore,
@@ -97,10 +98,12 @@ async def test_step_flight_fences_only_after_real_unresolved_readback() -> None:
             error=RuntimeError("readback unavailable"),
         )
 
-    with pytest.raises(Exception) as raised:
+    with pytest.raises(AIError) as raised:
         await store._settle_durability_flight(flight, operation, readback)
 
-    assert type(raised.value).__name__ == "AIError"
+    assert raised.value.code is ErrorCode.STORAGE_COMMIT_UNKNOWN
     assert flight.run_id in store._durability_flights
     assert flight.completion.done()
-    assert type(flight.completion.exception()).__name__ == "AIError"
+    completion_error = flight.completion.exception()
+    assert isinstance(completion_error, AIError)
+    assert completion_error.code is ErrorCode.STORAGE_COMMIT_UNKNOWN

--- a/tests/ai/test_durable_contract_repairs.py
+++ b/tests/ai/test_durable_contract_repairs.py
@@ -16,6 +16,7 @@ from linktools.ai.runtime._factory import _RuntimeCloseCoordinator
 from linktools.ai.runtime._execution import DefaultExecutionService
 from linktools.ai.runtime._local import LocalExecutionBackend
 from linktools.ai.runtime.state._durability import (
+    CommitObservation,
     DurableCommitState,
     run_durable_commit,
 )
@@ -163,7 +164,7 @@ def test_global_runtime_capability_is_restored_from_composition() -> None:
 
 
 @pytest.mark.asyncio
-async def test_durable_commit_cancellation_keeps_operation_owned_until_done() -> None:
+async def test_durable_commit_cancellation_settles_operation_before_returning() -> None:
     started = asyncio.Event()
     release = asyncio.Event()
     owner: set[asyncio.Task[object]] = set()
@@ -174,30 +175,27 @@ async def test_durable_commit_cancellation_keeps_operation_owned_until_done() ->
         return "committed"
 
     async def readback() -> object:
-        raise AssertionError("readback is not used for a pending operation")
+        raise AssertionError("readback is not used after a committed operation")
 
     caller = asyncio.create_task(
         run_durable_commit(operation, readback, background_tasks=owner)
     )
     await started.wait()
     caller.cancel()
-    result = await caller
-    assert result.state is DurableCommitState.UNRESOLVED
-    assert result.cancelled
+    await asyncio.sleep(0)
+    assert not caller.done()
     assert len(owner) == 1
-    owned = next(iter(owner))
-    assert not owned.done()
 
     release.set()
-    await owned
-    await asyncio.sleep(0)
+    result = await caller
+    assert result.state is DurableCommitState.COMMITTED
+    assert result.value == "committed"
+    assert result.cancelled
     assert owner == set()
 
 
 @pytest.mark.asyncio
-async def test_durable_commit_cancellation_owns_failed_readback_until_done(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
+async def test_durable_commit_cancellation_settles_readback_before_unknown() -> None:
     started = asyncio.Event()
     release = asyncio.Event()
     owner: set[asyncio.Task[object]] = set()
@@ -215,19 +213,46 @@ async def test_durable_commit_cancellation_owns_failed_readback_until_done(
     )
     await started.wait()
     caller.cancel()
-    result = await caller
-    assert result.state is DurableCommitState.UNRESOLVED
+    await asyncio.sleep(0)
+    assert not caller.done()
     assert len(owner) == 1
-    readback_task = next(iter(owner))
 
     release.set()
-    await asyncio.gather(readback_task, return_exceptions=True)
-    await asyncio.sleep(0)
+    result = await caller
+    assert result.state is DurableCommitState.UNRESOLVED
+    assert isinstance(result.error, RuntimeError)
+    assert result.cancelled
     assert owner == set()
-    assert any(
-        "detached durable commit readback failed" in record.message
-        for record in caplog.records
+
+
+@pytest.mark.asyncio
+async def test_durable_commit_cancellation_accepts_committed_readback() -> None:
+    started = asyncio.Event()
+    release = asyncio.Event()
+    owner: set[asyncio.Task[object]] = set()
+
+    async def operation() -> None:
+        raise RuntimeError("commit response lost")
+
+    async def readback() -> CommitObservation[str]:
+        started.set()
+        await release.wait()
+        return CommitObservation(DurableCommitState.COMMITTED, value="reconciled")
+
+    caller = asyncio.create_task(
+        run_durable_commit(operation, readback, background_tasks=owner)
     )
+    await started.wait()
+    caller.cancel()
+    await asyncio.sleep(0)
+    assert not caller.done()
+
+    release.set()
+    result = await caller
+    assert result.state is DurableCommitState.COMMITTED
+    assert result.value == "reconciled"
+    assert result.cancelled
+    assert owner == set()
 
 
 def _step_store_for_preflight() -> RuntimeStepStore:
@@ -261,6 +286,7 @@ async def test_step_preflight_rejects_flights_tasks_and_terminal_seals() -> None
     with pytest.raises(AIError) as task_error:
         await store.preflight_close()
     assert task_error.value.code is ErrorCode.STORAGE_RECOVERY_REQUIRED
+    assert not store._preflight
     assert task_error.value.safe_details["pending_tasks"] == 1
     release.set()
     await task

--- a/tests/ai/test_model_usage_trace.py
+++ b/tests/ai/test_model_usage_trace.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Per-request model usage projection into Runtime trace."""
+
+from types import SimpleNamespace
+
+from linktools.ai.adapter._history import _trace_item
+from linktools.ai.agent._capabilities import _model_usage_metadata
+from pydantic_ai.messages import ModelResponse
+from pydantic_ai.usage import RequestUsage, RunUsage
+from pydantic_ai_harness.step_persistence import StepEvent
+
+
+def _response_usage(
+    *,
+    input_tokens: int,
+    output_tokens: int,
+    cache_read_tokens: int,
+    cache_write_tokens: int,
+) -> RequestUsage:
+    return RequestUsage(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cache_read_tokens=cache_read_tokens,
+        cache_write_tokens=cache_write_tokens,
+    )
+
+
+def _project_usage(usage: RequestUsage) -> dict[str, object] | None:
+    event = StepEvent(
+        run_id="run",
+        kind="model_request_completed",
+        step_index=1,
+        metadata=_model_usage_metadata(ModelResponse(parts=(), usage=usage)),
+    )
+    item = _trace_item(
+        SimpleNamespace(execution_id="execution"),
+        1,
+        0,
+        0,
+        event,
+    )
+    assert item is not None
+    assert item.payload["kind"] == "MODEL_RESPONSE"
+    return item.payload["token_usage"]
+
+
+def test_model_response_trace_contains_request_usage() -> None:
+    assert _project_usage(
+        _response_usage(
+            input_tokens=1234,
+            output_tokens=256,
+            cache_read_tokens=1000,
+            cache_write_tokens=0,
+        )
+    ) == {
+        "input_tokens": 1234,
+        "output_tokens": 256,
+        "cache_read_tokens": 1000,
+        "cache_write_tokens": 0,
+    }
+
+
+def test_model_response_trace_keeps_each_request_usage_separate() -> None:
+    first = _response_usage(
+        input_tokens=100,
+        output_tokens=20,
+        cache_read_tokens=80,
+        cache_write_tokens=0,
+    )
+    second = _response_usage(
+        input_tokens=140,
+        output_tokens=30,
+        cache_read_tokens=0,
+        cache_write_tokens=40,
+    )
+
+    first_trace = _project_usage(first)
+    second_trace = _project_usage(second)
+    assert first_trace is not None
+    assert second_trace is not None
+    assert first_trace != second_trace
+
+    total = RunUsage()
+    total.incr(first)
+    total.incr(second)
+    assert total.input_tokens == first_trace["input_tokens"] + second_trace["input_tokens"]
+    assert total.output_tokens == first_trace["output_tokens"] + second_trace["output_tokens"]
+    assert total.cache_read_tokens == first_trace["cache_read_tokens"] + second_trace["cache_read_tokens"]
+    assert total.cache_write_tokens == first_trace["cache_write_tokens"] + second_trace["cache_write_tokens"]
+
+
+def test_legacy_model_response_trace_without_usage_returns_null() -> None:
+    event = StepEvent(
+        run_id="run",
+        kind="model_request_completed",
+        step_index=1,
+        metadata={},
+    )
+    item = _trace_item(
+        SimpleNamespace(execution_id="execution"),
+        1,
+        0,
+        0,
+        event,
+    )
+    assert item is not None
+    assert item.payload["token_usage"] is None
+
+
+def test_failed_model_response_trace_has_no_request_usage() -> None:
+    event = StepEvent(
+        run_id="run",
+        kind="model_request_failed",
+        step_index=1,
+        metadata={},
+    )
+    item = _trace_item(
+        SimpleNamespace(execution_id="execution"),
+        1,
+        0,
+        0,
+        event,
+    )
+    assert item is not None
+    assert item.payload["token_usage"] is None

--- a/tests/ai/test_model_usage_trace.py
+++ b/tests/ai/test_model_usage_trace.py
@@ -4,11 +4,45 @@
 
 from types import SimpleNamespace
 
+import pytest
 from linktools.ai.adapter._history import _trace_item
-from linktools.ai.agent._capabilities import _model_usage_metadata
+from linktools.ai.agent._capabilities import (
+    ToolOperationDecision,
+    _RuntimeStepPersistence,
+    _model_usage_metadata,
+)
+from linktools.ai.runtime import ExecutionTraceItem
+from pydantic_ai import Agent, ModelRetry
 from pydantic_ai.messages import ModelResponse
+from pydantic_ai.models.test import TestModel
 from pydantic_ai.usage import RequestUsage, RunUsage
-from pydantic_ai_harness.step_persistence import StepEvent
+from pydantic_ai_harness.step_persistence import InMemoryStepStore, StepEvent
+
+
+class _ToolOperations:
+    async def begin(self, ctx, call, tool_def, args, replay_safe):
+        del ctx, tool_def, args
+        return ToolOperationDecision(
+            operation_id=f"operation:{call.tool_call_id}",
+            owner="owner",
+            fence=1,
+            replay_safe=replay_safe,
+        )
+
+    async def renew(self, decision):
+        return decision
+
+    async def complete(self, decision, result):
+        del decision, result
+        return False
+
+    async def fail(self, decision, error):
+        del decision, error
+        return False
+
+    async def unknown(self, decision, error):
+        del decision, error
+        raise AssertionError("unexpected unknown tool effect")
 
 
 def _response_usage(
@@ -26,23 +60,55 @@ def _response_usage(
     )
 
 
-def _project_usage(usage: RequestUsage) -> dict[str, object] | None:
-    event = StepEvent(
-        run_id="run",
-        kind="model_request_completed",
-        step_index=1,
-        metadata=_model_usage_metadata(ModelResponse(parts=(), usage=usage)),
-    )
+def _project_event(event: StepEvent, ordinal: int = 0) -> dict[str, object] | None:
     item = _trace_item(
         SimpleNamespace(execution_id="execution"),
         1,
         0,
-        0,
+        ordinal,
         event,
     )
     assert item is not None
     assert item.payload["kind"] == "MODEL_RESPONSE"
     return item.payload["token_usage"]
+
+
+def _project_usage(usage: RequestUsage) -> dict[str, object] | None:
+    return _project_event(
+        StepEvent(
+            run_id="run",
+            kind="model_request_completed",
+            step_index=1,
+            metadata=_model_usage_metadata(ModelResponse(parts=(), usage=usage)),
+        )
+    )
+
+
+def _persistence(store: InMemoryStepStore, run_id: str) -> _RuntimeStepPersistence:
+    return _RuntimeStepPersistence(
+        store=store,
+        agent_name="usage-test",
+        run_id=run_id,
+        tool_operations=_ToolOperations(),
+    )
+
+
+async def _completed_usage(store: InMemoryStepStore, run_id: str) -> list[dict[str, object]]:
+    events = await store.list_events(run_id=run_id)
+    values = [
+        _project_event(event, ordinal)
+        for ordinal, event in enumerate(events)
+        if event.kind == "model_request_completed"
+    ]
+    assert all(value is not None for value in values)
+    return [value for value in values if value is not None]
+
+
+def _assert_token_sum(values: list[dict[str, object]], usage: RunUsage) -> None:
+    assert sum(int(value["input_tokens"]) for value in values) == usage.input_tokens
+    assert sum(int(value["output_tokens"]) for value in values) == usage.output_tokens
+    assert sum(int(value["cache_read_tokens"]) for value in values) == usage.cache_read_tokens
+    assert sum(int(value["cache_write_tokens"]) for value in values) == usage.cache_write_tokens
 
 
 def test_model_response_trace_contains_request_usage() -> None:
@@ -116,6 +182,13 @@ def test_legacy_model_response_trace_without_usage_returns_null() -> None:
     assert item is not None
     assert item.payload["token_usage"] is None
 
+    cached = ExecutionTraceItem(
+        "execution",
+        1,
+        {"kind": "MODEL_RESPONSE", "status": "SUCCEEDED"},
+    )
+    assert cached.payload["token_usage"] is None
+
 
 def test_failed_model_response_trace_has_no_request_usage() -> None:
     event = StepEvent(
@@ -133,3 +206,65 @@ def test_failed_model_response_trace_has_no_request_usage() -> None:
     )
     assert item is not None
     assert item.payload["token_usage"] is None
+
+
+@pytest.mark.asyncio
+async def test_model_retry_records_each_request_usage() -> None:
+    store = InMemoryStepStore()
+    agent = Agent(
+        TestModel(custom_output_text="done"),
+        capabilities=[_persistence(store, "retry-run")],
+    )
+    attempts = 0
+
+    @agent.output_validator
+    def retry_once(output: str) -> str:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise ModelRetry("retry once")
+        return output
+
+    result = await agent.run("hello")
+    values = await _completed_usage(store, "retry-run")
+
+    assert attempts == 2
+    assert len(values) == result.usage.requests == 2
+    _assert_token_sum(values, result.usage)
+
+
+@pytest.mark.asyncio
+async def test_tool_loop_records_usage_before_and_after_tool() -> None:
+    store = InMemoryStepStore()
+    agent = Agent(
+        TestModel(),
+        capabilities=[_persistence(store, "tool-run")],
+    )
+
+    @agent.tool_plain
+    async def echo(text: str) -> str:
+        return text
+
+    result = await agent.run("hello")
+    values = await _completed_usage(store, "tool-run")
+
+    assert result.usage.tool_calls == 1
+    assert len(values) == result.usage.requests == 2
+    _assert_token_sum(values, result.usage)
+
+
+@pytest.mark.asyncio
+async def test_streaming_records_completed_request_usage() -> None:
+    store = InMemoryStepStore()
+    agent = Agent(
+        TestModel(custom_output_text="streamed"),
+        capabilities=[_persistence(store, "stream-run")],
+    )
+
+    async with agent.run_stream("hello") as result:
+        assert await result.get_output() == "streamed"
+        usage = result.usage
+
+    values = await _completed_usage(store, "stream-run")
+    assert len(values) == usage.requests == 1
+    _assert_token_sum(values, usage)

--- a/tests/ai/test_model_usage_trace.py
+++ b/tests/ai/test_model_usage_trace.py
@@ -13,7 +13,8 @@ from linktools.ai.agent._capabilities import (
 )
 from linktools.ai.runtime import ExecutionTraceItem
 from pydantic_ai import Agent, ModelRetry
-from pydantic_ai.messages import ModelResponse
+from pydantic_ai.messages import ModelMessage, ModelResponse, TextPart
+from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.usage import RequestUsage, RunUsage
 from pydantic_ai_harness.step_persistence import InMemoryStepStore, StepEvent
@@ -43,6 +44,11 @@ class _ToolOperations:
     async def unknown(self, decision, error):
         del decision, error
         raise AssertionError("unexpected unknown tool effect")
+
+
+async def _text_model(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+    del messages, info
+    return ModelResponse(parts=[TextPart("done")])
 
 
 def _response_usage(
@@ -212,7 +218,7 @@ def test_failed_model_response_trace_has_no_request_usage() -> None:
 async def test_model_retry_records_each_request_usage() -> None:
     store = InMemoryStepStore()
     agent = Agent(
-        TestModel(custom_output_text="done"),
+        FunctionModel(_text_model),
         capabilities=[_persistence(store, "retry-run")],
     )
     attempts = 0

--- a/tests/ai/test_model_usage_trace.py
+++ b/tests/ai/test_model_usage_trace.py
@@ -61,6 +61,15 @@ def test_model_response_trace_contains_request_usage() -> None:
     }
 
 
+def test_model_response_trace_defaults_missing_cache_usage_to_zero() -> None:
+    assert _project_usage(RequestUsage(input_tokens=100, output_tokens=20)) == {
+        "input_tokens": 100,
+        "output_tokens": 20,
+        "cache_read_tokens": 0,
+        "cache_write_tokens": 0,
+    }
+
+
 def test_model_response_trace_keeps_each_request_usage_separate() -> None:
     first = _response_usage(
         input_tokens=100,


### PR DESCRIPTION
Fix durable commit cancellation ownership so caller cancellation cannot be mistaken for an unknown storage outcome.

Scope:
- keep shielded durable operation/readback owned until their actual outcome is observable
- record cancellation separately and propagate it only after durable state converges
- prevent StepStore durability flights from being fenced as STORAGE_COMMIT_UNKNOWN merely because the waiter was cancelled
- keep same-run waiters blocked on a pending flight until finalization
- retain STORAGE_COMMIT_UNKNOWN only for genuinely unresolved operation/readback outcomes
- keep the cancellation implementation portable across the supported Python 3.10+ runtime surface without Task.cancelling()
- add focused cancellation/reconciliation and StepStore flight race regressions
- codify the cancellation-vs-durable-truth rule in linktools-ai/AGENTS.md

Validation on current head:
- Python 3.6 compatibility: success
- Python 3.10 checks: success
- Python latest checks: success
- final diff cold review: only durability primitive, focused tests, and one AGENTS.md design rule

The PR remains draft and unmerged pending final acceptance.