### PR TITLE
fix(ai): make latest fact query portable

### DIFF
--- a/linktools-ai/src/linktools/ai/runtime/state/_sql.py
+++ b/linktools-ai/src/linktools/ai/runtime/state/_sql.py
@@ -970,23 +970,18 @@ class _SqlTransaction:
         if query.subject_digest is not None:
             conditions.append(table.c.subject_digest == _hex(query.subject_digest))
         if query.latest_per_subject:
-            ranked = (
-                select(
-                    table,
-                    func.row_number()
-                    .over(
-                        partition_by=table.c.subject_digest,
-                        order_by=table.c.sequence.desc(),
-                    )
-                    .label("_subject_rank"),
-                )
+            latest_sequences = (
+                select(func.max(table.c.sequence))
                 .where(*conditions)
-                .subquery()
+                .group_by(table.c.subject_digest)
             )
             statement = (
-                select(ranked)
-                .where(ranked.c._subject_rank == 1)
-                .order_by(ranked.c.sequence)
+                select(table)
+                .where(
+                    table.c.stream_digest == _hex(query.stream_digest),
+                    table.c.sequence.in_(latest_sequences),
+                )
+                .order_by(table.c.sequence)
             )
         else:
             if query.latest:

--- a/tests/ai/test_runtime_storage_contracts.py
+++ b/tests/ai/test_runtime_storage_contracts.py
@@ -15,9 +15,13 @@ from linktools.ai.runtime import RuntimeDomain, RuntimeState
 from linktools.ai.runtime._capabilities import _RuntimeStepPersistence
 from linktools.ai.runtime._tool import RuntimeToolOperationBridge
 from linktools.ai.runtime.state import (
+    FactQuery,
     FilesystemStateStore,
     RuntimeStateCommands,
+    SqlStateStore,
     StateTransaction,
+    StoredFact,
+    StoredRecord,
 )
 from linktools.ai.spec import AgentSpec
 from linktools.ai.storage import PayloadPolicy
@@ -26,6 +30,7 @@ from pydantic_ai.models.test import TestModel
 from pydantic_ai.tools import RunContext, ToolDefinition
 from pydantic_ai.usage import RunUsage
 from pydantic_ai_harness.step_persistence import RunRecord
+from sqlalchemy import event
 from sqlalchemy.dialects import mysql
 from sqlalchemy.ext.asyncio import create_async_engine
 from sqlalchemy.schema import CreateTable
@@ -76,6 +81,85 @@ async def test_sql_state_group_maps_programming_failure_to_internal(tmp_path: Pa
         assert raised.value.safe_details == {"phase": "runtime_state_sql_mutation"}
     finally:
         await state.close()
+        await engine.dispose()
+
+
+async def test_sql_latest_per_subject_uses_portable_aggregate_query(tmp_path: Path) -> None:
+    path = tmp_path / "runtime.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{path}")
+    await provision_database(engine)
+    store = SqlStateStore(engine)
+    await store.initialize()
+    statements: list[str] = []
+
+    def capture_sql(
+        _connection: object,
+        _cursor: object,
+        statement: str,
+        _parameters: object,
+        _context: object,
+        _executemany: bool,
+    ) -> None:
+        statements.append(statement)
+
+    event.listen(engine.sync_engine, "before_cursor_execute", capture_sql)
+    owner = b"o" * 32
+    stream = b"s" * 32
+    subject_a = b"a" * 32
+    subject_b = b"b" * 32
+    record = StoredRecord(
+        owner,
+        b"p" * 32,
+        None,
+        None,
+        "test",
+        "owner",
+        None,
+        0,
+        None,
+        0,
+        None,
+        {},
+    )
+    facts = (
+        StoredFact(stream, 1, owner, "test", subject_a, None, {"value": 1}),
+        StoredFact(stream, 2, owner, "test", subject_b, None, {"value": 2}),
+        StoredFact(stream, 3, owner, "test", subject_a, None, {"value": 3}),
+        StoredFact(stream, 4, owner, "test", None, None, {"value": 4}),
+        StoredFact(stream, 5, owner, "test", None, None, {"value": 5}),
+    )
+
+    async def seed(transaction: StateTransaction) -> None:
+        await transaction.insert_record(record)
+        await transaction.insert_facts(facts)
+
+    try:
+        await store.mutate(seed)
+        statements.clear()
+        values = await store.read(
+            lambda transaction: transaction.list_facts(
+                FactQuery(stream, latest_per_subject=True)
+            )
+        )
+        assert tuple(value.sequence for value in values) == (2, 3, 5)
+        filtered = await store.read(
+            lambda transaction: transaction.list_facts(
+                FactQuery(
+                    stream,
+                    after_sequence=2,
+                    limit=1,
+                    latest_per_subject=True,
+                )
+            )
+        )
+        assert tuple(value.sequence for value in filtered) == (3,)
+        sql = "\n".join(statements).upper()
+        assert "ROW_NUMBER" not in sql
+        assert " OVER " not in sql
+        assert "GROUP BY" in sql
+    finally:
+        event.remove(engine.sync_engine, "before_cursor_execute", capture_sql)
+        await store.close()
         await engine.dispose()
 
 


### PR DESCRIPTION
## Summary

- Replace the `ROW_NUMBER() OVER (...)` implementation of `FactQuery.latest_per_subject` with `MAX(sequence) GROUP BY subject_digest`.
- Preserve the existing latest-per-subject semantics, including `NULL` subjects, `after_sequence`, ordering, and `limit`.
- Add a SQL regression test covering the query semantics and asserting that the generated query does not use window functions.

## Root cause

The Runtime SQL StateStore used a window function for `latest_per_subject`. Downstream deployments using MySQL-compatible databases without window-function support fail while reading unresolved tool effects during recovery.

## Compatibility

- No schema or migration changes.
- No public API, wire-format, or persisted-data changes.
- No database minimum-version increase.
- No pessimistic locking or concurrency-model changes.
- No additional SQL round trips; the operation remains one SELECT.
- The replacement uses portable aggregate/subquery SQL supported by the existing SQLite, MySQL, and PostgreSQL backends.

## Review coverage

Reviewed the Runtime State SQL backend and the other SQL surfaces in `linktools-ai` (`asset` SQL backend, SQL object store, SQL context, and dialect helpers) for the same class of window-function/version-specific query dependency. No additional `ROW_NUMBER`, window `OVER`, or equivalent latest-per-group implementation was found.

## Validation

The regression test covers:

- multiple subjects;
- latest fact per subject;
- `NULL` subject grouping;
- `after_sequence` filtering before latest selection;
- result ordering and `limit`;
- absence of `ROW_NUMBER` / `OVER` in emitted SQL.

Repository CI is expected to run on this PR.