### PR TITLE
fix(ai): restore cancellation ownership

### DIFF
--- a/linktools-ai/src/linktools/ai/runtime/_local.py
+++ b/linktools-ai/src/linktools/ai/runtime/_local.py
@@ -110,6 +110,9 @@ class _SubagentDispatcher(Protocol):
     @property
     def pending_background_tasks(self) -> tuple[asyncio.Task[object], ...]: ...
 
+    @property
+    def background_failure(self) -> "AIError | None": ...
+
     def delegate_for(
         self,
         *,
@@ -1884,7 +1887,12 @@ class LocalExecutionBackend:
             if isinstance(task, asyncio.Task) and not task.done()
         }
         pending_background = tuple(pending_background_by_identity.values())
-        if pending or pending_background:
+        dispatcher_failure = (
+            None
+            if self._subagent_dispatcher is None
+            else self._subagent_dispatcher.background_failure
+        )
+        if pending or pending_background or dispatcher_failure is not None:
             raise AIError(
                 ErrorCode.STORAGE_RECOVERY_REQUIRED,
                 safe_details={
@@ -1893,6 +1901,7 @@ class LocalExecutionBackend:
                     "pending_background_tasks": len(pending_background),
                     "pending_checkpoint_tasks": len(checkpoint_background),
                     "pending_execution_tasks": len(execution_background),
+                    "background_failures": int(dispatcher_failure is not None),
                 },
             )
         for execution_id, task in tasks:

--- a/linktools-ai/src/linktools/ai/runtime/_planner.py
+++ b/linktools-ai/src/linktools/ai/runtime/_planner.py
@@ -63,6 +63,7 @@ class RuntimeTaskNodeRunner:
         self._catalog = catalog
         self._compiler = compiler
         self._detached_tasks: set[asyncio.Task[object]] = set()
+        self._background_failures: dict[tuple[str, str, str], AIError] = {}
         self._active_execution_ids: dict[tuple[str, str, str], str] = {}
         self._active_launch_tasks: dict[
             tuple[str, str, str], asyncio.Task[ExecutionHandle]
@@ -71,6 +72,13 @@ class RuntimeTaskNodeRunner:
     @property
     def pending_background_tasks(self) -> tuple[asyncio.Task[object], ...]:
         return tuple(task for task in self._detached_tasks if not task.done())
+
+    @property
+    def background_failure(self) -> "AIError | None":
+        if not self._background_failures:
+            return None
+        failure = next(iter(self._background_failures.values()))
+        return AIError(failure.code, safe_details=dict(failure.safe_details))
 
     async def prepare(
         self,
@@ -237,12 +245,18 @@ class RuntimeTaskNodeRunner:
             handle = await asyncio.shield(launch_task)
         except asyncio.CancelledError:
             continuation = asyncio.create_task(
-                self._observe_after_launch(launch_task, key, graph_id, node.node_id),
-                name=f"task-execution-launch-handoff-{graph_id}-{node.node_id}",
+                self._cancel_after_launch(
+                    launch_task,
+                    key,
+                    principal,
+                    graph_id,
+                    node.node_id,
+                ),
+                name=f"task-execution-launch-cleanup-{graph_id}-{node.node_id}",
             )
             self._detach(
                 cast("asyncio.Task[object]", continuation),
-                "task execution launch handoff",
+                f"task execution launch cleanup graph={graph_id} task={node.node_id}",
             )
             raise
         except BaseException:
@@ -263,13 +277,27 @@ class RuntimeTaskNodeRunner:
                 wait_task.cancel()
                 self._detach(
                     cast("asyncio.Task[object]", wait_task),
-                    "task execution wait handoff",
+                    f"task execution wait cleanup graph={graph_id} task={node.node_id}",
                 )
             else:
                 self._consume_done(
                     cast("asyncio.Task[object]", wait_task),
-                    "task execution wait handoff",
+                    f"task execution wait cleanup graph={graph_id} task={node.node_id}",
                 )
+            cleanup = asyncio.create_task(
+                self._cancel_active_execution(
+                    key,
+                    handle.execution_id,
+                    principal,
+                    graph_id,
+                    node.node_id,
+                ),
+                name=f"task-execution-cancel-{graph_id}-{node.node_id}",
+            )
+            self._detach(
+                cast("asyncio.Task[object]", cleanup),
+                f"task execution cancellation graph={graph_id} task={node.node_id}",
+            )
             raise
         try:
             return await self.result(handle.execution_id, principal=principal)
@@ -320,34 +348,51 @@ class RuntimeTaskNodeRunner:
             except asyncio.CancelledError:
                 raise
             except AIError as error:
-                if error.code is ErrorCode.EXECUTION_START_UNKNOWN:
-                    raise AIError(ErrorCode.STORAGE_RECOVERY_REQUIRED) from error
+                if error.code in {
+                    ErrorCode.EXECUTION_START_UNKNOWN,
+                    ErrorCode.STORAGE_RECOVERY_REQUIRED,
+                }:
+                    failure = self._record_background_failure(
+                        key,
+                        error,
+                        phase="task_execution_resolve_cancel",
+                    )
+                    raise failure from error
                 raise
             except BaseException as error:  # noqa: BLE001
-                raise AIError(ErrorCode.STORAGE_RECOVERY_REQUIRED) from error
+                failure = self._record_background_failure(
+                    key,
+                    error,
+                    phase="task_execution_resolve_cancel",
+                )
+                raise failure from error
             if handle is None:
                 self._active_execution_ids.pop(key, None)
+                self._background_failures.pop(key, None)
                 return
             if not handle.execution_id:
-                raise AIError(ErrorCode.STORAGE_RECOVERY_REQUIRED)
+                failure = self._record_background_failure(
+                    key,
+                    AIError(ErrorCode.STORAGE_RECOVERY_REQUIRED),
+                    phase="task_execution_resolve_cancel",
+                )
+                raise failure
             execution_id = handle.execution_id
             self._active_execution_ids[key] = execution_id
 
-        try:
-            await _cancel_execution(
-                self._execution,
-                execution_id,
-                principal,
-                graph_id,
-                node.node_id,
-            )
-        finally:
-            self._active_execution_ids.pop(key, None)
+        await self._cancel_active_execution(
+            key,
+            execution_id,
+            principal,
+            graph_id,
+            node.node_id,
+        )
 
-    async def _observe_after_launch(
+    async def _cancel_after_launch(
         self,
         launch_task: "asyncio.Task[ExecutionHandle]",
         key: tuple[str, str, str],
+        principal: Principal,
         graph_id: str,
         node_id: str,
     ) -> None:
@@ -355,25 +400,97 @@ class RuntimeTaskNodeRunner:
             handle = await launch_task
         except asyncio.CancelledError:
             return
-        except BaseException as error:  # noqa: BLE001
+        except AIError as error:
+            if error.code in {
+                ErrorCode.EXECUTION_START_UNKNOWN,
+                ErrorCode.STORAGE_RECOVERY_REQUIRED,
+            }:
+                failure = self._record_background_failure(
+                    key,
+                    error,
+                    phase="task_execution_launch_cleanup",
+                )
+                raise failure from error
             _logger.warning(
-                "task execution launch failed during ownership handoff: graph=%s task=%s error=%s",
+                "task execution launch failed during cancellation: "
+                "graph=%s task=%s error=%s",
                 graph_id,
                 node_id,
                 type(error).__name__,
             )
             return
+        except BaseException as error:  # noqa: BLE001
+            failure = self._record_background_failure(
+                key,
+                error,
+                phase="task_execution_launch_cleanup",
+            )
+            raise failure from error
         finally:
             if self._active_launch_tasks.get(key) is launch_task:
                 self._active_launch_tasks.pop(key, None)
         if not handle.execution_id:
-            _logger.error(
-                "task execution launch returned invalid handle during ownership handoff: graph=%s task=%s",
+            failure = self._record_background_failure(
+                key,
+                AIError(ErrorCode.STORAGE_RECOVERY_REQUIRED),
+                phase="task_execution_launch_cleanup",
+            )
+            raise failure
+        self._active_execution_ids[key] = handle.execution_id
+        await self._cancel_active_execution(
+            key,
+            handle.execution_id,
+            principal,
+            graph_id,
+            node_id,
+        )
+
+    async def _cancel_active_execution(
+        self,
+        key: tuple[str, str, str],
+        execution_id: str,
+        principal: Principal,
+        graph_id: str,
+        node_id: str,
+    ) -> None:
+        try:
+            await _cancel_execution(
+                self._execution,
+                execution_id,
+                principal,
                 graph_id,
                 node_id,
             )
-            return
-        self._active_execution_ids[key] = handle.execution_id
+        except asyncio.CancelledError:
+            raise
+        except BaseException as error:  # noqa: BLE001
+            failure = self._record_background_failure(
+                key,
+                error,
+                phase="task_execution_cancel_cleanup",
+            )
+            raise failure from error
+        self._background_failures.pop(key, None)
+        if self._active_execution_ids.get(key) == execution_id:
+            self._active_execution_ids.pop(key, None)
+
+    def _record_background_failure(
+        self,
+        key: tuple[str, str, str],
+        error: BaseException,
+        *,
+        phase: str,
+    ) -> AIError:
+        details = dict(error.safe_details) if isinstance(error, AIError) else {}
+        details.setdefault("phase", phase)
+        details.setdefault("graph_id", key[1])
+        details.setdefault("node_id", key[2])
+        failure = AIError(
+            ErrorCode.STORAGE_RECOVERY_REQUIRED,
+            safe_details=details,
+        )
+        self._background_failures[key] = failure
+        return failure
 
     def _detach(
         self,

--- a/linktools-ai/src/linktools/ai/runtime/_subagent.py
+++ b/linktools-ai/src/linktools/ai/runtime/_subagent.py
@@ -30,10 +30,18 @@ class SubagentDispatcher:
         self._compiler = compiler
         self._execution = execution
         self._detached_tasks: set[asyncio.Task[object]] = set()
+        self._background_failures: dict[str, AIError] = {}
 
     @property
     def pending_background_tasks(self) -> tuple[asyncio.Task[object], ...]:
         return tuple(task for task in self._detached_tasks if not task.done())
+
+    @property
+    def background_failure(self) -> "AIError | None":
+        if not self._background_failures:
+            return None
+        failure = next(iter(self._background_failures.values()))
+        return AIError(failure.code, safe_details=dict(failure.safe_details))
 
     def descriptions_for(
         self,
@@ -188,6 +196,7 @@ class SubagentDispatcher:
                 )
                 raise AIError(ErrorCode.STORAGE_RECOVERY_REQUIRED) from primary
             raise
+        self._background_failures.pop(child.execution_id, None)
         return _subagent_result(result)
 
     async def cancel_children(
@@ -205,6 +214,7 @@ class SubagentDispatcher:
                 ExecutionStatus.FAILED,
                 ExecutionStatus.CANCELLED,
             }:
+                self._background_failures.pop(child.execution_id, None)
                 continue
             await self.cancel_child(
                 child.execution_id,
@@ -228,6 +238,7 @@ class SubagentDispatcher:
             ExecutionStatus.FAILED,
             ExecutionStatus.CANCELLED,
         }:
+            self._background_failures.pop(execution_id, None)
             return
         request = CancelExecutionRequest(
             principal=principal,
@@ -282,12 +293,25 @@ class SubagentDispatcher:
         principal: Principal,
     ) -> None:
         try:
-            result = await self._execution.cancel(execution_id, request)
-        except AIError:
-            raise
-        except BaseException as error:  # noqa: BLE001
-            raise AIError(ErrorCode.STORAGE_RECOVERY_REQUIRED) from error
-        if not result.cancelled:
+            try:
+                result = await self._execution.cancel(execution_id, request)
+            except asyncio.CancelledError:
+                raise
+            except AIError:
+                raise
+            except BaseException as error:  # noqa: BLE001
+                raise AIError(ErrorCode.STORAGE_RECOVERY_REQUIRED) from error
+            if not result.cancelled:
+                current = await self._execution.inspect(
+                    execution_id,
+                    principal=principal,
+                )
+                if current.status not in {
+                    ExecutionStatus.SUCCEEDED,
+                    ExecutionStatus.FAILED,
+                    ExecutionStatus.CANCELLED,
+                }:
+                    raise AIError(ErrorCode.STORAGE_RECOVERY_REQUIRED)
             current = await self._execution.inspect(
                 execution_id,
                 principal=principal,
@@ -298,16 +322,33 @@ class SubagentDispatcher:
                 ExecutionStatus.CANCELLED,
             }:
                 raise AIError(ErrorCode.STORAGE_RECOVERY_REQUIRED)
-        current = await self._execution.inspect(
-            execution_id,
-            principal=principal,
+        except asyncio.CancelledError:
+            raise
+        except BaseException as error:  # noqa: BLE001
+            failure = self._record_background_failure(
+                execution_id,
+                error,
+                phase="subagent_cancel_cleanup",
+            )
+            raise failure from error
+        self._background_failures.pop(execution_id, None)
+
+    def _record_background_failure(
+        self,
+        execution_id: str,
+        error: BaseException,
+        *,
+        phase: str,
+    ) -> AIError:
+        details = dict(error.safe_details) if isinstance(error, AIError) else {}
+        details.setdefault("phase", phase)
+        details.setdefault("execution_id", execution_id)
+        failure = AIError(
+            ErrorCode.STORAGE_RECOVERY_REQUIRED,
+            safe_details=details,
         )
-        if current.status not in {
-            ExecutionStatus.SUCCEEDED,
-            ExecutionStatus.FAILED,
-            ExecutionStatus.CANCELLED,
-        }:
-            raise AIError(ErrorCode.STORAGE_RECOVERY_REQUIRED)
+        self._background_failures[execution_id] = failure
+        return failure
 
     def _detach(
         self,

--- a/linktools-ai/src/linktools/ai/task/_local.py
+++ b/linktools-ai/src/linktools/ai/task/_local.py
@@ -64,6 +64,12 @@ class _BackgroundTaskOwner(Protocol):
     def pending_background_tasks(self) -> tuple[asyncio.Task[object], ...]: ...
 
 
+@runtime_checkable
+class _BackgroundTaskFailureOwner(Protocol):
+    @property
+    def background_failure(self) -> "AIError | None": ...
+
+
 class _TaskNodeState(Protocol):
     node_id: str
     status: TaskStatus
@@ -256,12 +262,16 @@ class LocalTaskGraphLauncher:
             self._close_run(run)
             if run.task is not None and not run.task.done():
                 run.task.cancel()
-                await asyncio.gather(run.task, return_exceptions=True)
-            elif run.task is not None:
-                self._consume_done(run.task, "task graph cancellation")
+                await asyncio.sleep(0)
+            if run.task is not None:
+                if run.task.done():
+                    self._consume_done(run.task, "task graph cancellation")
+                else:
+                    self._detach(
+                        cast("asyncio.Task[object]", run.task),
+                        "task graph cancellation",
+                    )
             self._remove_run(key, run)
-        if self._detached_tasks:
-            await asyncio.gather(*tuple(self._detached_tasks), return_exceptions=True)
         if cleanup_error is not None:
             if isinstance(cleanup_error, asyncio.CancelledError):
                 raise cleanup_error
@@ -283,18 +293,22 @@ class LocalTaskGraphLauncher:
                 run.task.cancel()
             elif run.task is not None:
                 self._consume_done(run.task, "task graph shutdown")
-        local_tasks = tuple(
-            run.task for run in runs if run.task is not None and not run.task.done()
-        )
-        if local_tasks:
-            await asyncio.gather(*local_tasks, return_exceptions=True)
-        if self._detached_tasks:
-            await asyncio.gather(*tuple(self._detached_tasks), return_exceptions=True)
         runner_pending = (
             self._runner.pending_background_tasks
             if isinstance(self._runner, _BackgroundTaskOwner)
             else ()
         )
+        if (
+            any(run.task is not None and not run.task.done() for run in runs)
+            or any(not task.done() for task in self._detached_tasks)
+            or any(not task.done() for task in runner_pending)
+        ):
+            await asyncio.sleep(0)
+            runner_pending = (
+                self._runner.pending_background_tasks
+                if isinstance(self._runner, _BackgroundTaskOwner)
+                else ()
+            )
         pending = tuple(
             task
             for task in (
@@ -311,6 +325,16 @@ class LocalTaskGraphLauncher:
                     "phase": "task_graph_shutdown",
                     "pending_tasks": len(pending),
                 },
+            )
+        runner_failure = (
+            self._runner.background_failure
+            if isinstance(self._runner, _BackgroundTaskFailureOwner)
+            else None
+        )
+        if runner_failure is not None:
+            raise AIError(
+                runner_failure.code,
+                safe_details=dict(runner_failure.safe_details),
             )
         for run in runs:
             if run.task is not None:
@@ -562,12 +586,6 @@ class LocalTaskGraphLauncher:
                 else None
             )
             if heartbeat_error is not None:
-                runner_task.cancel()
-                await asyncio.gather(runner_task, return_exceptions=True)
-                self._consume_done(
-                    cast("asyncio.Task[object]", runner_task),
-                    "task node runner after heartbeat loss",
-                )
                 _logger.warning(
                     "task heartbeat lost ownership: graph=%s task=%s",
                     request.graph.graph_id,
@@ -638,15 +656,13 @@ class LocalTaskGraphLauncher:
                 task for task in (runner_task, heartbeat_task) if task is not None
             )
             for task in cleanup_tasks:
+                tracked = cast("asyncio.Task[object]", task)
                 if not task.done():
                     task.cancel()
-            if cleanup_tasks:
-                await asyncio.gather(*cleanup_tasks, return_exceptions=True)
-            for task in cleanup_tasks:
-                self._consume_done(
-                    cast("asyncio.Task[object]", task),
-                    "task node cleanup",
-                )
+                if task.done():
+                    self._consume_done(tracked, "task node cleanup")
+                else:
+                    self._detach(tracked, "task node cleanup")
             if not run.closed:
                 self._signal(run)
 
@@ -751,13 +767,18 @@ class LocalTaskGraphLauncher:
         for task in tasks:
             if not task.done():
                 task.cancel()
-        if tasks:
-            await asyncio.gather(*tasks, return_exceptions=True)
         for task in tasks:
-            self._consume_done(
-                cast("asyncio.Task[object]", task),
-                "task graph inflight cleanup",
-            )
+            tracked = cast("asyncio.Task[object]", task)
+            if task.done():
+                self._consume_done(
+                    tracked,
+                    "task graph inflight cleanup",
+                )
+            else:
+                self._detach(
+                    tracked,
+                    "task graph inflight cleanup",
+                )
         inflight.clear()
 
     def _detach(

--- a/linktools-ai/src/linktools/ai/task/_service_impl.py
+++ b/linktools-ai/src/linktools/ai/task/_service_impl.py
@@ -209,15 +209,27 @@ class DefaultTaskService(TaskApi):
             self._launcher.start(launch),
             name=f"task-scheduler-arm-{launch.principal.tenant_id}-{launch.graph.graph_id}",
         )
-        cancelled = False
-        while True:
+        try:
+            await asyncio.shield(task)
+        except asyncio.CancelledError:
+            if not task.done():
+                self._detach_finalizer(
+                    cast("asyncio.Task[object]", task),
+                    launch.graph.graph_id,
+                    label="task scheduler arm",
+                )
+                raise
             try:
-                await asyncio.shield(task)
-                break
-            except asyncio.CancelledError:
-                if task.done():
-                    break
-                cancelled = True
+                task.result()
+            except asyncio.CancelledError as error:
+                raise AIError(
+                    ErrorCode.STORAGE_RECOVERY_REQUIRED,
+                    safe_details={
+                        "phase": "task_scheduler_arm",
+                        "graph_id": launch.graph.graph_id,
+                        "durable_admitted": True,
+                    },
+                ) from error
             except BaseException as error:  # noqa: BLE001
                 raise AIError(
                     ErrorCode.STORAGE_RECOVERY_REQUIRED,
@@ -227,17 +239,8 @@ class DefaultTaskService(TaskApi):
                         "durable_admitted": True,
                     },
                 ) from error
-        if task.cancelled():
-            raise AIError(
-                ErrorCode.STORAGE_RECOVERY_REQUIRED,
-                safe_details={
-                    "phase": "task_scheduler_arm",
-                    "graph_id": launch.graph.graph_id,
-                    "durable_admitted": True,
-                },
-            )
-        error = task.exception()
-        if error is not None:
+            raise
+        except BaseException as error:  # noqa: BLE001
             raise AIError(
                 ErrorCode.STORAGE_RECOVERY_REQUIRED,
                 safe_details={
@@ -246,8 +249,6 @@ class DefaultTaskService(TaskApi):
                     "durable_admitted": True,
                 },
             ) from error
-        if cancelled:
-            raise asyncio.CancelledError
 
     async def recover_pending(self) -> None:
         if self._launcher is None:
@@ -923,6 +924,8 @@ class DefaultTaskService(TaskApi):
         self,
         task: "asyncio.Task[object]",
         graph_id: str,
+        *,
+        label: str = "task graph cancel finalizer",
     ) -> None:
         if task in self._detached_finalizers:
             return
@@ -935,8 +938,8 @@ class DefaultTaskService(TaskApi):
                 pass
             except BaseException as error:  # noqa: BLE001
                 _logger.warning(
-                    "task graph cancel finalizer failed after caller cancellation: "
-                    "graph=%s error=%s",
+                    "%s failed after caller cancellation: graph=%s error=%s",
+                    label,
                     graph_id,
                     type(error).__name__,
                 )

--- a/linktools-ai/src/linktools/commands/ai/run.py
+++ b/linktools-ai/src/linktools/commands/ai/run.py
@@ -19,7 +19,7 @@ from ...ai.core import ExecutionDeltaType, ExecutionEventType, ExecutionStatus
 from ...ai.errors import AIError
 from ...ai.migrate import provision_runtime_database
 from ...ai.model import ModelRegistry
-from ...ai.runtime import ExecutionResult, Runtime, RuntimeState
+from ...ai.runtime import Execution, ExecutionResult, Runtime, RuntimeState
 from ...ai.workspace import Workspace
 
 if TYPE_CHECKING:
@@ -132,13 +132,18 @@ async def _emit_result(
 ) -> int:
     agent = runtime.agent()
     if as_json:
-        result = await agent.run(
+        execution = await agent.start(
             prompt,
             session_id=session_id,
             memory_scope=memory_scope,
             planning=planning,
             thinking=thinking,
         )
+        try:
+            result = await execution.wait()
+        except asyncio.CancelledError:
+            await _cancel_interrupted_execution(execution)
+            raise
         payload = _result_payload(result)
         print(json.dumps(payload, ensure_ascii=False, sort_keys=True))
         if result.status is not ExecutionStatus.SUCCEEDED:
@@ -162,30 +167,34 @@ async def _emit_result(
     terminal_status = "UNKNOWN"
     terminal_error_code: object = None
     terminal_safe_details: object = {}
-    async for event in execution.stream():
-        execution_id = event.execution_id
-        if event.event_type is ExecutionDeltaType.ASSISTANT_TEXT_DELTA:
-            text = event.payload.get("text") if isinstance(event.payload, dict) else None
-            if isinstance(text, str):
-                sys.stdout.write(text)
-                sys.stdout.flush()
-        elif event.event_type is ExecutionDeltaType.ASSISTANT_THINKING_DELTA:
-            _write_stderr("[thinking] " + _payload_text(event.payload))
-        elif event.event_type is ExecutionEventType.TOOL_CALL_STARTED:
-            _write_stderr("[tool] " + _payload_text(event.payload))
-        elif event.event_type is ExecutionEventType.TOOL_CALL_FINISHED:
-            _write_stderr("[tool] finished " + _payload_text(event.payload))
-        elif event.event_type is ExecutionEventType.EXECUTION_SUCCEEDED:
-            succeeded = True
-            terminal_status = ExecutionStatus.SUCCEEDED.value
-        elif event.event_type in {
-            ExecutionEventType.EXECUTION_FAILED,
-            ExecutionEventType.EXECUTION_CANCELLED,
-        }:
-            terminal_status = event.event_type.value.removeprefix("EXECUTION_")
-            if isinstance(event.payload, dict):
-                terminal_error_code = event.payload.get("error_code")
-                terminal_safe_details = event.payload.get("safe_error_details", {})
+    try:
+        async for event in execution.stream():
+            execution_id = event.execution_id
+            if event.event_type is ExecutionDeltaType.ASSISTANT_TEXT_DELTA:
+                text = event.payload.get("text") if isinstance(event.payload, dict) else None
+                if isinstance(text, str):
+                    sys.stdout.write(text)
+                    sys.stdout.flush()
+            elif event.event_type is ExecutionDeltaType.ASSISTANT_THINKING_DELTA:
+                _write_stderr("[thinking] " + _payload_text(event.payload))
+            elif event.event_type is ExecutionEventType.TOOL_CALL_STARTED:
+                _write_stderr("[tool] " + _payload_text(event.payload))
+            elif event.event_type is ExecutionEventType.TOOL_CALL_FINISHED:
+                _write_stderr("[tool] finished " + _payload_text(event.payload))
+            elif event.event_type is ExecutionEventType.EXECUTION_SUCCEEDED:
+                succeeded = True
+                terminal_status = ExecutionStatus.SUCCEEDED.value
+            elif event.event_type in {
+                ExecutionEventType.EXECUTION_FAILED,
+                ExecutionEventType.EXECUTION_CANCELLED,
+            }:
+                terminal_status = event.event_type.value.removeprefix("EXECUTION_")
+                if isinstance(event.payload, dict):
+                    terminal_error_code = event.payload.get("error_code")
+                    terminal_safe_details = event.payload.get("safe_error_details", {})
+    except asyncio.CancelledError:
+        await _cancel_interrupted_execution(execution)
+        raise
     sys.stdout.write("\n")
     sys.stdout.flush()
     if not succeeded:
@@ -195,6 +204,18 @@ async def _emit_result(
             f"error_code={terminal_error_code} safe_error_details={terminal_safe_details}"
         )
     return 0
+
+
+async def _cancel_interrupted_execution(execution: "Execution[object]") -> None:
+    result = await execution.cancel(
+        idempotency_key=f"ai-run-interrupt:{execution.execution_id}",
+    )
+    if not result.cancelled:
+        _logger.warning(
+            "ai run cancellation effect not yet confirmed: execution=%s",
+            execution.execution_id,
+        )
+    await execution.wait()
 
 
 def _result_payload(result: ExecutionResult) -> dict[str, object]:

--- a/tests/ai/test_cli_run_cancellation.py
+++ b/tests/ai/test_cli_run_cancellation.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Cancellation cleanup for the interactive ai run command.
+
+from types import SimpleNamespace
+
+import pytest
+
+from linktools.commands.ai.run import _cancel_interrupted_execution
+
+
+@pytest.mark.asyncio
+async def test_ai_run_interrupt_waits_for_execution_quiescence() -> None:
+    calls: list[object] = []
+
+    class Execution:
+        execution_id = "execution"
+
+        async def cancel(self, *, idempotency_key: str | None = None, force: bool = False):
+            calls.append(("cancel", idempotency_key, force))
+            return SimpleNamespace(cancelled=False)
+
+        async def wait(self, *, timeout_seconds: float | None = None):
+            calls.append(("wait", timeout_seconds))
+            return SimpleNamespace()
+
+    await _cancel_interrupted_execution(Execution())
+
+    assert calls == [
+        ("cancel", "ai-run-interrupt:execution", False),
+        ("wait", None),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_ai_run_json_interrupt_cancels_owned_execution() -> None:
+    import asyncio
+
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+
+    class Execution:
+        execution_id = "execution"
+
+        def __init__(self) -> None:
+            self.wait_calls = 0
+
+        async def wait(self):
+            self.wait_calls += 1
+            if self.wait_calls == 1:
+                started.set()
+                await asyncio.Event().wait()
+            return SimpleNamespace()
+
+        async def cancel(self, *, idempotency_key=None, force=False):
+            assert idempotency_key == "ai-run-interrupt:execution"
+            assert force is False
+            cancelled.set()
+            return SimpleNamespace(cancelled=True)
+
+    execution = Execution()
+
+    class Agent:
+        async def start(self, *args, **kwargs):
+            del args, kwargs
+            return execution
+
+    class Runtime:
+        def agent(self):
+            return Agent()
+
+    from linktools.commands.ai.run import _emit_result
+
+    task = asyncio.create_task(
+        _emit_result(Runtime(), "prompt", "session", "memory", True, False, False)
+    )
+    await started.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert cancelled.is_set()
+    assert execution.wait_calls == 2

--- a/tests/ai/test_error_cancellation_contract.py
+++ b/tests/ai/test_error_cancellation_contract.py
@@ -13,10 +13,12 @@ from linktools.ai.core import ExecutionStatus, Principal, ResourceKind, Resource
 from linktools.ai.errors import AIError, ErrorCode
 from linktools.ai.runtime._evaluation import DefaultEvaluationService
 from linktools.ai.runtime._execution import DefaultExecutionService
+from linktools.ai.runtime._local import LocalExecutionBackend
 from linktools.ai.runtime._planner import RuntimeTaskNodeRunner
 from linktools.ai.runtime._session import DefaultSessionService
 from linktools.ai.runtime._subagent import SubagentDispatcher
 from linktools.ai.spec import MCPServerSpec
+from linktools.ai.task._local import LocalTaskGraphLauncher, _InflightNode
 from linktools.ai.task._service_impl import DefaultTaskService
 from linktools.ai.workspace import trusted_workspace_principal
 
@@ -113,11 +115,12 @@ async def test_transient_handoff_cleanup_preserves_cancellation(
 
 
 @pytest.mark.asyncio
-async def test_task_runner_cancellation_hands_off_without_business_cancel() -> None:
+async def test_task_runner_preserves_cancellation_when_child_cleanup_fails() -> None:
     class Execution:
         def __init__(self) -> None:
             self.wait_started = asyncio.Event()
-            self.cancel_called = False
+            self.cancel_started = asyncio.Event()
+            self.finish_cancel = asyncio.Event()
 
         async def run(self, *args, **kwargs):
             del args, kwargs
@@ -130,13 +133,15 @@ async def test_task_runner_cancellation_hands_off_without_business_cancel() -> N
 
         async def cancel(self, *args, **kwargs):
             del args, kwargs
-            self.cancel_called = True
-            raise AssertionError("runner handoff must not business-cancel execution")
+            self.cancel_started.set()
+            await self.finish_cancel.wait()
+            raise RuntimeError("cleanup failed")
 
     execution = Execution()
     runner = object.__new__(RuntimeTaskNodeRunner)
     runner._execution = execution
     runner._detached_tasks = set()
+    runner._background_failures = {}
     runner._active_execution_ids = {}
     runner._active_launch_tasks = {}
 
@@ -159,12 +164,348 @@ async def test_task_runner_cancellation_hands_off_without_business_cancel() -> N
     with pytest.raises(asyncio.CancelledError):
         await task
 
-    await asyncio.sleep(0)
-    assert execution.cancel_called is False
+    await execution.cancel_started.wait()
     pending = runner.pending_background_tasks
+    assert pending
+    execution.finish_cancel.set()
+    await asyncio.gather(*pending, return_exceptions=True)
+    await asyncio.sleep(0)
+    assert runner.pending_background_tasks == ()
+    failure = runner.background_failure
+    assert failure is not None
+    assert failure.code is ErrorCode.STORAGE_RECOVERY_REQUIRED
+
+    launcher = object.__new__(LocalTaskGraphLauncher)
+    launcher._accepting = True
+    launcher._graphs = {}
+    launcher._wait_observations = {}
+    launcher._detached_tasks = set()
+    launcher._runner = runner
+    with pytest.raises(AIError) as shutdown_error:
+        await launcher.shutdown()
+    assert shutdown_error.value.code is ErrorCode.STORAGE_RECOVERY_REQUIRED
+
+
+@pytest.mark.asyncio
+async def test_task_runner_cancels_execution_that_finishes_launch_after_caller_cancel() -> None:
+    class Execution:
+        def __init__(self) -> None:
+            self.launch_started = asyncio.Event()
+            self.release_launch = asyncio.Event()
+            self.cancel_called = asyncio.Event()
+
+        async def run(self, *args, **kwargs):
+            del args, kwargs
+            self.launch_started.set()
+            await self.release_launch.wait()
+            return SimpleNamespace(execution_id="execution")
+
+        async def wait(self, *args, **kwargs):
+            del args, kwargs
+            raise AssertionError("wait must not start after caller cancellation")
+
+        async def cancel(self, *args, **kwargs):
+            del args, kwargs
+            self.cancel_called.set()
+            return SimpleNamespace(cancelled=True)
+
+    execution = Execution()
+    runner = object.__new__(RuntimeTaskNodeRunner)
+    runner._execution = execution
+    runner._detached_tasks = set()
+    runner._background_failures = {}
+    runner._active_execution_ids = {}
+    runner._active_launch_tasks = {}
+
+    async def prepare(*args, **kwargs):
+        del args, kwargs
+        return "binding", object()
+
+    runner.prepare = prepare
+    task = asyncio.create_task(
+        runner.run(
+            SimpleNamespace(node_id="node"),
+            graph_id="graph",
+            principal=trusted_workspace_principal("tenant"),
+            dependency_results={},
+        )
+    )
+    await execution.launch_started.wait()
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    pending = runner.pending_background_tasks
+    assert pending
+    execution.release_launch.set()
+    await asyncio.gather(*pending, return_exceptions=True)
+    assert execution.cancel_called.is_set()
+    assert runner.pending_background_tasks == ()
+    assert runner._active_execution_ids == {}
+
+
+@pytest.mark.asyncio
+async def test_task_runner_start_unknown_after_caller_cancel_blocks_shutdown() -> None:
+    class Execution:
+        def __init__(self) -> None:
+            self.launch_started = asyncio.Event()
+            self.release_launch = asyncio.Event()
+
+        async def run(self, *args, **kwargs):
+            del args, kwargs
+            self.launch_started.set()
+            await self.release_launch.wait()
+            raise AIError(ErrorCode.EXECUTION_START_UNKNOWN)
+
+        async def wait(self, *args, **kwargs):
+            del args, kwargs
+            raise AssertionError("wait must not start after unknown launch")
+
+    execution = Execution()
+    runner = object.__new__(RuntimeTaskNodeRunner)
+    runner._execution = execution
+    runner._detached_tasks = set()
+    runner._background_failures = {}
+    runner._active_execution_ids = {}
+    runner._active_launch_tasks = {}
+
+    async def prepare(*args, **kwargs):
+        del args, kwargs
+        return "binding", object()
+
+    runner.prepare = prepare
+    task = asyncio.create_task(
+        runner.run(
+            SimpleNamespace(node_id="node"),
+            graph_id="graph",
+            principal=trusted_workspace_principal("tenant"),
+            dependency_results={},
+        )
+    )
+    await execution.launch_started.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    execution.release_launch.set()
+    pending = runner.pending_background_tasks
+    assert pending
+    await asyncio.gather(*pending, return_exceptions=True)
+    await asyncio.sleep(0)
+    assert runner.pending_background_tasks == ()
+    failure = runner.background_failure
+    assert failure is not None
+    assert failure.code is ErrorCode.STORAGE_RECOVERY_REQUIRED
+
+    launcher = object.__new__(LocalTaskGraphLauncher)
+    launcher._accepting = True
+    launcher._graphs = {}
+    launcher._wait_observations = {}
+    launcher._detached_tasks = set()
+    launcher._runner = runner
+    with pytest.raises(AIError) as shutdown_error:
+        await launcher.shutdown()
+    assert shutdown_error.value.code is ErrorCode.STORAGE_RECOVERY_REQUIRED
+
+
+@pytest.mark.asyncio
+async def test_task_scheduler_arm_cancellation_detaches_pending_launcher() -> None:
+    class Launcher:
+        def __init__(self) -> None:
+            self.started = asyncio.Event()
+            self.release = asyncio.Event()
+
+        async def start(self, launch: object) -> object:
+            del launch
+            self.started.set()
+            await self.release.wait()
+            return object()
+
+    launcher = Launcher()
+    service = DefaultTaskService(SimpleNamespace(), SimpleNamespace(), launcher)
+    launch = SimpleNamespace(
+        principal=trusted_workspace_principal("tenant"),
+        graph=SimpleNamespace(graph_id="graph"),
+    )
+    task = asyncio.create_task(service._arm_graph(launch))
+    await launcher.started.wait()
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    pending = tuple(service._detached_finalizers)
+    assert pending
+    launcher.release.set()
+    await asyncio.gather(*pending, return_exceptions=True)
+    await asyncio.sleep(0)
+    assert service._detached_finalizers == set()
+
+
+@pytest.mark.asyncio
+async def test_task_inflight_cleanup_detaches_cancellation_resistant_node() -> None:
+    launcher = object.__new__(LocalTaskGraphLauncher)
+    launcher._detached_tasks = set()
+    cancelled = asyncio.Event()
+    release = asyncio.Event()
+
+    async def node() -> None:
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cancelled.set()
+            await release.wait()
+
+    task = asyncio.create_task(node())
+    await asyncio.sleep(0)
+    inflight = {"node": _InflightNode(task)}
+
+    await launcher._cancel_inflight(inflight)
+    await cancelled.wait()
+
+    assert inflight == {}
+    pending = tuple(launcher._detached_tasks)
+    assert pending
+    release.set()
+    await asyncio.gather(*pending, return_exceptions=True)
+    await asyncio.sleep(0)
+    assert launcher._detached_tasks == set()
+
+
+@pytest.mark.asyncio
+async def test_task_shutdown_allows_one_turn_for_cancelled_detached_cleanup() -> None:
+    launcher = object.__new__(LocalTaskGraphLauncher)
+    launcher._accepting = True
+    launcher._graphs = {}
+    launcher._wait_observations = {}
+    launcher._detached_tasks = set()
+    launcher._runner = SimpleNamespace()
+    started = asyncio.Event()
+
+    async def cleanup() -> None:
+        started.set()
+        await asyncio.Event().wait()
+
+    task = asyncio.create_task(cleanup())
+    await started.wait()
+    task.cancel()
+    launcher._detach(task, "test cleanup")
+
+    await launcher.shutdown()
+
+    assert task.done()
+    await asyncio.sleep(0)
+    assert launcher._detached_tasks == set()
+
+
+@pytest.mark.asyncio
+async def test_task_shutdown_still_rejects_cancellation_resistant_detached_cleanup() -> None:
+    launcher = object.__new__(LocalTaskGraphLauncher)
+    launcher._accepting = True
+    launcher._graphs = {}
+    launcher._wait_observations = {}
+    launcher._detached_tasks = set()
+    launcher._runner = SimpleNamespace()
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def cleanup() -> None:
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            await release.wait()
+
+    task = asyncio.create_task(cleanup())
+    await started.wait()
+    task.cancel()
+    launcher._detach(task, "test stuck cleanup")
+    try:
+        with pytest.raises(AIError) as error:
+            await launcher.shutdown()
+        assert error.value.code is ErrorCode.STORAGE_RECOVERY_REQUIRED
+        assert error.value.safe_details["phase"] == "task_graph_shutdown"
+    finally:
+        release.set()
+        await task
+        await asyncio.sleep(0)
+
+
+@pytest.mark.asyncio
+async def test_task_heartbeat_loss_detaches_cancellation_resistant_runner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Repository:
+        async def claim(self, *args, **kwargs):
+            del args, kwargs
+            return SimpleNamespace(owner="owner", fence=1, lease_expires_at=None)
+
+        async def list_nodes(self, *args, **kwargs):
+            del args, kwargs
+            return ()
+
+    class Runner:
+        def __init__(self) -> None:
+            self.started = asyncio.Event()
+            self.cancelled = asyncio.Event()
+            self.release = asyncio.Event()
+
+        async def run(self, *args, **kwargs):
+            del args, kwargs
+            self.started.set()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                self.cancelled.set()
+                await self.release.wait()
+                raise
+
+        async def cancel(self, *args, **kwargs):
+            del args, kwargs
+            raise AssertionError("heartbeat cleanup must cancel the owned runner task")
+
+    runner = Runner()
+
+    async def lost_heartbeat(self, state, tenant_id):
+        del self, state, tenant_id
+        await runner.started.wait()
+        raise AIError(ErrorCode.TASK_FENCE_STALE)
+
+    monkeypatch.setattr(LocalTaskGraphLauncher, "_heartbeat", lost_heartbeat)
+    launcher = object.__new__(LocalTaskGraphLauncher)
+    launcher._repository = Repository()
+    launcher._runner = runner
+    launcher._owner = "owner"
+    launcher._detached_tasks = set()
+
+    request = SimpleNamespace(
+        principal=trusted_workspace_principal("tenant"),
+        graph=SimpleNamespace(graph_id="graph"),
+    )
+    node = SimpleNamespace(node_id="node", dependencies=())
+    inflight = {"node": SimpleNamespace(lease=None)}
+    run = SimpleNamespace(
+        closed=False,
+        activity=asyncio.Event(),
+        activity_generation=0,
+    )
+    task = asyncio.create_task(launcher._run_node(request, node, inflight, run))
+    await runner.started.wait()
+
+    try:
+        await asyncio.wait_for(asyncio.shield(task), 0.2)
+    finally:
+        runner.release.set()
+        if not task.done():
+            await task
+
+    assert runner.cancelled.is_set()
+    pending = tuple(launcher._detached_tasks)
     if pending:
         await asyncio.gather(*pending, return_exceptions=True)
-    assert runner.pending_background_tasks == ()
+        await asyncio.sleep(0)
+    assert launcher._detached_tasks == set()
 
 
 @pytest.mark.asyncio
@@ -173,10 +514,11 @@ async def test_subagent_child_cleanup_failure_does_not_replace_cancellation() ->
         def __init__(self) -> None:
             self.cancel_started = asyncio.Event()
             self.finish_cancel = asyncio.Event()
+            self.status = ExecutionStatus.STARTED
 
         async def inspect(self, *args, **kwargs):
             del args, kwargs
-            return SimpleNamespace(status=ExecutionStatus.STARTED)
+            return SimpleNamespace(status=self.status)
 
         async def cancel(self, *args, **kwargs):
             del args, kwargs
@@ -188,6 +530,7 @@ async def test_subagent_child_cleanup_failure_does_not_replace_cancellation() ->
     dispatcher = object.__new__(SubagentDispatcher)
     dispatcher._execution = execution
     dispatcher._detached_tasks = set()
+    dispatcher._background_failures = {}
     task = asyncio.create_task(
         dispatcher.cancel_child(
             "execution",
@@ -205,4 +548,34 @@ async def test_subagent_child_cleanup_failure_does_not_replace_cancellation() ->
     assert pending
     execution.finish_cancel.set()
     await asyncio.gather(*pending, return_exceptions=True)
+    await asyncio.sleep(0)
     assert dispatcher.pending_background_tasks == ()
+    failure = dispatcher.background_failure
+    assert failure is not None
+    assert failure.code is ErrorCode.STORAGE_RECOVERY_REQUIRED
+
+    backend = object.__new__(LocalExecutionBackend)
+    backend._accepting = True
+    backend._tasks = {}
+    backend._executor = SimpleNamespace(pending_background_tasks=())
+    backend._subagent_dispatcher = dispatcher
+    backend._checkpoint_tasks = set()
+    backend._execution_durable_tasks = {}
+    backend._captured_usage = {}
+    backend._terminal_events = {}
+    backend._worker_failures = {}
+    backend._pending_audit_events = {}
+    backend._pending_audit_locks = {}
+    with pytest.raises(AIError) as close_error:
+        await backend.close()
+    assert close_error.value.code is ErrorCode.STORAGE_RECOVERY_REQUIRED
+    assert close_error.value.safe_details["background_failures"] == 1
+
+    execution.status = ExecutionStatus.CANCELLED
+    await dispatcher.cancel_child(
+        "execution",
+        parent_execution_id="parent",
+        principal=trusted_workspace_principal("tenant"),
+    )
+    assert dispatcher.background_failure is None
+    await backend.close()

--- a/tests/ai/test_error_contract_matrix.py
+++ b/tests/ai/test_error_contract_matrix.py
@@ -238,11 +238,23 @@ async def test_task_wait_timeout_has_stable_code() -> None:
     assert error.value.code is ErrorCode.TASK_WAIT_TIMEOUT
 
 
+class _FailedExecution:
+    def __init__(self, result: ExecutionResult) -> None:
+        self._result = result
+
+    async def wait(self) -> ExecutionResult:
+        return self._result
+
+    def stream(self, *args: object, **kwargs: object) -> object:
+        del args, kwargs
+        raise AssertionError("JSON result path must not scan execution events")
+
+
 class _FailedAgent:
     def __init__(self, result: ExecutionResult) -> None:
         self._result = result
 
-    async def run(
+    async def start(
         self,
         prompt: str,
         *,
@@ -250,13 +262,9 @@ class _FailedAgent:
         memory_scope: str,
         planning: bool,
         thinking: bool,
-    ) -> ExecutionResult:
+    ) -> _FailedExecution:
         del prompt, session_id, memory_scope, planning, thinking
-        return self._result
-
-    def stream(self, *args: object, **kwargs: object) -> object:
-        del args, kwargs
-        raise AssertionError("JSON result path must not scan execution events")
+        return _FailedExecution(self._result)
 
 
 class _FailedRuntime:

--- a/tests/ai/test_runtime_persistence_evidence.py
+++ b/tests/ai/test_runtime_persistence_evidence.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 """End-to-end evidence for tolerant Runtime persistence reads."""
 
+import asyncio
 import copy
 from dataclasses import replace
 from datetime import datetime, timezone
@@ -24,6 +25,7 @@ from linktools.ai.core import (
 from linktools.ai.errors import AIError, ErrorCode
 from linktools.ai.migrate import provision_runtime_database
 from linktools.ai.runtime import DefaultSessionService, Runtime, RuntimeState
+from linktools.ai.runtime._agent_executor import AgentExecutor
 from linktools.ai.runtime.state._codec import (
     _decode_enveloped_domain,
     _encode_persisted_domain,
@@ -39,6 +41,7 @@ from linktools.ai.runtime.state._contracts import (
 from linktools.ai.spec import AgentSpec, AgentSpecCodec
 from linktools.ai.storage import ObjectRef, StoredPayload
 from linktools.ai.workspace import Workspace
+from linktools.commands.ai.run import _emit_result
 from pydantic import BaseModel
 from pydantic_ai.models.test import TestModel
 from sqlalchemy.ext.asyncio import create_async_engine
@@ -251,6 +254,71 @@ async def test_terminal_stream_allows_immediate_runtime_close(
             assert len(terminal_events) == 1
     finally:
         await state.close()
+
+
+@pytest.mark.asyncio
+async def test_ai_run_interrupt_closes_and_reopens_sqlite_runtime(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_root = tmp_path / "workspace"
+    agent_path = workspace_root / ".linktools" / "agents" / "default"
+    agent_path.parent.mkdir(parents=True)
+    agent_path.write_bytes(
+        AgentSpecCodec().encode(
+            AgentSpec("default", model="default", allow_tools=())
+        )
+    )
+    database = tmp_path / "runtime.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{database}")
+    await provision_runtime_database(engine)
+    await engine.dispose()
+
+    execution_started = asyncio.Event()
+
+    async def blocking_execute(self, scope):
+        del self, scope
+        execution_started.set()
+        await asyncio.Event().wait()
+        raise AssertionError("blocked execution unexpectedly completed")
+
+    monkeypatch.setattr(AgentExecutor, "execute", blocking_execute)
+    workspace = Workspace.load(workspace_root)
+    state = RuntimeState.sqlite(database)
+    try:
+        async with Runtime.open(
+            workspace,
+            models=_PersistenceTestModels(),  # type: ignore[arg-type]
+            state=state,
+        ) as runtime:
+            task = asyncio.create_task(
+                _emit_result(
+                    runtime,
+                    "hello",
+                    workspace.workspace_id,
+                    workspace.workspace_id,
+                    False,
+                    False,
+                    False,
+                )
+            )
+            await execution_started.wait()
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+    finally:
+        await state.close()
+
+    reopened = RuntimeState.sqlite(database)
+    try:
+        async with Runtime.open(
+            workspace,
+            models=_PersistenceTestModels(),  # type: ignore[arg-type]
+            state=reopened,
+        ):
+            pass
+    finally:
+        await reopened.close()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- restore deterministic child-execution cancellation when TaskNode callers are cancelled during launch or wait
- detach cancellation-resistant scheduler/node cleanup under explicit strong ownership so shutdown remains fail-closed instead of blocking indefinitely
- preserve completed cleanup failures until cancellation/start outcome is durably resolved, including TaskNode and Subagent child executions
- clear those recovery blockers once a later cancel, replay/readback, successful wait, or terminal child state proves the side effect is settled
- remove remaining unbounded TaskNode cleanup waits, including heartbeat-loss cleanup
- give already-owned cancellation cleanup one bounded event-loop turn before shutdown classifies it as a recovery blocker
- make `ai run` retain its Execution handle and cancel/wait for local quiescence on Ctrl+C for both streaming and `--json`
- preserve existing durable task recovery, terminal checkpoint, Runtime close, and generic `Execution.stream()` contracts

## Root cause
Durable task recovery changed TaskNode caller cancellation from business cancellation into observation-only handoff. That allowed a cancelled caller to leave a live child execution behind. The CLI also exited its execution observation path on Ctrl+C without first settling the execution it had created, so Runtime close could correctly detect a pending owner and surface `STORAGE_RECOVERY_REQUIRED`.

Repeated review found two additional ownership classes that pending-task tracking alone could not represent. A detached cancellation/start cleanup may finish quickly with `STORAGE_RECOVERY_REQUIRED` or `EXECUTION_START_UNKNOWN`; the task is then no longer pending, but the side effect is still unresolved. The same issue existed for Subagent child cancellation. Both paths now retain an in-memory unresolved-cleanup failure until later durable evidence proves the execution is terminal or absent.

The review also found and repaired two liveness gaps in `LocalTaskGraphLauncher`: heartbeat/node cleanup could still perform `cancel() -> await gather()` on cancellation-resistant tasks, and shutdown only yielded for pending graph-run tasks, so a just-cancelled detached cleanup could be misclassified as a storage recovery blocker.

## Verification
- focused cancellation regressions cover late launch, `EXECUTION_START_UNKNOWN` after caller cancellation, wait cancellation, scheduler-arm cancellation, cancellation-resistant node/heartbeat cleanup, completed cleanup failure latching, bounded shutdown settling, stuck cleanup fail-closed behavior, and blocker clearing after terminal evidence
- Subagent regression proves a failed detached child cancellation blocks `LocalExecutionBackend.close()` even after the task itself is done, then clears once terminal state is confirmed
- real SQLite integration regression covers running `ai run` -> caller cancellation -> durable execution cancellation/quiescence -> Runtime close -> immediate reopen of the same `runtime.db`
- `python manage.py check linktools-ai` passed on the exact final source tree before the authoring history was squashed
- `git diff --check` passed
- final branch is one commit on current `master`; net diff contains only 6 production files and 4 test files, with no temporary workflow/script files