### PR TITLE
fix(ai): constrain Pydantic tool return schemas

### DIFF
--- a/linktools-ai/src/linktools/ai/runtime/_skill_adapter.py
+++ b/linktools-ai/src/linktools/ai/runtime/_skill_adapter.py
@@ -3,6 +3,7 @@
 """Pydantic AI adapter for the vendor-neutral Skill capability."""
 
 from collections.abc import Awaitable, Callable
+from typing import cast
 
 from pydantic_ai.capabilities import AbstractCapability
 from pydantic_ai.exceptions import ModelRetry
@@ -10,7 +11,6 @@ from pydantic_ai.tools import RunContext as PydanticRunContext
 from pydantic_ai.toolsets import FunctionToolset
 
 from ..capability import RunContext, SkillCapability
-from ..core import JsonValue
 from ..errors import AIError, ErrorCode
 
 _SKILL_CAPABILITY_ID = "linktools-skill"
@@ -57,11 +57,14 @@ class _PydanticSkillCapability(AbstractCapability[RunContext[object]]):
             ctx: PydanticRunContext[RunContext[object]],
             skill_id: str,
             path: "str | None" = None,
-        ) -> "dict[str, JsonValue]":
+        ) -> "dict[str, str | list[str]]":
             """Load skill instructions or one relative text resource."""
             del ctx
             try:
-                return await self._capability.load_skill(skill_id, path)
+                return cast(
+                    dict[str, str | list[str]],
+                    await self._capability.load_skill(skill_id, path),
+                )
             except AIError as error:
                 if error.code not in _MODEL_CORRECTABLE_ERRORS:
                     raise

--- a/linktools-ai/src/linktools/ai/runtime/_subagent_adapter.py
+++ b/linktools-ai/src/linktools/ai/runtime/_subagent_adapter.py
@@ -3,14 +3,15 @@
 """Pydantic AI adapter for the vendor-neutral Subagent capability."""
 
 from collections.abc import Awaitable, Callable
+from typing import cast
 
+from pydantic import JsonValue as PydanticJsonValue
 from pydantic_ai.capabilities import AbstractCapability
 from pydantic_ai.exceptions import ModelRetry
 from pydantic_ai.tools import RunContext as PydanticRunContext
 from pydantic_ai.toolsets import FunctionToolset
 
 from ..capability import RunContext, SubagentCapability
-from ..core import JsonValue
 from ..errors import AIError, ErrorCode
 
 _SUBAGENT_CAPABILITY_ID = "linktools-subagent"
@@ -54,15 +55,18 @@ class _PydanticSubagentCapability(AbstractCapability[RunContext[object]]):
             ctx: PydanticRunContext[RunContext[object]],
             subagent_id: str,
             task: str,
-        ) -> "dict[str, JsonValue]":
+        ) -> "dict[str, PydanticJsonValue]":
             """Delegate one task to a selected subagent."""
             if not ctx.tool_call_id:
                 raise AIError(ErrorCode.RUNTIME_DEPENDENCY_NOT_READY)
             try:
-                return await self._capability.delegate_task(
-                    subagent_id,
-                    task,
-                    invocation_id=ctx.tool_call_id,
+                return cast(
+                    dict[str, PydanticJsonValue],
+                    await self._capability.delegate_task(
+                        subagent_id,
+                        task,
+                        invocation_id=ctx.tool_call_id,
+                    ),
                 )
             except AIError as error:
                 if error.code not in _MODEL_CORRECTABLE_ERRORS:

--- a/tests/ai/test_pydantic_tool_return_schema.py
+++ b/tests/ai/test_pydantic_tool_return_schema.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Pydantic tool return-schema regressions for runtime capabilities."""
+
+import warnings
+
+from linktools.ai.capability import (
+    SkillCapability,
+    SkillDefinition,
+    SkillSourceRegistry,
+    SubagentCapability,
+)
+from linktools.ai.core import JsonValue
+from linktools.ai.runtime._skill_adapter import _PydanticSkillCapability
+from linktools.ai.runtime._subagent_adapter import _PydanticSubagentCapability
+from linktools.ai.spec import SkillSpec, SubagentRef
+
+
+def test_pydantic_capability_tool_return_schemas_are_constrained() -> None:
+    async def delegate(
+        _ref: SubagentRef,
+        _task: str,
+        *,
+        invocation_id: str,
+    ) -> dict[str, JsonValue]:
+        assert invocation_id
+        return {
+            "execution_id": "child",
+            "status": "SUCCEEDED",
+            "output": {"value": True},
+        }
+
+    skill = _PydanticSkillCapability(
+        SkillCapability(
+            (SkillDefinition(SkillSpec("skill", content="instructions")),),
+            SkillSourceRegistry(),
+        )
+    )
+    subagent = _PydanticSubagentCapability(
+        SubagentCapability((SubagentRef("agent", "child"),), delegate)
+    )
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "error",
+            message=r"Could not generate return schema.*",
+            category=UserWarning,
+        )
+        assert skill.get_toolset() is not None
+        assert subagent.get_toolset() is not None


### PR DESCRIPTION
## Summary
- keep vendor-neutral `JsonValue` contracts unchanged
- constrain the Pydantic-facing Skill return schema to its actual string/list payload shape
- use Pydantic's JSON value type only at the Subagent adapter boundary
- add a regression test that turns Pydantic return-schema fallback warnings into failures

## Scope
This fixes the two known `Could not generate return schema` warnings introduced by the generalized Skill/Subagent adapters. No persistence, durable contract, tool input, or capability API semantics are changed.

## Validation
CI should run the repository gates. The regression test specifically fails if either adapter falls back to an unconstrained Pydantic return schema.