### PR TITLE
fix(ai): repair runtime boundaries

### DIFF
--- a/linktools-ai/AGENTS.md
+++ b/linktools-ai/AGENTS.md
@@ -19,6 +19,8 @@ Package instructions for `linktools-ai`. Repository-wide rules in [../AGENTS.md]
 - Persisted or replayed data is a versioned contract. Compatibility must be based on explicit semantics, not accidental byte-for-byte output of dependencies.
 - Persistence protocols must remain evolvable and backward-compatible. Additive or non-semantic changes must not invalidate previously persisted data or make the storage system unreadable; incompatible changes require an explicit version boundary and a defined compatibility or migration path.
 - Stable hashes and idempotency identities must remain stable when non-semantic optional/default fields change; include codec/version/provenance when they change semantics.
+- Durable contracts must stay minimal. Persist stable references for dependencies intentionally resolved at use time; persist dependency semantics only when exact replay of an already-established durable fact requires them. Do not copy, embed, or recursively snapshot referenced configuration for convenience or speculative future recovery.
+- A semantic fact must have one durable owner. Any persisted duplicate used as an index, projection, or cache must be explicitly derived and must not become an independent source of truth or define conflicting recovery semantics.
 - Caller cancellation does not determine durable truth. Resolve commit/readback state before reporting an unknown outcome.
 - Filesystem coordination uses `filelock`. Database concurrency must avoid pessimistic locking.
 

--- a/linktools-ai/src/linktools/ai/runtime/_agent.py
+++ b/linktools-ai/src/linktools/ai/runtime/_agent.py
@@ -40,7 +40,6 @@ class Execution(Generic[AppT]):
     _principal: Principal
 
     async def wait(self, *, timeout_seconds: "float | None" = None) -> ExecutionResult:
-        self._runtime._abandon_execution_stream(self.execution_id)
         return await self._runtime.execution.wait(
             self.execution_id,
             principal=self._principal,

--- a/linktools-ai/src/linktools/ai/runtime/_coordinator.py
+++ b/linktools-ai/src/linktools/ai/runtime/_coordinator.py
@@ -1,107 +1,29 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-"""Private local service coordination for launch and stream leases."""
+"""Private local stream coordination for Runtime."""
 
 from collections.abc import AsyncIterator
 
 from linktools.core import environ
 
 from ..core import ExecutionEventType, Principal
-from ._event import DefaultEventService, _PreparedStreamLease
+from ._event import DefaultEventService
 from ._execution import DefaultExecutionService
-from ._local import LocalExecutionBackend
-from ._session import DefaultSessionService
-from .service_api import (
-    ExecutionHandle,
-    ExecutionRequest,
-    ExecutionStreamEvent,
-    ResumeSessionRequest,
-)
+from .service_api import ExecutionStreamEvent
 
 _logger = environ.get_logger("ai.runtime.coordinator")
 
 
 class _LocalRuntimeCoordinator:
-    """Own the concrete-only launch gate used by the local stream path."""
+    """Coordinate local event streaming and terminal handoff."""
 
     def __init__(
         self,
         execution: DefaultExecutionService,
-        session: DefaultSessionService,
         event: DefaultEventService,
-        backend: LocalExecutionBackend,
     ) -> None:
         self._execution = execution
-        self._session = session
         self._event = event
-        self._backend = backend
-        self._leases: dict[str, _PreparedStreamLease] = {}
-
-    async def run(
-        self,
-        binding_digest: str,
-        request: ExecutionRequest,
-    ) -> ExecutionHandle:
-        lease: _PreparedStreamLease | None = None
-
-        async def gate(execution_id: str) -> None:
-            nonlocal lease
-            if self._backend.worker_installed(execution_id):
-                return
-            lease = await self._event._prepare_local_stream(execution_id)
-            self._leases[execution_id] = lease
-
-        try:
-            handle = await self._execution._run_with_launch_gate(binding_digest, request, gate)
-            if lease is not None:
-                await self._event._authorize_stream(handle.execution_id, request.principal)
-                if lease.base_sequence is not None:
-                    await self._event._claim_local_stream(lease)
-                else:
-                    self._abort(lease)
-                    lease = None
-        except BaseException:
-            if lease is not None:
-                self._abort(lease)
-            raise
-        return handle
-
-    async def resume(
-        self,
-        agent_id: str,
-        binding_digest: str,
-        session_id: str,
-        request: ResumeSessionRequest,
-    ) -> ExecutionHandle:
-        lease: _PreparedStreamLease | None = None
-
-        async def gate(execution_id: str) -> None:
-            nonlocal lease
-            if self._backend.worker_installed(execution_id):
-                return
-            lease = await self._event._prepare_local_stream(execution_id)
-            self._leases[execution_id] = lease
-
-        try:
-            handle = await self._session._resume_with_launch_gate(
-                agent_id,
-                binding_digest,
-                session_id,
-                request,
-                gate,
-            )
-            if lease is not None:
-                await self._event._authorize_stream(handle.execution_id, request.principal)
-                if lease.base_sequence is not None:
-                    await self._event._claim_local_stream(lease)
-                else:
-                    self._abort(lease)
-                    lease = None
-        except BaseException:
-            if lease is not None:
-                self._abort(lease)
-            raise
-        return handle
 
     async def stream(
         self,
@@ -110,23 +32,13 @@ class _LocalRuntimeCoordinator:
         principal: Principal,
         after_sequence: int = 0,
     ) -> AsyncIterator[ExecutionStreamEvent]:
-        lease = self._leases.pop(execution_id, None)
         terminal_yielded = False
         try:
-            events = (
-                self._event.stream(
-                    execution_id,
-                    principal=principal,
-                    after_sequence=after_sequence,
-                )
-                if lease is None
-                else self._event._stream_claimed(
-                    lease,
-                    principal=principal,
-                    after_sequence=after_sequence,
-                )
-            )
-            async for event in events:
+            async for event in self._event.stream(
+                execution_id,
+                principal=principal,
+                after_sequence=after_sequence,
+            ):
                 if event.event_type in {
                     ExecutionEventType.EXECUTION_SUCCEEDED,
                     ExecutionEventType.EXECUTION_FAILED,
@@ -135,8 +47,6 @@ class _LocalRuntimeCoordinator:
                     terminal_yielded = True
                 yield event
         finally:
-            if lease is not None and lease.state == "PREPARED":
-                self._abort(lease)
             if terminal_yielded:
                 _logger.debug(
                     "local stream yielded terminal event; requesting execution handoff: execution=%s",
@@ -146,16 +56,6 @@ class _LocalRuntimeCoordinator:
                     execution_id,
                     tenant_id=principal.tenant_id,
                 )
-
-    def abandon_stream(self, execution_id: str) -> None:
-        """Release a prepared local stream when the caller never consumes it."""
-        lease = self._leases.pop(execution_id, None)
-        if lease is not None and lease.state == "PREPARED":
-            self._event.live_broker.abort_local_producer(lease)
-
-    def _abort(self, lease: _PreparedStreamLease) -> None:
-        self._leases.pop(lease.execution_id, None)
-        self._event.live_broker.abort_local_producer(lease)
 
 
 __all__ = ["_LocalRuntimeCoordinator"]

--- a/linktools-ai/src/linktools/ai/runtime/_event.py
+++ b/linktools-ai/src/linktools/ai/runtime/_event.py
@@ -56,8 +56,6 @@ class _LiveEvent:
 @dataclass(slots=True)
 class _PreparedStreamLease:
     execution_id: str
-    state: str = "PREPARED"
-    subscription: "_LiveSubscription | None" = None
     base_sequence: int | None = None
 
 
@@ -317,50 +315,42 @@ class LiveExecutionEventBroker:
             subscription.finish()
         return subscription
 
-    def prepare_local_producer(self, execution_id: str) -> _PreparedStreamLease:
-        current = self._prepared.get(execution_id)
-        if current is not None and current.state == "PREPARED":
-            return current
-        lease = _PreparedStreamLease(execution_id)
-        self._prepared[execution_id] = lease
+    def prepare_local_producer(self, execution_id: str) -> None:
+        if execution_id in self._prepared:
+            return
+        self._prepared[execution_id] = _PreparedStreamLease(execution_id)
         _logger.debug("local event stream prepared: execution=%s", execution_id)
-        return lease
 
-    def claim_local_producer(self, lease: _PreparedStreamLease) -> _LiveSubscription:
-        current = self._prepared.get(lease.execution_id)
-        if current is not lease or lease.state != "PREPARED":
-            raise RuntimeError("prepared event stream lease is not claimable")
+    def claim_local_producer(self, execution_id: str) -> "_LiveSubscription | None":
+        lease = self._prepared.get(execution_id)
+        if lease is None:
+            return None
         if lease.base_sequence is None:
-            raise RuntimeError("prepared event stream has no durable base")
-        subscription = _LiveSubscription(self, lease.execution_id, self._max_bytes)
-        lease.state = "CLAIMED"
-        lease.subscription = subscription
-        self._prepared.pop(lease.execution_id, None)
-        self._subscriptions.setdefault(lease.execution_id, set()).add(subscription)
-        self._fill_subscription(subscription, lease.execution_id)
-        if lease.execution_id in self._completed:
+            raise AIError(ErrorCode.EXECUTION_NOT_READY)
+        self._prepared.pop(execution_id, None)
+        subscription = _LiveSubscription(self, execution_id, self._max_bytes)
+        self._subscriptions.setdefault(execution_id, set()).add(subscription)
+        self._fill_subscription(subscription, execution_id)
+        if execution_id in self._completed:
             subscription.finish()
         return subscription
 
-    def abort_local_producer(self, lease: _PreparedStreamLease) -> None:
-        if lease.state != "PREPARED":
+    def abandon_prepared_local_producer(self, execution_id: str) -> None:
+        lease = self._prepared.pop(execution_id, None)
+        if lease is None:
             return
-        current = self._prepared.get(lease.execution_id)
-        if current is not lease:
-            lease.state = "ABANDONED"
-            return
-        lease.state = "ABANDONED"
-        self._prepared.pop(lease.execution_id, None)
-        if lease.base_sequence is None or (
-            lease.execution_id in self._completed
-            and not self._subscriptions.get(lease.execution_id)
+        if lease.base_sequence is None:
+            self._release_execution(execution_id)
+        elif (
+            execution_id in self._completed
+            and not self._subscriptions.get(execution_id)
         ):
-            self._release_execution(lease.execution_id)
+            self._release_execution(execution_id)
         else:
-            self._signal(lease.execution_id)
+            self._signal(execution_id)
         _logger.debug(
             "local event stream lease abandoned: execution=%s base_sequence=%s",
-            lease.execution_id,
+            execution_id,
             lease.base_sequence,
         )
 
@@ -476,12 +466,6 @@ class DefaultEventService:
     def live_broker(self) -> LiveExecutionEventBroker:
         return self._live
 
-    async def _prepare_local_stream(self, execution_id: str) -> _PreparedStreamLease:
-        return self._live.prepare_local_producer(execution_id)
-
-    async def _claim_local_stream(self, lease: _PreparedStreamLease) -> _LiveSubscription:
-        return self._live.claim_local_producer(lease)
-
     async def list(self, execution_id: str, *, principal: Principal, after_sequence: int = 0, limit: int = 100) -> Page[ExecutionEvent]:
         header = await self._executions.get_header(execution_id, tenant_id=principal.tenant_id)
         if header is None:
@@ -509,49 +493,16 @@ class DefaultEventService:
         principal: Principal,
         after_sequence: int = 0,
     ) -> AsyncIterator[ExecutionStreamEvent]:
+        await self._authorize_stream(execution_id, principal)
+        live = self._live.claim_local_producer(execution_id)
         async for event in self._stream_with_live(
             execution_id,
-            principal=principal,
-            after_sequence=after_sequence,
-        ):
-            yield event
-
-    async def _stream_prepared(
-        self,
-        lease: _PreparedStreamLease,
-        *,
-        principal: Principal,
-        after_sequence: int = 0,
-    ) -> AsyncIterator[ExecutionStreamEvent]:
-        await self._authorize_stream(lease.execution_id, principal)
-        live = self._live.claim_local_producer(lease)
-        async for event in self._stream_with_live(
-            lease.execution_id,
             principal=principal,
             after_sequence=after_sequence,
             live=live,
             authorized=True,
         ):
             yield event
-
-    async def _stream_claimed(
-        self,
-        lease: _PreparedStreamLease,
-        *,
-        principal: Principal,
-        after_sequence: int = 0,
-    ) -> AsyncIterator[ExecutionStreamEvent]:
-        if lease.state != "CLAIMED" or lease.subscription is None:
-            raise RuntimeError("claimed event stream lease is not active")
-        async for event in self._stream_with_live(
-            lease.execution_id,
-            principal=principal,
-            after_sequence=after_sequence,
-            live=lease.subscription,
-            authorized=True,
-        ):
-            yield event
-
 
 
     async def _stream_with_live(

--- a/linktools-ai/src/linktools/ai/runtime/_execution.py
+++ b/linktools-ai/src/linktools/ai/runtime/_execution.py
@@ -122,10 +122,6 @@ class _SubagentCancellation(Protocol):
     async def cancel_children(self, parent_execution_id: str, principal: Principal) -> None: ...
 
 
-class _LaunchGate(Protocol):
-    async def __call__(self, execution_id: str) -> None: ...
-
-
 class _LocalExecutionWaiter(Protocol):
     def owns_execution(self, execution_id: str, *, tenant_id: str) -> bool: ...
 
@@ -223,6 +219,8 @@ class DefaultExecutionService:
         self._terminal_verifier_is_default = terminal_verifier is None
         self._terminal_committer: _ExecutionTerminalCommitter | None = None
         self._local_waiter = local_waiter
+        self._local_stream_prepare: Callable[[str], None] | None = None
+        self._local_stream_abort: Callable[[str], None] | None = None
         self._subagent_cancellation: _SubagentCancellation | None = None
         self._session_locks: dict[tuple[str, str], _SessionLockEntry] = {}
         self._session_locks_guard = asyncio.Lock()
@@ -260,6 +258,18 @@ class DefaultExecutionService:
         if self._local_waiter is not None:
             raise RuntimeError("local execution waiter is already bound")
         self._local_waiter = waiter
+
+    def bind_local_stream(
+        self,
+        prepare: Callable[[str], None],
+        abort: Callable[[str], None],
+    ) -> None:
+        if not callable(prepare) or not callable(abort):
+            raise ValueError("local stream callbacks are required")
+        if self._local_stream_prepare is not None or self._local_stream_abort is not None:
+            raise RuntimeError("local stream lifecycle is already bound")
+        self._local_stream_prepare = prepare
+        self._local_stream_abort = abort
 
     def _binding(
         self,
@@ -387,7 +397,12 @@ class DefaultExecutionService:
                 await self._run_handoff_cleanup(execution_id, tenant_id, state)
 
     async def run(self, binding_digest: str, request: ExecutionRequest) -> ExecutionHandle:
-        return await self._start(binding_digest, request, scope="execution.run")
+        return await self._start(
+            binding_digest,
+            request,
+            scope="execution.run",
+            prepare_local_stream=True,
+        )
 
     async def run_for_session(
         self,
@@ -404,33 +419,7 @@ class DefaultExecutionService:
             session_id=session_id,
             session_agent_id=agent_id,
             scope="session.resume",
-        )
-
-    async def _run_with_launch_gate(
-        self,
-        binding_digest: str,
-        request: ExecutionRequest,
-        gate: _LaunchGate,
-    ) -> ExecutionHandle:
-        return await self._start(binding_digest, request, scope="execution.run", launch_gate=gate)
-
-    async def _run_for_session_with_launch_gate(
-        self,
-        agent_id: str,
-        binding_digest: str,
-        session_id: str,
-        request: ExecutionRequest,
-        gate: _LaunchGate,
-    ) -> ExecutionHandle:
-        if not session_id.strip():
-            raise AIError(ErrorCode.REQUEST_FIELD_INVALID)
-        return await self._start(
-            binding_digest,
-            request,
-            session_id=session_id,
-            session_agent_id=agent_id,
-            scope="session.resume",
-            launch_gate=gate,
+            prepare_local_stream=True,
         )
 
     async def start_subagent(
@@ -473,7 +462,7 @@ class DefaultExecutionService:
         root_execution_id: "str | None" = None,
         lineage_kind: ExecutionLineageKind = ExecutionLineageKind.RUN,
         scope: str = "execution.run",
-        launch_gate: _LaunchGate | None = None,
+        prepare_local_stream: bool = False,
     ) -> ExecutionHandle:
         if session_id is None:
             return await self._start_unlocked(
@@ -488,7 +477,7 @@ class DefaultExecutionService:
                 root_execution_id=root_execution_id,
                 lineage_kind=lineage_kind,
                 scope=scope,
-                launch_gate=launch_gate,
+                prepare_local_stream=prepare_local_stream,
             )
         async with self._session_guard(request.principal.tenant_id, session_id):
             return await self._start_unlocked(
@@ -503,7 +492,7 @@ class DefaultExecutionService:
                 root_execution_id=root_execution_id,
                 lineage_kind=lineage_kind,
                 scope=scope,
-                launch_gate=launch_gate,
+                prepare_local_stream=prepare_local_stream,
             )
 
     async def _start_unlocked(
@@ -520,7 +509,7 @@ class DefaultExecutionService:
         root_execution_id: "str | None" = None,
         lineage_kind: ExecutionLineageKind = ExecutionLineageKind.RUN,
         scope: str = "execution.run",
-        launch_gate: _LaunchGate | None = None,
+        prepare_local_stream: bool = False,
     ) -> ExecutionHandle:
         if re.fullmatch(r"[0-9a-f]{64}", binding_digest) is None:
             raise AIError(ErrorCode.REQUEST_FIELD_INVALID)
@@ -534,9 +523,8 @@ class DefaultExecutionService:
             session = await self._sessions.get(session_id, tenant_id=request.principal.tenant_id)
             if session is None:
                 raise AIError(ErrorCode.SESSION_NOT_FOUND)
-            from ._session import _session_agent_id
 
-            if _session_agent_id(session) != session_agent_id:
+            if session.resolved_agent_id() != session_agent_id:
                 raise AIError(ErrorCode.SESSION_BINDING_MISMATCH)
             conversation_run_id = None if session.continuation is None else session.continuation.step_run_id
             base_execution_id = None
@@ -566,7 +554,7 @@ class DefaultExecutionService:
                         pending,
                         scope=scope,
                         idempotency_key_digest=idempotency_key_digest,
-                        launch_gate=launch_gate,
+                        prepare_local_stream=prepare_local_stream,
                     )
                     return ExecutionHandle(existing.resource_id)
                 if pending is None or pending.status is not ExecutionStatus.PENDING_START:
@@ -577,7 +565,7 @@ class DefaultExecutionService:
                     scope=scope,
                     idempotency_key_digest=idempotency_key_digest,
                     request_digest=request_digest,
-                    launch_gate=launch_gate,
+                    prepare_local_stream=prepare_local_stream,
                 )
                 return ExecutionHandle(existing.resource_id)
             if existing.status is IdempotencyStatus.FAILED:
@@ -601,7 +589,7 @@ class DefaultExecutionService:
                 started,
                 scope=scope,
                 idempotency_key_digest=idempotency_key_digest,
-                launch_gate=launch_gate,
+                prepare_local_stream=prepare_local_stream,
             )
             return ExecutionHandle(existing.resource_id)
         now = datetime.now(timezone.utc)
@@ -660,7 +648,7 @@ class DefaultExecutionService:
                     scope=scope,
                     idempotency_key_digest=idempotency_key_digest,
                     request_digest=request_digest,
-                    launch_gate=launch_gate,
+                    prepare_local_stream=prepare_local_stream,
                 )
             elif reservation.idempotency.status is IdempotencyStatus.STARTED and reservation.execution.status in {
                 ExecutionStatus.STARTED,
@@ -674,7 +662,7 @@ class DefaultExecutionService:
                     reservation.execution,
                     scope=scope,
                     idempotency_key_digest=idempotency_key_digest,
-                    launch_gate=launch_gate,
+                    prepare_local_stream=prepare_local_stream,
                 )
             elif reservation.execution.status is ExecutionStatus.START_UNKNOWN or reservation.idempotency.status is IdempotencyStatus.START_UNKNOWN:
                 raise AIError(ErrorCode.EXECUTION_START_UNKNOWN)
@@ -688,7 +676,7 @@ class DefaultExecutionService:
             scope=scope,
             idempotency_key_digest=idempotency_key_digest,
             request_digest=request_digest,
-            launch_gate=launch_gate,
+            prepare_local_stream=prepare_local_stream,
         )
         _logger.info("execution started: execution=%s scope=%s", execution_id, scope)
         return ExecutionHandle(execution_id)
@@ -723,7 +711,7 @@ class DefaultExecutionService:
         scope: str,
         idempotency_key_digest: str,
         request_digest: str,
-        launch_gate: _LaunchGate | None = None,
+        prepare_local_stream: bool = False,
     ) -> None:
         if self._backend is None:
             raise AIError(ErrorCode.RUNTIME_DEPENDENCY_NOT_READY)
@@ -745,7 +733,7 @@ class DefaultExecutionService:
             started,
             scope=scope,
             idempotency_key_digest=idempotency_key_digest,
-            launch_gate=launch_gate,
+            prepare_local_stream=prepare_local_stream,
         )
 
     async def _reject_pending_start(
@@ -878,7 +866,7 @@ class DefaultExecutionService:
         *,
         scope: str,
         idempotency_key_digest: str,
-        launch_gate: _LaunchGate | None = None,
+        prepare_local_stream: bool = False,
     ) -> None:
         if self._backend is None:
             raise AIError(ErrorCode.RUNTIME_DEPENDENCY_NOT_READY)
@@ -900,11 +888,29 @@ class DefaultExecutionService:
             raise AIError(ErrorCode.EXECUTION_START_UNKNOWN)
         if launch_record.status is not ExecutionStatus.STARTED:
             raise AIError(ErrorCode.STORAGE_INTEGRITY_ERROR)
+        prepared_local_stream = False
         try:
-            if launch_gate is not None:
-                await launch_gate(launch_record.execution_id)
+            if (
+                prepare_local_stream
+                and self._local_stream_prepare is not None
+                and not self._backend.worker_installed(launch_record.execution_id)
+            ):
+                prepared_local_stream = True
+                self._local_stream_prepare(launch_record.execution_id)
             await self._backend.launch(request, launch_record)
+            if (
+                prepared_local_stream
+                and self._local_stream_abort is not None
+                and not self._backend.worker_installed(launch_record.execution_id)
+            ):
+                self._local_stream_abort(launch_record.execution_id)
         except asyncio.CancelledError:
+            if (
+                prepared_local_stream
+                and self._local_stream_abort is not None
+                and not self._backend.worker_installed(launch_record.execution_id)
+            ):
+                self._local_stream_abort(launch_record.execution_id)
             raise
         except BaseException as error:
             worker_installed = False
@@ -919,6 +925,8 @@ class DefaultExecutionService:
                     exc_info=environ.debug,
                 )
                 return
+            if prepared_local_stream and self._local_stream_abort is not None:
+                self._local_stream_abort(launch_record.execution_id)
             current = await self._state.executions.get(execution.execution_id, tenant_id=execution.tenant_id)
             if current is not None and current.status is ExecutionStatus.STARTED:
                 identity = await self._state.idempotency.get(
@@ -1024,10 +1032,16 @@ class DefaultExecutionService:
     async def wait(self, execution_id: str, *, principal: Principal, timeout_seconds: "float | None" = None) -> ExecutionResult:
         if timeout_seconds is not None and timeout_seconds < 0:
             raise AIError(ErrorCode.REQUEST_FIELD_INVALID)
-
         async def wait_once() -> ExecutionResult:
+            execution = await self._load_authorized(
+                execution_id,
+                principal,
+                AuthorizationAction.EXECUTION_READ,
+            )
+            if self._local_stream_abort is not None:
+                self._local_stream_abort(execution_id)
+            view = ExecutionView(execution.execution_id, execution.status)
             while True:
-                view = await self.inspect(execution_id, principal=principal)
                 waiter = self._local_waiter
                 owns_execution = waiter is not None and waiter.owns_execution(
                     execution_id,
@@ -1047,6 +1061,7 @@ class DefaultExecutionService:
                             execution_id,
                             tenant_id=principal.tenant_id,
                         )
+                        view = await self.inspect(execution_id, principal=principal)
                         continue
                     if self._backend is not None:
                         failure = self._backend.worker_failure(
@@ -1070,6 +1085,7 @@ class DefaultExecutionService:
                     )
                 else:
                     await asyncio.sleep(1.0)
+                view = await self.inspect(execution_id, principal=principal)
 
         try:
             return await asyncio.wait_for(wait_once(), timeout_seconds)

--- a/linktools-ai/src/linktools/ai/runtime/_factory.py
+++ b/linktools-ai/src/linktools/ai/runtime/_factory.py
@@ -16,7 +16,11 @@ from pydantic_ai_harness.memory import SearchableMemoryStore
 
 from ..agent import AgentCatalog, AgentCompiler, AgentDefinition
 from ..asset import AssetStore, DirectoryAssetBackend, PrefixAssetPathAdapter
-from ..capability import CapabilityContribution, CapabilityGroup, workspace_tool_contributions
+from ..capability import (
+    CapabilityContribution,
+    CapabilityGroup,
+    workspace_tool_contributions,
+)
 from ..core import HmacCursorSigner, TenantAuthorizationPolicy, validate_tenant_id
 from ..errors import AIError, ErrorCode
 from ..model import ModelRegistry
@@ -404,7 +408,6 @@ async def _build_local_components(
             history_reader=session_history_reader,
             transcript_store=state.steps.read_store(RuntimeDomain.CONVERSATION),
             release_terminal=state.retention.release_session,
-            gated_execution=execution,
         )
         task_runner = RuntimeTaskNodeRunner(execution, catalog, compiler)
         task_launcher = LocalTaskGraphLauncher(
@@ -447,7 +450,11 @@ async def _build_local_components(
             grant_key=grant_key,
             cursor_signer=HmacCursorSigner("artifact", grant_key),
         )
-        local_coordinator = _LocalRuntimeCoordinator(execution, session, event, backend)
+        execution.bind_local_stream(
+            live_broker.prepare_local_producer,
+            live_broker.abandon_prepared_local_producer,
+        )
+        local_coordinator = _LocalRuntimeCoordinator(execution, event)
         close_actions: list[Callable[[], Awaitable[None]]] = [
             task.preflight_close,
             task_launcher.shutdown,

--- a/linktools-ai/src/linktools/ai/runtime/_runtime_service.py
+++ b/linktools-ai/src/linktools/ai/runtime/_runtime_service.py
@@ -97,20 +97,6 @@ _AGENT_TASK_V1_FIELDS = frozenset(
 
 
 class _LocalRuntimeCoordinatorPort(Protocol):
-    async def run(
-        self,
-        binding_digest: str,
-        request: ExecutionRequest,
-    ) -> ExecutionHandle: ...
-
-    async def resume(
-        self,
-        agent_id: str,
-        binding_digest: str,
-        session_id: str,
-        request: ResumeSessionRequest,
-    ) -> ExecutionHandle: ...
-
     def stream(
         self,
         execution_id: str,
@@ -118,8 +104,6 @@ class _LocalRuntimeCoordinatorPort(Protocol):
         principal: Principal,
         after_sequence: int = 0,
     ) -> AsyncIterator[ExecutionStreamEvent]: ...
-
-    def abandon_stream(self, execution_id: str) -> None: ...
 
 
 class Runtime(Generic[AppT]):
@@ -324,11 +308,7 @@ class Runtime(Generic[AppT]):
             thinking=resolved_thinking,
         )
         if session_id is None:
-            handle = (
-                await self._local_coordinator.run(binding.digest, request)
-                if self._local_coordinator is not None
-                else await self.execution.run(binding.digest, request)
-            )
+            handle = await self.execution.run(binding.digest, request)
         else:
             if not isinstance(session_id, str) or not session_id.strip():
                 raise AIError(ErrorCode.REQUEST_FIELD_INVALID)
@@ -343,20 +323,11 @@ class Runtime(Generic[AppT]):
                 planning=request.planning,
                 thinking=request.thinking,
             )
-            handle = (
-                await self._local_coordinator.resume(
-                    definition.spec.id,
-                    binding.digest,
-                    session_id,
-                    resume_request,
-                )
-                if self._local_coordinator is not None
-                else await self.session.resume(
-                    definition.spec.id,
-                    binding.digest,
-                    session_id,
-                    resume_request,
-                )
+            handle = await self.session.resume(
+                definition.spec.id,
+                binding.digest,
+                session_id,
+                resume_request,
             )
         _logger.info(
             "runtime execution admitted: execution=%s agent=%s session=%s mode=%s planning=%s thinking=%s",
@@ -389,10 +360,6 @@ class Runtime(Generic[AppT]):
             principal=principal,
             after_sequence=after_sequence,
         )
-
-    def _abandon_execution_stream(self, execution_id: str) -> None:
-        if self._local_coordinator is not None:
-            self._local_coordinator.abandon_stream(execution_id)
 
     async def _retry_execution(
         self,

--- a/linktools-ai/src/linktools/ai/runtime/_session.py
+++ b/linktools-ai/src/linktools/ai/runtime/_session.py
@@ -57,6 +57,7 @@ from .state._contracts import (
     ExecutionRepository,
     OperationLedgerInput,
     OperationLedgerRecord,
+    SESSION_AGENT_ID_METADATA_KEY,
     SessionRecord,
 )
 
@@ -67,26 +68,13 @@ class _SessionReleaseCallback(Protocol):
     async def __call__(self, session_id: str, *, tenant_id: str, continuation: ConversationCursor | None) -> None: ...
 
 
-class _LaunchGate(Protocol):
-    async def __call__(self, execution_id: str) -> None: ...
-
-
-class _GatedExecutionService(Protocol):
+class _SessionExecutionService(ExecutionService, Protocol):
     async def run_for_session(
         self,
         agent_id: str,
         binding_digest: str,
         session_id: str,
         request: ExecutionRequest,
-    ) -> ExecutionHandle: ...
-
-    async def _run_for_session_with_launch_gate(
-        self,
-        agent_id: str,
-        binding_digest: str,
-        session_id: str,
-        request: ExecutionRequest,
-        gate: _LaunchGate,
     ) -> ExecutionHandle: ...
 
 
@@ -124,29 +112,6 @@ async def _no_release_terminal(session_id: str, *, tenant_id: str, continuation:
     del session_id, tenant_id, continuation
 
 
-_AGENT_ID_METADATA_KEY = "linktools.ai.agent_id"
-
-
-def _session_agent_id(record: SessionRecord) -> str:
-    explicit = record.agent_id
-    historical = record.metadata.get(_AGENT_ID_METADATA_KEY)
-    historical_id: str | None = None
-    if isinstance(historical, str):
-        try:
-            historical_id = validate_agent_id(historical)
-        except AIError:
-            historical_id = None
-    if explicit is not None:
-        try:
-            resolved = validate_agent_id(explicit)
-        except (AIError, TypeError) as error:
-            raise AIError(ErrorCode.STORAGE_INTEGRITY_ERROR) from error
-        if historical_id is not None and historical_id != resolved:
-            raise AIError(ErrorCode.STORAGE_INTEGRITY_ERROR)
-        return resolved
-    if historical_id is not None:
-        return historical_id
-    raise AIError(ErrorCode.STORAGE_VERSION_UNSUPPORTED)
 
 
 @dataclass
@@ -165,13 +130,12 @@ class DefaultSessionService:
         conversation: ConversationState,
         executions: ExecutionRepository,
         authorization: AuthorizationPolicy,
-        execution: ExecutionService,
+        execution: _SessionExecutionService,
         cursor_signer: CursorSigner,
         *,
         history_reader: SessionHistoryReader,
         transcript_store: "_SessionTranscriptStore | None" = None,
         release_terminal: _SessionReleaseCallback | None = None,
-        gated_execution: "_GatedExecutionService | None" = None,
     ) -> None:
         self._conversation = conversation
         self._executions = executions
@@ -181,7 +145,6 @@ class DefaultSessionService:
         self._history_reader = history_reader
         self._transcript_store = transcript_store
         self._release_terminal = release_terminal or _no_release_terminal
-        self._gated_execution = gated_execution
         self._handoff_states: dict[tuple[str, str], _SessionHandoffState] = {}
         self._handoff_condition = asyncio.Condition()
 
@@ -373,29 +336,7 @@ class DefaultSessionService:
         session_id: str,
         request: ResumeSessionRequest,
     ) -> ExecutionHandle:
-        return await self._resume(
-            agent_id,
-            binding_digest,
-            session_id,
-            request,
-            launch_gate=None,
-        )
-
-    async def _resume_with_launch_gate(
-        self,
-        agent_id: str,
-        binding_digest: str,
-        session_id: str,
-        request: ResumeSessionRequest,
-        gate: _LaunchGate,
-    ) -> ExecutionHandle:
-        return await self._resume(
-            agent_id,
-            binding_digest,
-            session_id,
-            request,
-            launch_gate=gate,
-        )
+        return await self._resume(agent_id, binding_digest, session_id, request)
 
     async def _resume(
         self,
@@ -403,8 +344,6 @@ class DefaultSessionService:
         binding_digest: str,
         session_id: str,
         request: ResumeSessionRequest,
-        *,
-        launch_gate: _LaunchGate | None,
     ) -> ExecutionHandle:
         async with self._session_consumer(session_id, request.principal.tenant_id):
             record = await self._authorized(
@@ -420,7 +359,7 @@ class DefaultSessionService:
                     request.principal.tenant_id,
                 ),
             )
-            if _session_agent_id(record) != agent_id:
+            if record.resolved_agent_id() != agent_id:
                 raise AIError(ErrorCode.SESSION_BINDING_MISMATCH)
             execution_request = ExecutionRequest(
                 user_prompt=request.user_prompt,
@@ -432,25 +371,12 @@ class DefaultSessionService:
                 planning=request.planning,
                 thinking=request.thinking,
             )
-            if self._gated_execution is None:
-                raise AIError(ErrorCode.RUNTIME_DEPENDENCY_NOT_READY)
-            if launch_gate is None:
-                try:
-                    return await self._gated_execution.run_for_session(
-                        agent_id,
-                        binding_digest,
-                        session_id,
-                        execution_request,
-                    )
-                except AttributeError as error:
-                    raise AIError(ErrorCode.RUNTIME_DEPENDENCY_NOT_READY) from error
             try:
-                return await self._gated_execution._run_for_session_with_launch_gate(
+                return await self._execution.run_for_session(
                     agent_id,
                     binding_digest,
                     session_id,
                     execution_request,
-                    launch_gate,
                 )
             except AttributeError as error:
                 raise AIError(ErrorCode.RUNTIME_DEPENDENCY_NOT_READY) from error
@@ -468,7 +394,7 @@ class DefaultSessionService:
                     request.principal.principal_id,
                 ),
             )
-            resolved_agent_id = _session_agent_id(source)
+            resolved_agent_id = source.resolved_agent_id()
             if resolved_agent_id != agent_id:
                 raise AIError(ErrorCode.SESSION_BINDING_MISMATCH)
             digest = canonical_sha256(
@@ -484,7 +410,7 @@ class DefaultSessionService:
             )
             now = datetime.now(timezone.utc)
             target_metadata = dict(source.metadata)
-            target_metadata.pop(_AGENT_ID_METADATA_KEY, None)
+            target_metadata.pop(SESSION_AGENT_ID_METADATA_KEY, None)
             target = SessionRecord(
                 session_id=request.new_session_id,
                 tenant_id=source.tenant_id,
@@ -526,7 +452,7 @@ class DefaultSessionService:
 
     async def _update(self, agent_id: str, session_id: str, request: UpdateSessionRequest) -> SessionView:
         current = await self._authorized(session_id, request.principal, AuthorizationAction.SESSION_UPDATE)
-        resolved_agent_id = _session_agent_id(current)
+        resolved_agent_id = current.resolved_agent_id()
         if resolved_agent_id != agent_id:
             raise AIError(ErrorCode.SESSION_BINDING_MISMATCH)
         if any(
@@ -536,7 +462,7 @@ class DefaultSessionService:
             raise AIError(ErrorCode.REQUEST_FIELD_INVALID)
         if any(
             key.startswith("linktools.ai.")
-            and key != _AGENT_ID_METADATA_KEY
+            and key != SESSION_AGENT_ID_METADATA_KEY
             and key not in request.metadata
             for key in current.metadata
         ):
@@ -927,7 +853,7 @@ class DefaultSessionService:
         active = () if active_execution is None else (active_execution.execution_id,)
         return SessionView(
             record.session_id,
-            _session_agent_id(record),
+            record.resolved_agent_id(),
             record.status,
             record.revision,
             record.resource_generation,

--- a/linktools-ai/src/linktools/ai/runtime/state/_contracts.py
+++ b/linktools-ai/src/linktools/ai/runtime/state/_contracts.py
@@ -40,7 +40,9 @@ from ...core import (
     UsageMetrics,
     normalize_execution_mode,
     normalize_thinking,
+    validate_agent_id,
 )
+from ...errors import AIError, ErrorCode
 from ...storage import ObjectRef, StoredPayload
 from ...task import (
     TaskGraph,
@@ -323,6 +325,9 @@ class ConversationHistoryRecord:
             raise ValueError("forked history with content requires a prefix head")
 
 
+SESSION_AGENT_ID_METADATA_KEY = "linktools.ai.agent_id"
+
+
 @dataclass(frozen=True, slots=True)
 class SessionRecord:
     session_id: str
@@ -349,6 +354,26 @@ class SessionRecord:
             raise ValueError("closed session cannot have an active execution")
         if self.history_quality not in {"complete", "conservative"}:
             raise ValueError("session history quality summary is invalid")
+
+    def resolved_agent_id(self) -> str:
+        historical = self.metadata.get(SESSION_AGENT_ID_METADATA_KEY)
+        historical_id: str | None = None
+        if isinstance(historical, str):
+            try:
+                historical_id = validate_agent_id(historical)
+            except AIError:
+                historical_id = None
+        if self.agent_id is not None:
+            try:
+                resolved = validate_agent_id(self.agent_id)
+            except (AIError, TypeError) as error:
+                raise AIError(ErrorCode.STORAGE_INTEGRITY_ERROR) from error
+            if historical_id is not None and historical_id != resolved:
+                raise AIError(ErrorCode.STORAGE_INTEGRITY_ERROR)
+            return resolved
+        if historical_id is not None:
+            return historical_id
+        raise AIError(ErrorCode.STORAGE_VERSION_UNSUPPORTED)
 
 
 @dataclass(frozen=True, slots=True)

--- a/linktools-ai/src/linktools/ai/runtime/state/_repositories.py
+++ b/linktools-ai/src/linktools/ai/runtime/state/_repositories.py
@@ -4904,13 +4904,11 @@ def _projected_record(
 ) -> StoredRecord:
     _require_tenant(value, repository._tenant_id)
     if isinstance(value, SessionRecord):
-        from .._session import _session_agent_id
-
         if value.agent_id is None:
             current_value = _decode_enveloped_domain(current.data, SessionRecord)
-            value = replace(value, agent_id=_session_agent_id(current_value))
+            value = replace(value, agent_id=current_value.resolved_agent_id())
         else:
-            _session_agent_id(value)
+            value.resolved_agent_id()
     identity = _canonical_record_identity(current.kind, value)
     projected = repository._stored(current.kind, identity, value, state=_record_state(value))
     return replace(projected, storage_version=current.storage_version + 1)

--- a/tests/ai/test_agent_composition.py
+++ b/tests/ai/test_agent_composition.py
@@ -147,7 +147,7 @@ async def test_session_resume_preserves_mode_planning_and_thinking() -> None:
     service = object.__new__(DefaultSessionService)
     capture = _CaptureSessionExecution()
     service._authorization = _AllowAuthorization()
-    service._gated_execution = capture
+    service._execution = capture
 
     @asynccontextmanager
     async def _consumer(session_id: str, tenant_id: str):
@@ -156,7 +156,7 @@ async def test_session_resume_preserves_mode_planning_and_thinking() -> None:
 
     async def _authorized(session_id: str, principal: object, action: object) -> object:
         del session_id, principal, action
-        return SimpleNamespace(agent_id="agent", metadata={})
+        return SimpleNamespace(resolved_agent_id=lambda: "agent")
 
     async def _reconcile(record: object) -> object:
         return record

--- a/tests/ai/test_durable_contract_repairs.py
+++ b/tests/ai/test_durable_contract_repairs.py
@@ -438,6 +438,14 @@ async def test_execution_wait_rechecks_after_local_worker_quiescence() -> None:
     service = object.__new__(DefaultExecutionService)
     service._local_waiter = Waiter()
     service._backend = None
+    abandoned: list[str] = []
+    service._local_stream_abort = abandoned.append
+
+    async def load_authorized(execution_id: str, principal: Principal, action: object) -> object:
+        del principal, action
+        return SimpleNamespace(execution_id=execution_id, status=ExecutionStatus.SUCCEEDED)
+
+    service._load_authorized = load_authorized  # type: ignore[method-assign]
 
     async def inspect(execution_id: str, *, principal: Principal) -> object:
         del execution_id, principal
@@ -459,6 +467,7 @@ async def test_execution_wait_rechecks_after_local_worker_quiescence() -> None:
         )
     )
     await started.wait()
+    assert abandoned == ["execution"]
     assert not task.done()
     release.set()
     assert await task == "terminal"

--- a/tests/ai/test_error_contract_matrix.py
+++ b/tests/ai/test_error_contract_matrix.py
@@ -190,8 +190,15 @@ async def test_execution_wait_timeout_has_stable_code() -> None:
         return SimpleNamespace(status=ExecutionStatus.STARTED)
 
     service.inspect = inspect  # type: ignore[method-assign]
+
+    async def load_authorized(execution_id: str, principal: Principal, action: object) -> object:
+        del principal, action
+        return SimpleNamespace(execution_id=execution_id, status=ExecutionStatus.STARTED)
+
+    service._load_authorized = load_authorized  # type: ignore[method-assign]
     service._backend = None
     service._local_waiter = None
+    service._local_stream_abort = None
     principal = Principal("principal", "tenant", "service")
     with pytest.raises(AIError) as error:
         await DefaultExecutionService.wait.__wrapped__(

--- a/tests/ai/test_runtime_boundary_contract.py
+++ b/tests/ai/test_runtime_boundary_contract.py
@@ -1,0 +1,399 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Regression coverage for local Runtime launch and stream ownership."""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from linktools.ai.core import (
+    ExecutionDeltaType,
+    ExecutionStatus,
+    Page,
+    Principal,
+    ResourceKind,
+    ResourceRef,
+)
+from linktools.ai.errors import AIError, ErrorCode
+from linktools.ai.runtime._coordinator import _LocalRuntimeCoordinator
+from linktools.ai.runtime._event import DefaultEventService, ExecutionDelta, LiveExecutionEventBroker
+from linktools.ai.runtime._execution import DefaultExecutionService
+from linktools.ai.runtime.service_api import ExecutionStreamEvent
+
+
+class _AllowAuthorization:
+    async def authorize(self, principal: object, action: object, resource: object) -> None:
+        del principal, action, resource
+
+
+class _DenyAuthorization:
+    async def authorize(self, principal: object, action: object, resource: object) -> None:
+        del principal, action, resource
+        raise AIError(ErrorCode.AUTHORIZATION_DENIED)
+
+
+class _ExecutionRepository:
+    async def get_header(self, execution_id: str, *, tenant_id: str) -> ResourceRef:
+        return ResourceRef(ResourceKind.EXECUTION, execution_id, tenant_id)
+
+    async def get(self, execution_id: str, *, tenant_id: str) -> object:
+        del execution_id, tenant_id
+        return SimpleNamespace(status=ExecutionStatus.STARTED, event_sequence=0)
+
+
+class _EventRepository:
+    async def list(
+        self,
+        execution_id: str,
+        *,
+        tenant_id: str,
+        after_sequence: int,
+        limit: int,
+    ) -> Page[object]:
+        del execution_id, tenant_id, after_sequence, limit
+        return Page(())
+
+
+class _ExecutionService:
+    async def request_terminal_handoff(self, execution_id: str, *, tenant_id: str) -> None:
+        del execution_id, tenant_id
+
+
+def _event_service(
+    authorization: object,
+    broker: LiveExecutionEventBroker,
+) -> DefaultEventService:
+    return DefaultEventService(
+        _ExecutionRepository(),
+        _EventRepository(),
+        authorization,
+        lambda execution_id, *, tenant_id: None,
+        broker,
+    )
+
+
+def _coordinator(
+    authorization: object,
+) -> tuple[_LocalRuntimeCoordinator, LiveExecutionEventBroker]:
+    broker = LiveExecutionEventBroker()
+    coordinator = _LocalRuntimeCoordinator(
+        _ExecutionService(),
+        _event_service(authorization, broker),
+    )
+    return coordinator, broker
+
+
+@pytest.mark.asyncio
+async def test_prepared_reservation_is_one_shot_and_idempotent() -> None:
+    broker = LiveExecutionEventBroker()
+    broker.prepare_local_producer("execution")
+    broker.prepare_local_producer("execution")
+    broker.register_local_producer("execution", 0)
+
+    live = broker.claim_local_producer("execution")
+    assert live is not None
+    assert broker.claim_local_producer("execution") is None
+
+    broker.complete("execution")
+    await live.close()
+    assert not broker.is_local_producer("execution")
+
+
+@pytest.mark.asyncio
+async def test_non_stream_path_can_abandon_prepared_reservation() -> None:
+    broker = LiveExecutionEventBroker()
+    broker.prepare_local_producer("execution")
+    broker.register_local_producer("execution", 0)
+
+    broker.abandon_prepared_local_producer("execution")
+    broker.complete("execution")
+
+    assert not broker.is_local_producer("execution")
+
+
+@pytest.mark.asyncio
+async def test_stream_authorization_failure_does_not_consume_reservation() -> None:
+    coordinator, broker = _coordinator(_DenyAuthorization())
+    principal = Principal("principal", "tenant", "service")
+    broker.prepare_local_producer("execution")
+    broker.register_local_producer("execution", 0)
+
+    denied = coordinator.stream("execution", principal=principal).__aiter__()
+    with pytest.raises(AIError) as error:
+        await denied.__anext__()
+    assert error.value.code is ErrorCode.AUTHORIZATION_DENIED
+
+    broker.publish(
+        ExecutionDelta(
+            "execution",
+            ExecutionDeltaType.ASSISTANT_TEXT_DELTA,
+            "still-buffered",
+        )
+    )
+    allowed = _event_service(_AllowAuthorization(), broker)
+    stream = allowed.stream("execution", principal=principal).__aiter__()
+    first = await stream.__anext__()
+    assert first.payload["text"] == "still-buffered"
+    await stream.aclose()
+
+
+@pytest.mark.asyncio
+async def test_prepared_stream_replays_early_delta() -> None:
+    coordinator, broker = _coordinator(_AllowAuthorization())
+    principal = Principal("principal", "tenant", "service")
+    broker.prepare_local_producer("execution")
+    broker.register_local_producer("execution", 0)
+    broker.publish(
+        ExecutionDelta(
+            "execution",
+            ExecutionDeltaType.ASSISTANT_TEXT_DELTA,
+            "early",
+        )
+    )
+
+    stream = coordinator.stream("execution", principal=principal).__aiter__()
+    first = await stream.__anext__()
+    assert isinstance(first, ExecutionStreamEvent)
+    assert first.event_type is ExecutionDeltaType.ASSISTANT_TEXT_DELTA
+    assert first.payload["text"] == "early"
+    await stream.aclose()
+
+
+@pytest.mark.asyncio
+async def test_stream_before_producer_registration_is_not_ready_without_consuming_reservation() -> None:
+    broker = LiveExecutionEventBroker()
+    service = _event_service(_AllowAuthorization(), broker)
+    principal = Principal("principal", "tenant", "service")
+    broker.prepare_local_producer("execution")
+
+    early = service.stream("execution", principal=principal).__aiter__()
+    with pytest.raises(AIError) as error:
+        await early.__anext__()
+    assert error.value.code is ErrorCode.EXECUTION_NOT_READY
+
+    broker.register_local_producer("execution", 0)
+    broker.publish(
+        ExecutionDelta(
+            "execution",
+            ExecutionDeltaType.ASSISTANT_TEXT_DELTA,
+            "registered",
+        )
+    )
+    ready = service.stream("execution", principal=principal).__aiter__()
+    first = await ready.__anext__()
+    assert first.payload["text"] == "registered"
+    await ready.aclose()
+
+
+@pytest.mark.asyncio
+async def test_abandon_after_claim_does_not_close_claimed_stream() -> None:
+    broker = LiveExecutionEventBroker()
+    service = _event_service(_AllowAuthorization(), broker)
+    principal = Principal("principal", "tenant", "service")
+    broker.prepare_local_producer("execution")
+    broker.register_local_producer("execution", 0)
+    broker.publish(
+        ExecutionDelta("execution", ExecutionDeltaType.ASSISTANT_TEXT_DELTA, "one")
+    )
+
+    stream = service.stream("execution", principal=principal).__aiter__()
+    assert (await stream.__anext__()).payload["text"] == "one"
+
+    broker.abandon_prepared_local_producer("execution")
+    broker.publish(
+        ExecutionDelta("execution", ExecutionDeltaType.ASSISTANT_TEXT_DELTA, "two")
+    )
+    assert (await stream.__anext__()).payload["text"] == "two"
+    await stream.aclose()
+
+
+@pytest.mark.asyncio
+async def test_second_stream_close_does_not_close_first_subscription() -> None:
+    broker = LiveExecutionEventBroker()
+    service = _event_service(_AllowAuthorization(), broker)
+    principal = Principal("principal", "tenant", "service")
+    broker.prepare_local_producer("execution")
+    broker.register_local_producer("execution", 0)
+    broker.publish(
+        ExecutionDelta("execution", ExecutionDeltaType.ASSISTANT_TEXT_DELTA, "initial")
+    )
+
+    first = service.stream("execution", principal=principal).__aiter__()
+    assert (await first.__anext__()).payload["text"] == "initial"
+    second = service.stream("execution", principal=principal).__aiter__()
+    assert (await second.__anext__()).payload["text"] == "initial"
+    await second.aclose()
+
+    broker.publish(
+        ExecutionDelta("execution", ExecutionDeltaType.ASSISTANT_TEXT_DELTA, "next")
+    )
+    assert (await first.__anext__()).payload["text"] == "next"
+    await first.aclose()
+
+
+@pytest.mark.asyncio
+async def test_wait_authorizes_before_abandoning_stream() -> None:
+    service = object.__new__(DefaultExecutionService)
+    abandoned: list[str] = []
+    service._local_stream_abort = abandoned.append
+
+    async def denied(
+        execution_id: str,
+        principal: Principal,
+        action: object,
+    ) -> object:
+        del execution_id, principal, action
+        raise AIError(ErrorCode.AUTHORIZATION_DENIED)
+
+    service._load_authorized = denied
+    principal = Principal("principal", "tenant", "service")
+    with pytest.raises(AIError) as error:
+        await DefaultExecutionService.wait.__wrapped__(
+            service,
+            "execution",
+            principal=principal,
+        )
+    assert error.value.code is ErrorCode.AUTHORIZATION_DENIED
+    assert abandoned == []
+
+
+class _LaunchExecutions:
+    async def get(self, execution_id: str, *, tenant_id: str) -> object:
+        return SimpleNamespace(
+            execution_id=execution_id,
+            tenant_id=tenant_id,
+            status=ExecutionStatus.STARTED,
+        )
+
+
+def _launch_service(backend: object) -> tuple[DefaultExecutionService, list[str], list[str]]:
+    service = object.__new__(DefaultExecutionService)
+    service._state = SimpleNamespace(executions=_LaunchExecutions())
+    service._backend = backend
+    prepared: list[str] = []
+    abandoned: list[str] = []
+    service._local_stream_prepare = prepared.append
+    service._local_stream_abort = abandoned.append
+    return service, prepared, abandoned
+
+
+@pytest.mark.asyncio
+async def test_launch_normal_return_without_worker_abandons_prepared_stream() -> None:
+    class Backend:
+        async def launch(self, request: object, execution: object) -> None:
+            del request, execution
+
+        def worker_installed(self, execution_id: str) -> bool:
+            del execution_id
+            return False
+
+    service, prepared, abandoned = _launch_service(Backend())
+    await service._launch_started(
+        SimpleNamespace(),
+        SimpleNamespace(execution_id="execution", tenant_id="tenant"),
+        scope="execution.run",
+        idempotency_key_digest="digest",
+        prepare_local_stream=True,
+    )
+    assert prepared == ["execution"]
+    assert abandoned == ["execution"]
+
+
+@pytest.mark.asyncio
+async def test_existing_worker_skips_new_prepared_reservation() -> None:
+    class Backend:
+        async def launch(self, request: object, execution: object) -> None:
+            del request, execution
+
+        def worker_installed(self, execution_id: str) -> bool:
+            del execution_id
+            return True
+
+    service, prepared, abandoned = _launch_service(Backend())
+    await service._launch_started(
+        SimpleNamespace(),
+        SimpleNamespace(execution_id="execution", tenant_id="tenant"),
+        scope="execution.run",
+        idempotency_key_digest="digest",
+        prepare_local_stream=True,
+    )
+    assert prepared == []
+    assert abandoned == []
+
+
+@pytest.mark.asyncio
+async def test_cancellation_before_worker_installation_abandons_reservation() -> None:
+    class Backend:
+        async def launch(self, request: object, execution: object) -> None:
+            del request, execution
+            raise asyncio.CancelledError
+
+        def worker_installed(self, execution_id: str) -> bool:
+            del execution_id
+            return False
+
+    service, prepared, abandoned = _launch_service(Backend())
+    with pytest.raises(asyncio.CancelledError):
+        await service._launch_started(
+            SimpleNamespace(),
+            SimpleNamespace(execution_id="execution", tenant_id="tenant"),
+            scope="execution.run",
+            idempotency_key_digest="digest",
+            prepare_local_stream=True,
+        )
+    assert prepared == ["execution"]
+    assert abandoned == ["execution"]
+
+
+@pytest.mark.asyncio
+async def test_cancellation_after_worker_installation_retains_reservation() -> None:
+    class Backend:
+        def __init__(self) -> None:
+            self.installed = False
+
+        async def launch(self, request: object, execution: object) -> None:
+            del request, execution
+            self.installed = True
+            raise asyncio.CancelledError
+
+        def worker_installed(self, execution_id: str) -> bool:
+            del execution_id
+            return self.installed
+
+    service, prepared, abandoned = _launch_service(Backend())
+    with pytest.raises(asyncio.CancelledError):
+        await service._launch_started(
+            SimpleNamespace(),
+            SimpleNamespace(execution_id="execution", tenant_id="tenant"),
+            scope="execution.run",
+            idempotency_key_digest="digest",
+            prepare_local_stream=True,
+        )
+    assert prepared == ["execution"]
+    assert abandoned == []
+
+
+@pytest.mark.asyncio
+async def test_wait_timeout_includes_initial_authorized_read() -> None:
+    service = object.__new__(DefaultExecutionService)
+    service._local_stream_abort = None
+
+    async def slow_authorized(
+        execution_id: str,
+        principal: Principal,
+        action: object,
+    ) -> object:
+        del execution_id, principal, action
+        await asyncio.sleep(0.05)
+        return SimpleNamespace(execution_id="execution", status=ExecutionStatus.STARTED)
+
+    service._load_authorized = slow_authorized
+    principal = Principal("principal", "tenant", "service")
+    with pytest.raises(AIError) as error:
+        await DefaultExecutionService.wait.__wrapped__(
+            service,
+            "execution",
+            principal=principal,
+            timeout_seconds=0.001,
+        )
+    assert error.value.code is ErrorCode.EXECUTION_WAIT_TIMEOUT

--- a/tests/ai/test_runtime_persistence_error_contract.py
+++ b/tests/ai/test_runtime_persistence_error_contract.py
@@ -16,7 +16,6 @@ from linktools.ai.core import (
 )
 from linktools.ai.errors import AIError, ErrorCode
 from linktools.ai.runtime import RuntimeDomain, RuntimeState
-from linktools.ai.runtime._session import _session_agent_id
 from linktools.ai.runtime._tool import ToolOperationRecord
 from linktools.ai.runtime.state._codec import (
     _decode_enveloped_domain,
@@ -164,9 +163,9 @@ def _transcript_chunk_data() -> dict[str, object]:
 
 def test_generic_tolerance_does_not_guess_missing_agent_identity() -> None:
     with pytest.raises(AIError) as raised:
-        _session_agent_id(
-            _decode_enveloped_domain(_precomposition_session_data(), SessionRecord)
-        )
+        _decode_enveloped_domain(
+            _precomposition_session_data(), SessionRecord
+        ).resolved_agent_id()
 
     assert raised.value.code is ErrorCode.STORAGE_VERSION_UNSUPPORTED
 

--- a/tests/ai/test_runtime_persistence_evidence.py
+++ b/tests/ai/test_runtime_persistence_evidence.py
@@ -24,7 +24,6 @@ from linktools.ai.core import (
 from linktools.ai.errors import AIError, ErrorCode
 from linktools.ai.migrate import provision_runtime_database
 from linktools.ai.runtime import DefaultSessionService, Runtime, RuntimeState
-from linktools.ai.runtime._session import _session_agent_id
 from linktools.ai.runtime.state._codec import (
     _decode_enveloped_domain,
     _encode_persisted_domain,
@@ -640,7 +639,7 @@ async def test_historical_session_business_write_persists_resolved_agent_id(
 def test_historical_session_identity_failures_are_scoped() -> None:
     session = replace(_session(), agent_id=None, metadata={})
     with pytest.raises(AIError) as raised:
-        _session_agent_id(session)
+        session.resolved_agent_id()
     assert raised.value.code is ErrorCode.STORAGE_VERSION_UNSUPPORTED
 
     conflicting = replace(
@@ -648,7 +647,7 @@ def test_historical_session_identity_failures_are_scoped() -> None:
         metadata={"linktools.ai.agent_id": "other"},
     )
     with pytest.raises(AIError) as raised:
-        _session_agent_id(conflicting)
+        conflicting.resolved_agent_id()
     assert raised.value.code is ErrorCode.STORAGE_INTEGRITY_ERROR
 
 

--- a/tests/ai/test_runtime_stream_order.py
+++ b/tests/ai/test_runtime_stream_order.py
@@ -144,9 +144,10 @@ def _service(
 @pytest.mark.asyncio
 async def test_live_semantic_events_keep_agent_source_order() -> None:
     broker = LiveExecutionEventBroker()
-    lease = broker.prepare_local_producer("execution")
+    broker.prepare_local_producer("execution")
     broker.register_local_producer("execution", 1)
-    live = broker.claim_local_producer(lease)
+    live = broker.claim_local_producer("execution")
+    assert live is not None
     broker.publish(ExecutionDelta("execution", ExecutionDeltaType.ASSISTANT_TEXT_DELTA, "before"))
     broker.publish_event(
         "execution",
@@ -177,9 +178,10 @@ async def test_live_semantic_events_keep_agent_source_order() -> None:
 @pytest.mark.asyncio
 async def test_live_durable_terminal_publication_is_idempotent() -> None:
     broker = LiveExecutionEventBroker()
-    lease = broker.prepare_local_producer("execution")
+    broker.prepare_local_producer("execution")
     broker.register_local_producer("execution", 0)
-    live = broker.claim_local_producer(lease)
+    live = broker.claim_local_producer("execution")
+    assert live is not None
     payload = {"run_id": "run"}
 
     broker.publish_event(
@@ -544,9 +546,8 @@ async def test_durable_stream_stops_when_terminal_cursor_already_seen() -> None:
 @pytest.mark.asyncio
 async def test_local_stream_skips_already_seen_terminal_and_stops() -> None:
     broker = LiveExecutionEventBroker()
-    lease = broker.prepare_local_producer("execution")
+    broker.prepare_local_producer("execution")
     broker.register_local_producer("execution", 0)
-    live = broker.claim_local_producer(lease)
     broker.publish_event(
         "execution",
         ExecutionEventType.EXECUTION_SUCCEEDED,
@@ -562,27 +563,27 @@ async def test_local_stream_skips_already_seen_terminal_and_stops() -> None:
     principal = Principal("user", "tenant", "user")
     streamed = [
         item
-        async for item in service._stream_claimed(
-            lease,
+        async for item in service.stream(
+            "execution",
             principal=principal,
             after_sequence=1,
         )
     ]
     assert streamed == []
-    assert live is lease.subscription
+    assert not broker.is_local_producer("execution")
 
 
 @pytest.mark.asyncio
 async def test_fast_completed_prepared_abort_releases_live_state() -> None:
     broker = LiveExecutionEventBroker()
-    lease = broker.prepare_local_producer("execution")
+    broker.prepare_local_producer("execution")
     broker.register_local_producer("execution", 0)
     broker.publish(
         ExecutionDelta("execution", ExecutionDeltaType.ASSISTANT_TEXT_DELTA, "buffered")
     )
     broker.complete("execution")
     assert broker.is_local_producer("execution")
-    broker.abort_local_producer(lease)
+    broker.abandon_prepared_local_producer("execution")
     assert not broker.is_local_producer("execution")
     assert "execution" not in broker._buffers
     assert "execution" not in broker._completed
@@ -592,9 +593,8 @@ async def test_fast_completed_prepared_abort_releases_live_state() -> None:
 @pytest.mark.asyncio
 async def test_reconnect_aligns_to_confirmed_cursor_before_replaying_deltas() -> None:
     broker = LiveExecutionEventBroker()
-    lease = broker.prepare_local_producer("execution")
+    broker.prepare_local_producer("execution")
     broker.register_local_producer("execution", 1)
-    broker.claim_local_producer(lease)
     broker.publish(
         ExecutionDelta("execution", ExecutionDeltaType.ASSISTANT_TEXT_DELTA, "before")
     )
@@ -609,8 +609,8 @@ async def test_reconnect_aligns_to_confirmed_cursor_before_replaying_deltas() ->
     )
     service = _service(_execution(revision=1, event_sequence=1), _EventReader({}), broker)
     principal = Principal("user", "tenant", "user")
-    iterator = service._stream_claimed(
-        lease,
+    iterator = service.stream(
+        "execution",
         principal=principal,
         after_sequence=2,
     ).__aiter__()
@@ -641,9 +641,8 @@ async def test_reconnect_aligns_to_confirmed_cursor_before_replaying_deltas() ->
 @pytest.mark.asyncio
 async def test_reconnect_after_terminal_cursor_does_not_replay_deltas() -> None:
     broker = LiveExecutionEventBroker()
-    lease = broker.prepare_local_producer("execution")
+    broker.prepare_local_producer("execution")
     broker.register_local_producer("execution", 1)
-    broker.claim_local_producer(lease)
     broker.publish(
         ExecutionDelta("execution", ExecutionDeltaType.ASSISTANT_TEXT_DELTA, "before")
     )
@@ -671,8 +670,8 @@ async def test_reconnect_after_terminal_cursor_does_not_replay_deltas() -> None:
     principal = Principal("user", "tenant", "user")
     streamed = [
         item
-        async for item in service._stream_claimed(
-            lease,
+        async for item in service.stream(
+            "execution",
             principal=principal,
             after_sequence=3,
         )


### PR DESCRIPTION
## Summary
- remove cross-module private launch/stream orchestration from the local runtime path
- keep execution start ownership in `DefaultExecutionService` while `LiveExecutionEventBroker` remains the single owner of prepared live-stream state
- reduce `_LocalRuntimeCoordinator` to stream coordination and terminal handoff instead of duplicating run/resume ownership
- centralize Session logical Agent identity resolution on the persisted `SessionRecord` contract
- collapse Session execution handling to one execution dependency; no parallel gated execution dependency remains
- preserve caller-cancellation, early-delta replay, non-stream cleanup, terminal-handoff, and idempotent replay invariants
- add focused regression coverage and strengthen `AGENTS.md` rules for minimal durable contracts and single semantic ownership

## Validation
- focused local Runtime ownership regressions: 90 passed
- `python manage.py check linktools-ai`: passed on the audited final tree
- final PR `Python checks` run #280: passed
  - Python 3.6 compatibility: passed
  - Python 3.10 checks: passed
  - Python latest checks: passed
- final branch is exactly one commit on top of `master`
- final commit: `64b0ae3874ef489e67cff109ae4fe764ec34f111`
- final tree: `b5da20455d1123996ee6810cb57bfd8b23e8453c`
- no temporary repair workflow/helper files remain in the final diff

## Review
- final diff re-reviewed after squash
- no unresolved PR review threads
- no additional correctness, ownership, persistence, or concurrency issues found in the reviewed scope