### PR TITLE
fix(ai): make cancellation cleanup quiescent

### DIFF
--- a/linktools-ai/src/linktools/ai/runtime/_execution.py
+++ b/linktools-ai/src/linktools/ai/runtime/_execution.py
@@ -265,6 +265,10 @@ class DefaultExecutionService:
         self._session_locks_guard = asyncio.Lock()
         self._handoff_states: dict[tuple[str, str], _ExecutionHandoffState] = {}
         self._handoff_condition = asyncio.Condition()
+        self._detached_cancel_finalizers: set[
+            asyncio.Task[CancelExecutionResult]
+        ] = set()
+        self._detached_cancel_failure: AIError | None = None
 
     async def _materialize_repository_instructions(
         self,
@@ -1418,9 +1422,89 @@ class DefaultExecutionService:
 
     async def cancel(self, execution_id: str, request: CancelExecutionRequest) -> CancelExecutionResult:
         async with self._execution_consumer(execution_id, request.principal.tenant_id):
+            finalizer = asyncio.create_task(
+                self._cancel_finalizer_with_handoff(execution_id, request),
+                name=f"execution-cancel-finalizer-{request.principal.tenant_id}-{execution_id}",
+            )
+            try:
+                return await asyncio.shield(finalizer)
+            except asyncio.CancelledError:
+                if finalizer.done():
+                    return finalizer.result()
+                self._detach_cancel_finalizer(finalizer, execution_id)
+                raise
+
+    async def _cancel_finalizer_with_handoff(
+        self,
+        execution_id: str,
+        request: CancelExecutionRequest,
+    ) -> CancelExecutionResult:
+        async with self._execution_consumer(
+            execution_id,
+            request.principal.tenant_id,
+        ):
             result = await self._cancel(execution_id, request)
-            await self._request_handoff_if_terminal(execution_id, request.principal.tenant_id)
+            await self._request_handoff_if_terminal(
+                execution_id,
+                request.principal.tenant_id,
+            )
             return result
+
+    def _detach_cancel_finalizer(
+        self,
+        task: asyncio.Task[CancelExecutionResult],
+        execution_id: str,
+    ) -> None:
+        if task in self._detached_cancel_finalizers:
+            return
+        self._detached_cancel_finalizers.add(task)
+
+        def consume(done: asyncio.Task[CancelExecutionResult]) -> None:
+            try:
+                done.result()
+            except BaseException as error:  # noqa: BLE001
+                _logger.warning(
+                    "execution cancel finalizer failed after caller cancellation: "
+                    "execution=%s error=%s",
+                    execution_id,
+                    type(error).__name__,
+                )
+                if self._detached_cancel_failure is None:
+                    details = (
+                        dict(error.safe_details)
+                        if isinstance(error, AIError)
+                        else {}
+                    )
+                    details.setdefault("phase", "execution_cancel_finalizer")
+                    details.setdefault("execution_id", execution_id)
+                    self._detached_cancel_failure = AIError(
+                        ErrorCode.STORAGE_RECOVERY_REQUIRED,
+                        safe_details=details,
+                    )
+            finally:
+                self._detached_cancel_finalizers.discard(done)
+
+        task.add_done_callback(consume)
+
+    async def preflight_close(self) -> None:
+        while True:
+            pending = tuple(
+                task
+                for task in self._detached_cancel_finalizers
+                if not task.done()
+            )
+            if not pending:
+                break
+            await asyncio.gather(
+                *(asyncio.shield(task) for task in pending),
+                return_exceptions=True,
+            )
+        failure = self._detached_cancel_failure
+        if failure is not None:
+            raise AIError(
+                failure.code,
+                safe_details=dict(failure.safe_details),
+            )
 
     async def _cancel(self, execution_id: str, request: CancelExecutionRequest) -> CancelExecutionResult:
         execution = await self._load_authorized(execution_id, request.principal, AuthorizationAction.EXECUTION_CANCEL)

--- a/linktools-ai/src/linktools/ai/runtime/_factory.py
+++ b/linktools-ai/src/linktools/ai/runtime/_factory.py
@@ -583,6 +583,7 @@ async def _build_local_components(
         )
         local_coordinator = _LocalRuntimeCoordinator(execution, event)
         close_actions: list[Callable[[], Awaitable[None]]] = [
+            task.drain_owned_finalizers,
             task.preflight_close,
             task_launcher.shutdown,
             execution.preflight_close,

--- a/linktools-ai/src/linktools/ai/runtime/_factory.py
+++ b/linktools-ai/src/linktools/ai/runtime/_factory.py
@@ -585,6 +585,7 @@ async def _build_local_components(
         close_actions: list[Callable[[], Awaitable[None]]] = [
             task.preflight_close,
             task_launcher.shutdown,
+            execution.preflight_close,
             backend.close,
             state.close,
         ]

--- a/linktools-ai/src/linktools/ai/runtime/_local.py
+++ b/linktools-ai/src/linktools/ai/runtime/_local.py
@@ -438,18 +438,29 @@ class LocalExecutionBackend:
             label,
             execution_id,
         )
-        try:
-            return await asyncio.shield(task), None
-        except asyncio.CancelledError as cancellation:
-            if not task.done():
-                raise AIError(
-                    ErrorCode.STORAGE_COMMIT_UNKNOWN,
-                    safe_details={"phase": "local_checkpoint", "operation": label},
-                ) from cancellation
+        cancellation: asyncio.CancelledError | None = None
+        while True:
             try:
-                return task.result(), cancellation
-            except BaseException as error:  # noqa: BLE001
-                raise error from cancellation
+                value = await asyncio.shield(task)
+            except asyncio.CancelledError as error:
+                if task.done():
+                    if task.cancelled():
+                        raise AIError(
+                            ErrorCode.STORAGE_COMMIT_UNKNOWN,
+                            safe_details={
+                                "phase": "local_checkpoint",
+                                "operation": label,
+                            },
+                        ) from error
+                    try:
+                        value = task.result()
+                    except BaseException as task_error:  # noqa: BLE001
+                        raise task_error from error
+                    return value, cancellation or error
+                if cancellation is None:
+                    cancellation = error
+                continue
+            return value, cancellation
 
     async def _commit_terminal_checkpoint_owned(
         self,

--- a/linktools-ai/src/linktools/ai/runtime/_local.py
+++ b/linktools-ai/src/linktools/ai/runtime/_local.py
@@ -379,6 +379,14 @@ class LocalExecutionBackend:
             self._execution_durable_tasks = task_map
             return task_map
 
+    def _worker_cancel_request_set(self) -> set[str]:
+        try:
+            return self._worker_cancel_requests
+        except AttributeError:
+            requests: set[str] = set()
+            self._worker_cancel_requests = requests
+            return requests
+
     def _execution_task_set(
         self,
         execution_id: str,
@@ -430,29 +438,18 @@ class LocalExecutionBackend:
             label,
             execution_id,
         )
-        cancellation: asyncio.CancelledError | None = None
-        while True:
+        try:
+            return await asyncio.shield(task), None
+        except asyncio.CancelledError as cancellation:
+            if not task.done():
+                raise AIError(
+                    ErrorCode.STORAGE_COMMIT_UNKNOWN,
+                    safe_details={"phase": "local_checkpoint", "operation": label},
+                ) from cancellation
             try:
-                value = await asyncio.shield(task)
-            except asyncio.CancelledError as error:
-                if task.done():
-                    if task.cancelled():
-                        raise AIError(
-                            ErrorCode.STORAGE_COMMIT_UNKNOWN,
-                            safe_details={
-                                "phase": "local_checkpoint",
-                                "operation": label,
-                            },
-                        ) from error
-                    try:
-                        value = task.result()
-                    except BaseException as task_error:  # noqa: BLE001
-                        raise task_error from error
-                    return value, cancellation or error
-                if cancellation is None:
-                    cancellation = error
-                continue
-            return value, cancellation
+                return task.result(), cancellation
+            except BaseException as error:  # noqa: BLE001
+                raise error from cancellation
 
     async def _commit_terminal_checkpoint_owned(
         self,
@@ -968,7 +965,7 @@ class LocalExecutionBackend:
         if self._tasks.get(execution_id) is not task:
             return
         self._tasks.pop(execution_id, None)
-        self._worker_cancel_requests.discard(execution_id)
+        self._worker_cancel_request_set().discard(execution_id)
         self._captured_usage.pop(execution_id, None)
         if self._approval_pause_segments.get(execution_id) is task:
             self._approval_pause_segments.pop(execution_id, None)
@@ -1012,9 +1009,10 @@ class LocalExecutionBackend:
         execution_id: str,
         task: asyncio.Task[None],
     ) -> None:
-        if task.done() or execution_id in self._worker_cancel_requests:
+        requests = self._worker_cancel_request_set()
+        if task.done() or execution_id in requests:
             return
-        self._worker_cancel_requests.add(execution_id)
+        requests.add(execution_id)
         task.cancel()
 
     async def _drain_worker_task(
@@ -3189,8 +3187,15 @@ class LocalExecutionBackend:
             )
         if dispatcher_failure is not None:
             raise AIError(
-                dispatcher_failure.code,
-                safe_details=dict(dispatcher_failure.safe_details),
+                ErrorCode.STORAGE_RECOVERY_REQUIRED,
+                safe_details={
+                    "phase": "local_execution_close",
+                    "pending_workers": 0,
+                    "pending_background_tasks": 0,
+                    "pending_checkpoint_tasks": 0,
+                    "pending_execution_tasks": 0,
+                    "background_failures": 1,
+                },
             )
         self._tasks.clear()
         self._captured_usage.clear()
@@ -3202,7 +3207,7 @@ class LocalExecutionBackend:
         self._segment_only_worker_exits.clear()
         self._repository_instruction_provenance.clear()
         self._checkpoint_tasks.clear()
-        self._worker_cancel_requests.clear()
+        self._worker_cancel_request_set().clear()
         self._execution_task_map().clear()
 
     async def release_runtime_execution(
@@ -3231,7 +3236,7 @@ class LocalExecutionBackend:
             raise AIError(ErrorCode.STORAGE_CONFLICT)
         if task is not None:
             self._tasks.pop(execution_id, None)
-        self._worker_cancel_requests.discard(execution_id)
+        self._worker_cancel_request_set().discard(execution_id)
         self._terminal_events.pop(execution_id, None)
         self._worker_failures.pop(execution_id, None)
         self._captured_usage.pop(execution_id, None)

--- a/linktools-ai/src/linktools/ai/runtime/_local.py
+++ b/linktools-ai/src/linktools/ai/runtime/_local.py
@@ -310,6 +310,7 @@ class LocalExecutionBackend:
             str,
             set[asyncio.Task[object]],
         ] = {}
+        self._worker_cancel_requests: set[str] = set()
         self._accepting = True
         execution_steps = self._step_reads[RuntimeDomain.EXECUTION]
         conversation_steps = self._step_reads[RuntimeDomain.CONVERSATION]
@@ -429,18 +430,29 @@ class LocalExecutionBackend:
             label,
             execution_id,
         )
-        try:
-            return await asyncio.shield(task), None
-        except asyncio.CancelledError as cancellation:
-            if not task.done():
-                raise AIError(
-                    ErrorCode.STORAGE_COMMIT_UNKNOWN,
-                    safe_details={"phase": "local_checkpoint", "operation": label},
-                ) from cancellation
+        cancellation: asyncio.CancelledError | None = None
+        while True:
             try:
-                return task.result(), cancellation
-            except BaseException as error:  # noqa: BLE001
-                raise error from cancellation
+                value = await asyncio.shield(task)
+            except asyncio.CancelledError as error:
+                if task.done():
+                    if task.cancelled():
+                        raise AIError(
+                            ErrorCode.STORAGE_COMMIT_UNKNOWN,
+                            safe_details={
+                                "phase": "local_checkpoint",
+                                "operation": label,
+                            },
+                        ) from error
+                    try:
+                        value = task.result()
+                    except BaseException as task_error:  # noqa: BLE001
+                        raise task_error from error
+                    return value, cancellation or error
+                if cancellation is None:
+                    cancellation = error
+                continue
+            return value, cancellation
 
     async def _commit_terminal_checkpoint_owned(
         self,
@@ -956,6 +968,7 @@ class LocalExecutionBackend:
         if self._tasks.get(execution_id) is not task:
             return
         self._tasks.pop(execution_id, None)
+        self._worker_cancel_requests.discard(execution_id)
         self._captured_usage.pop(execution_id, None)
         if self._approval_pause_segments.get(execution_id) is task:
             self._approval_pause_segments.pop(execution_id, None)
@@ -993,6 +1006,31 @@ class LocalExecutionBackend:
         )
         if live_broker is not None:
             live_broker.complete(execution_id)
+
+    def _request_worker_cancel(
+        self,
+        execution_id: str,
+        task: asyncio.Task[None],
+    ) -> None:
+        if task.done() or execution_id in self._worker_cancel_requests:
+            return
+        self._worker_cancel_requests.add(execution_id)
+        task.cancel()
+
+    async def _drain_worker_task(
+        self,
+        execution_id: str,
+        task: asyncio.Task[None],
+    ) -> None:
+        try:
+            await asyncio.shield(task)
+        except asyncio.CancelledError:
+            if not task.done():
+                raise
+        except BaseException:  # noqa: BLE001
+            pass
+        if self._tasks.get(execution_id) is task:
+            self._task_done(execution_id, task)
 
     def worker_failure(self, execution_id: str, *, tenant_id: str) -> AIError | None:
         if tenant_id != self._tenant_id:
@@ -1064,11 +1102,8 @@ class LocalExecutionBackend:
             }:
                 return CancelEffectOutcome.CONFIRMED
             return CancelEffectOutcome.UNKNOWN
-        task.cancel()
-        await asyncio.sleep(0)
-        if not task.done():
-            return CancelEffectOutcome.UNKNOWN
-        self._task_done(execution.execution_id, task)
+        self._request_worker_cancel(execution.execution_id, task)
+        await self._drain_worker_task(execution.execution_id, task)
         current = await self._execution.executions.get(
             execution.execution_id,
             tenant_id=execution.tenant_id,
@@ -3057,7 +3092,6 @@ class LocalExecutionBackend:
     async def close(self) -> None:
         self._accepting = False
         tasks = tuple(self._tasks.items())
-        cancel_tasks: list[asyncio.Task[None]] = []
         for execution_id, task in tasks:
             current = await self._execution.executions.get(
                 execution_id,
@@ -3069,63 +3103,62 @@ class LocalExecutionBackend:
                 ExecutionStatus.FAILED,
                 ExecutionStatus.CANCELLED,
             }:
-                task.cancel()
+                self._request_worker_cancel(execution_id, task)
             else:
                 _logger.info(
                     "close draining terminal execution worker: execution=%s status=%s",
                     execution_id,
                     current.status.value,
                 )
-            cancel_tasks.append(task)
-        if cancel_tasks:
-            await asyncio.sleep(0)
-        pending = tuple(task for task in cancel_tasks if not task.done())
-        background = self._executor.pending_background_tasks
-        dispatcher_background = (
-            ()
-            if self._subagent_dispatcher is None
-            else self._subagent_dispatcher.pending_background_tasks
-        )
-        checkpoint_background = tuple(
-            task for task in self._checkpoint_tasks if not task.done()
-        )
-        execution_task_map = self._execution_task_map()
-        execution_background = tuple(
-            task
-            for tasks_for_execution in execution_task_map.values()
-            for task in tasks_for_execution
-            if isinstance(task, asyncio.Task) and not task.done()
-        )
-        pending_background_by_identity = {
-            id(task): task
-            for task in (
-                *background,
-                *dispatcher_background,
-                *checkpoint_background,
-                *execution_background,
+
+        for execution_id, task in tasks:
+            await self._drain_worker_task(execution_id, task)
+
+        while True:
+            background = self._executor.pending_background_tasks
+            dispatcher_background = (
+                ()
+                if self._subagent_dispatcher is None
+                else self._subagent_dispatcher.pending_background_tasks
             )
-            if isinstance(task, asyncio.Task) and not task.done()
-        }
-        pending_background = tuple(pending_background_by_identity.values())
+            checkpoint_background = tuple(
+                task for task in self._checkpoint_tasks if not task.done()
+            )
+            execution_task_map = self._execution_task_map()
+            execution_background = tuple(
+                task
+                for tasks_for_execution in execution_task_map.values()
+                for task in tasks_for_execution
+                if isinstance(task, asyncio.Task) and not task.done()
+            )
+            pending_background_by_identity = {
+                id(task): task
+                for task in (
+                    *background,
+                    *dispatcher_background,
+                    *checkpoint_background,
+                    *execution_background,
+                )
+                if isinstance(task, asyncio.Task) and not task.done()
+            }
+            pending_background = tuple(pending_background_by_identity.values())
+            if not pending_background:
+                break
+            await asyncio.gather(
+                *(asyncio.shield(task) for task in pending_background),
+                return_exceptions=True,
+            )
+
         dispatcher_failure = (
             None
             if self._subagent_dispatcher is None
             else self._subagent_dispatcher.background_failure
         )
-        if pending or pending_background or dispatcher_failure is not None:
+        if dispatcher_failure is not None:
             raise AIError(
-                ErrorCode.STORAGE_RECOVERY_REQUIRED,
-                safe_details={
-                    "phase": "local_execution_close",
-                    "pending_workers": len(pending),
-                    "pending_background_tasks": len(pending_background),
-                    "pending_checkpoint_tasks": len(checkpoint_background),
-                    "pending_execution_tasks": len(execution_background),
-                    "background_failures": int(dispatcher_failure is not None),
-                },
+                dispatcher_failure.code,
+                safe_details=dict(dispatcher_failure.safe_details),
             )
-        for execution_id, task in tasks:
-            self._task_done(execution_id, task)
         self._tasks.clear()
         self._captured_usage.clear()
         self._terminal_events.clear()
@@ -3136,7 +3169,8 @@ class LocalExecutionBackend:
         self._segment_only_worker_exits.clear()
         self._repository_instruction_provenance.clear()
         self._checkpoint_tasks.clear()
-        execution_task_map.clear()
+        self._worker_cancel_requests.clear()
+        self._execution_task_map().clear()
 
     async def release_runtime_execution(
         self,
@@ -3164,6 +3198,7 @@ class LocalExecutionBackend:
             raise AIError(ErrorCode.STORAGE_CONFLICT)
         if task is not None:
             self._tasks.pop(execution_id, None)
+        self._worker_cancel_requests.discard(execution_id)
         self._terminal_events.pop(execution_id, None)
         self._worker_failures.pop(execution_id, None)
         self._captured_usage.pop(execution_id, None)

--- a/linktools-ai/src/linktools/ai/runtime/_local.py
+++ b/linktools-ai/src/linktools/ai/runtime/_local.py
@@ -3121,39 +3121,72 @@ class LocalExecutionBackend:
                 if self._subagent_dispatcher is None
                 else self._subagent_dispatcher.pending_background_tasks
             )
-            checkpoint_background = tuple(
-                task for task in self._checkpoint_tasks if not task.done()
-            )
-            execution_task_map = self._execution_task_map()
-            execution_background = tuple(
-                task
-                for tasks_for_execution in execution_task_map.values()
-                for task in tasks_for_execution
-                if isinstance(task, asyncio.Task) and not task.done()
-            )
-            pending_background_by_identity = {
+            owned_background_by_identity = {
                 id(task): task
-                for task in (
-                    *background,
-                    *dispatcher_background,
-                    *checkpoint_background,
-                    *execution_background,
-                )
+                for task in (*background, *dispatcher_background)
                 if isinstance(task, asyncio.Task) and not task.done()
             }
-            pending_background = tuple(pending_background_by_identity.values())
-            if not pending_background:
+            owned_background = tuple(owned_background_by_identity.values())
+            if not owned_background:
                 break
             await asyncio.gather(
-                *(asyncio.shield(task) for task in pending_background),
+                *(asyncio.shield(task) for task in owned_background),
                 return_exceptions=True,
             )
 
+        pending_workers = tuple(
+            task for task in self._tasks.values() if not task.done()
+        )
+        background = self._executor.pending_background_tasks
+        dispatcher_background = (
+            ()
+            if self._subagent_dispatcher is None
+            else self._subagent_dispatcher.pending_background_tasks
+        )
+        checkpoint_background = tuple(
+            task for task in self._checkpoint_tasks if not task.done()
+        )
+        execution_task_map = self._execution_task_map()
+        execution_background = tuple(
+            task
+            for tasks_for_execution in execution_task_map.values()
+            for task in tasks_for_execution
+            if isinstance(task, asyncio.Task) and not task.done()
+        )
+        pending_background_by_identity = {
+            id(task): task
+            for task in (
+                *background,
+                *dispatcher_background,
+                *checkpoint_background,
+                *execution_background,
+            )
+            if isinstance(task, asyncio.Task) and not task.done()
+        }
+        pending_background = tuple(pending_background_by_identity.values())
         dispatcher_failure = (
             None
             if self._subagent_dispatcher is None
             else self._subagent_dispatcher.background_failure
         )
+        if pending_workers or pending_background:
+            raise AIError(
+                ErrorCode.STORAGE_RECOVERY_REQUIRED,
+                safe_details={
+                    "phase": "local_execution_close",
+                    "pending_workers": len(pending_workers),
+                    "pending_background_tasks": len(pending_background),
+                    "pending_checkpoint_tasks": len(checkpoint_background),
+                    "pending_execution_tasks": len(execution_background),
+                    "background_failures": int(dispatcher_failure is not None),
+                },
+            )
+        if self._worker_failures:
+            worker_failure = self._worker_failures[sorted(self._worker_failures)[0]]
+            raise AIError(
+                worker_failure.code,
+                safe_details=dict(worker_failure.safe_details),
+            )
         if dispatcher_failure is not None:
             raise AIError(
                 dispatcher_failure.code,

--- a/linktools-ai/src/linktools/ai/runtime/_planner.py
+++ b/linktools-ai/src/linktools/ai/runtime/_planner.py
@@ -63,6 +63,7 @@ class RuntimeTaskNodeRunner:
         self._catalog = catalog
         self._compiler = compiler
         self._detached_tasks: set[asyncio.Task[object]] = set()
+        self._cancelled_tasks: set[asyncio.Task[object]] = set()
         self._background_failures: dict[tuple[str, str, str], AIError] = {}
         self._active_execution_ids: dict[tuple[str, str, str], str] = {}
         self._active_launch_tasks: dict[
@@ -72,6 +73,12 @@ class RuntimeTaskNodeRunner:
     @property
     def pending_background_tasks(self) -> tuple[asyncio.Task[object], ...]:
         return tuple(task for task in self._detached_tasks if not task.done())
+
+    @property
+    def pending_cancelled_tasks(self) -> tuple[asyncio.Task[object], ...]:
+        return tuple(
+            task for task in self._cancelled_task_set() if not task.done()
+        )
 
     @property
     def background_failure(self) -> "AIError | None":
@@ -275,7 +282,7 @@ class RuntimeTaskNodeRunner:
         except asyncio.CancelledError:
             if not wait_task.done():
                 wait_task.cancel()
-                self._detach(
+                self._detach_cancelled(
                     cast("asyncio.Task[object]", wait_task),
                     f"task execution wait cleanup graph={graph_id} task={node.node_id}",
                 )
@@ -492,6 +499,14 @@ class RuntimeTaskNodeRunner:
         self._background_failures[key] = failure
         return failure
 
+    def _cancelled_task_set(self) -> set[asyncio.Task[object]]:
+        try:
+            return self._cancelled_tasks
+        except AttributeError:
+            cancelled: set[asyncio.Task[object]] = set()
+            self._cancelled_tasks = cancelled
+            return cancelled
+
     def _detach(
         self,
         task: "asyncio.Task[object]",
@@ -509,6 +524,27 @@ class RuntimeTaskNodeRunner:
                 self._consume_done(done, label)
             finally:
                 self._detached_tasks.discard(done)
+
+        task.add_done_callback(consume)
+
+    def _detach_cancelled(
+        self,
+        task: "asyncio.Task[object]",
+        label: str,
+    ) -> None:
+        if task.done():
+            self._consume_done(task, label)
+            return
+        tasks = self._cancelled_task_set()
+        if task in tasks:
+            return
+        tasks.add(task)
+
+        def consume(done: "asyncio.Task[object]") -> None:
+            try:
+                self._consume_done(done, label)
+            finally:
+                tasks.discard(done)
 
         task.add_done_callback(consume)
 

--- a/linktools-ai/src/linktools/ai/task/_api.py
+++ b/linktools-ai/src/linktools/ai/task/_api.py
@@ -26,6 +26,7 @@ async def open_local_task_api(
         await service.recover_pending()
         yield service
     finally:
+        await service.drain_owned_finalizers()
         await service.preflight_close()
         await launcher.shutdown()
 

--- a/linktools-ai/src/linktools/ai/task/_local.py
+++ b/linktools-ai/src/linktools/ai/task/_local.py
@@ -271,6 +271,15 @@ class LocalTaskGraphLauncher:
                         cast("asyncio.Task[object]", run.task),
                         "task graph cancellation",
                     )
+                    if cleanup_error is None:
+                        cleanup_error = AIError(
+                            ErrorCode.STORAGE_RECOVERY_REQUIRED,
+                            safe_details={
+                                "phase": "task_graph_cancel_cleanup",
+                                "graph_id": graph_id,
+                                "pending_tasks": 1,
+                            },
+                        )
             self._remove_run(key, run)
         if cleanup_error is not None:
             if isinstance(cleanup_error, asyncio.CancelledError):
@@ -291,6 +300,20 @@ class LocalTaskGraphLauncher:
             self._close_run(run)
             if run.task is not None and not run.task.done():
                 run.task.cancel()
+            elif run.task is not None:
+                self._consume_done(run.task, "task graph shutdown")
+
+        runner_pending = (
+            self._runner.pending_background_tasks
+            if isinstance(self._runner, _BackgroundTaskOwner)
+            else ()
+        )
+        if (
+            any(run.task is not None and not run.task.done() for run in runs)
+            or any(not task.done() for task in self._detached_tasks)
+            or any(not task.done() for task in runner_pending)
+        ):
+            await asyncio.sleep(0)
 
         while True:
             runner_pending = (
@@ -310,6 +333,14 @@ class LocalTaskGraphLauncher:
             pending = tuple(pending_by_identity.values())
             if not pending:
                 break
+            if any(task.cancelling() for task in pending):
+                raise AIError(
+                    ErrorCode.STORAGE_RECOVERY_REQUIRED,
+                    safe_details={
+                        "phase": "task_graph_shutdown",
+                        "pending_tasks": len(pending),
+                    },
+                )
             await asyncio.gather(
                 *(asyncio.shield(task) for task in pending),
                 return_exceptions=True,

--- a/linktools-ai/src/linktools/ai/task/_local.py
+++ b/linktools-ai/src/linktools/ai/task/_local.py
@@ -291,41 +291,30 @@ class LocalTaskGraphLauncher:
             self._close_run(run)
             if run.task is not None and not run.task.done():
                 run.task.cancel()
-            elif run.task is not None:
-                self._consume_done(run.task, "task graph shutdown")
-        runner_pending = (
-            self._runner.pending_background_tasks
-            if isinstance(self._runner, _BackgroundTaskOwner)
-            else ()
-        )
-        if (
-            any(run.task is not None and not run.task.done() for run in runs)
-            or any(not task.done() for task in self._detached_tasks)
-            or any(not task.done() for task in runner_pending)
-        ):
-            await asyncio.sleep(0)
+
+        while True:
             runner_pending = (
                 self._runner.pending_background_tasks
                 if isinstance(self._runner, _BackgroundTaskOwner)
                 else ()
             )
-        pending = tuple(
-            task
-            for task in (
-                *(run.task for run in runs if run.task is not None),
-                *self._detached_tasks,
-                *runner_pending,
+            pending_by_identity = {
+                id(task): task
+                for task in (
+                    *(run.task for run in runs if run.task is not None),
+                    *self._detached_tasks,
+                    *runner_pending,
+                )
+                if isinstance(task, asyncio.Task) and not task.done()
+            }
+            pending = tuple(pending_by_identity.values())
+            if not pending:
+                break
+            await asyncio.gather(
+                *(asyncio.shield(task) for task in pending),
+                return_exceptions=True,
             )
-            if isinstance(task, asyncio.Task) and not task.done()
-        )
-        if pending:
-            raise AIError(
-                ErrorCode.STORAGE_RECOVERY_REQUIRED,
-                safe_details={
-                    "phase": "task_graph_shutdown",
-                    "pending_tasks": len(pending),
-                },
-            )
+
         runner_failure = (
             self._runner.background_failure
             if isinstance(self._runner, _BackgroundTaskFailureOwner)

--- a/linktools-ai/src/linktools/ai/task/_local.py
+++ b/linktools-ai/src/linktools/ai/task/_local.py
@@ -65,6 +65,12 @@ class _BackgroundTaskOwner(Protocol):
 
 
 @runtime_checkable
+class _CancelledTaskOwner(Protocol):
+    @property
+    def pending_cancelled_tasks(self) -> tuple[asyncio.Task[object], ...]: ...
+
+
+@runtime_checkable
 class _BackgroundTaskFailureOwner(Protocol):
     @property
     def background_failure(self) -> "AIError | None": ...
@@ -303,17 +309,41 @@ class LocalTaskGraphLauncher:
             elif run.task is not None:
                 self._consume_done(run.task, "task graph shutdown")
 
-        runner_pending = (
-            self._runner.pending_background_tasks
-            if isinstance(self._runner, _BackgroundTaskOwner)
+        runner_cancelled = (
+            self._runner.pending_cancelled_tasks
+            if isinstance(self._runner, _CancelledTaskOwner)
             else ()
         )
         if (
             any(run.task is not None and not run.task.done() for run in runs)
             or any(not task.done() for task in self._detached_tasks)
-            or any(not task.done() for task in runner_pending)
+            or any(not task.done() for task in runner_cancelled)
         ):
             await asyncio.sleep(0)
+
+        runner_cancelled = (
+            self._runner.pending_cancelled_tasks
+            if isinstance(self._runner, _CancelledTaskOwner)
+            else ()
+        )
+        cancelled_by_identity = {
+            id(task): task
+            for task in (
+                *(run.task for run in runs if run.task is not None),
+                *self._detached_tasks,
+                *runner_cancelled,
+            )
+            if isinstance(task, asyncio.Task) and not task.done()
+        }
+        cancelled_pending = tuple(cancelled_by_identity.values())
+        if cancelled_pending:
+            raise AIError(
+                ErrorCode.STORAGE_RECOVERY_REQUIRED,
+                safe_details={
+                    "phase": "task_graph_shutdown",
+                    "pending_tasks": len(cancelled_pending),
+                },
+            )
 
         while True:
             runner_pending = (
@@ -323,28 +353,47 @@ class LocalTaskGraphLauncher:
             )
             pending_by_identity = {
                 id(task): task
-                for task in (
-                    *(run.task for run in runs if run.task is not None),
-                    *self._detached_tasks,
-                    *runner_pending,
-                )
+                for task in runner_pending
                 if isinstance(task, asyncio.Task) and not task.done()
             }
             pending = tuple(pending_by_identity.values())
             if not pending:
                 break
-            if any(task.cancelling() for task in pending):
-                raise AIError(
-                    ErrorCode.STORAGE_RECOVERY_REQUIRED,
-                    safe_details={
-                        "phase": "task_graph_shutdown",
-                        "pending_tasks": len(pending),
-                    },
-                )
             await asyncio.gather(
                 *(asyncio.shield(task) for task in pending),
                 return_exceptions=True,
             )
+
+        runner_cancelled = (
+            self._runner.pending_cancelled_tasks
+            if isinstance(self._runner, _CancelledTaskOwner)
+            else ()
+        )
+        cancelled_pending = tuple(
+            task
+            for task in runner_cancelled
+            if isinstance(task, asyncio.Task) and not task.done()
+        )
+        if cancelled_pending:
+            await asyncio.sleep(0)
+            runner_cancelled = (
+                self._runner.pending_cancelled_tasks
+                if isinstance(self._runner, _CancelledTaskOwner)
+                else ()
+            )
+            cancelled_pending = tuple(
+                task
+                for task in runner_cancelled
+                if isinstance(task, asyncio.Task) and not task.done()
+            )
+            if cancelled_pending:
+                raise AIError(
+                    ErrorCode.STORAGE_RECOVERY_REQUIRED,
+                    safe_details={
+                        "phase": "task_graph_shutdown",
+                        "pending_tasks": len(cancelled_pending),
+                    },
+                )
 
         runner_failure = (
             self._runner.background_failure

--- a/linktools-ai/src/linktools/ai/task/_service_impl.py
+++ b/linktools-ai/src/linktools/ai/task/_service_impl.py
@@ -173,6 +173,7 @@ class DefaultTaskService(TaskApi):
         self._handoff_states: dict[tuple[str, str], _TaskHandoffState] = {}
         self._handoff_condition = asyncio.Condition()
         self._detached_finalizers: set[asyncio.Task[object]] = set()
+        self._detached_finalizer_failure: AIError | None = None
 
     async def run_graph(self, request: TaskGraphRequest) -> TaskGraphResult:
         return await self._run_graph(request, release_terminal=True)
@@ -943,26 +944,35 @@ class DefaultTaskService(TaskApi):
                     graph_id,
                     type(error).__name__,
                 )
+                if getattr(self, "_detached_finalizer_failure", None) is None:
+                    details = dict(error.safe_details) if isinstance(error, AIError) else {}
+                    details.setdefault("phase", "task_service_finalizer")
+                    details.setdefault("graph_id", graph_id)
+                    self._detached_finalizer_failure = AIError(
+                        ErrorCode.STORAGE_RECOVERY_REQUIRED,
+                        safe_details=details,
+                    )
             finally:
                 self._detached_finalizers.discard(done)
 
         task.add_done_callback(consume)
 
     async def preflight_close(self) -> None:
-        pending = tuple(
-            task for task in self._detached_finalizers if not task.done()
-        )
-        if pending:
-            _logger.warning(
-                "task service close blocked by detached finalizers: tasks=%s",
-                len(pending),
+        while True:
+            pending = tuple(
+                task for task in self._detached_finalizers if not task.done()
             )
+            if not pending:
+                break
+            await asyncio.gather(
+                *(asyncio.shield(task) for task in pending),
+                return_exceptions=True,
+            )
+        failure = getattr(self, "_detached_finalizer_failure", None)
+        if failure is not None:
             raise AIError(
-                ErrorCode.STORAGE_RECOVERY_REQUIRED,
-                safe_details={
-                    "phase": "task_service_preflight_close",
-                    "pending_finalizers": len(pending),
-                },
+                failure.code,
+                safe_details=dict(failure.safe_details),
             )
 
 

--- a/linktools-ai/src/linktools/ai/task/_service_impl.py
+++ b/linktools-ai/src/linktools/ai/task/_service_impl.py
@@ -957,16 +957,34 @@ class DefaultTaskService(TaskApi):
 
         task.add_done_callback(consume)
 
-    async def preflight_close(self) -> None:
+    async def drain_owned_finalizers(self) -> None:
         while True:
             pending = tuple(
                 task for task in self._detached_finalizers if not task.done()
             )
             if not pending:
-                break
+                await asyncio.sleep(0)
+                return
             await asyncio.gather(
                 *(asyncio.shield(task) for task in pending),
                 return_exceptions=True,
+            )
+
+    async def preflight_close(self) -> None:
+        pending = tuple(
+            task for task in self._detached_finalizers if not task.done()
+        )
+        if pending:
+            _logger.warning(
+                "task service close blocked by detached finalizers: tasks=%s",
+                len(pending),
+            )
+            raise AIError(
+                ErrorCode.STORAGE_RECOVERY_REQUIRED,
+                safe_details={
+                    "phase": "task_service_preflight_close",
+                    "pending_finalizers": len(pending),
+                },
             )
         failure = self._detached_finalizer_failure
         if failure is not None:

--- a/linktools-ai/src/linktools/ai/task/_service_impl.py
+++ b/linktools-ai/src/linktools/ai/task/_service_impl.py
@@ -944,7 +944,7 @@ class DefaultTaskService(TaskApi):
                     graph_id,
                     type(error).__name__,
                 )
-                if getattr(self, "_detached_finalizer_failure", None) is None:
+                if self._detached_finalizer_failure is None:
                     details = dict(error.safe_details) if isinstance(error, AIError) else {}
                     details.setdefault("phase", "task_service_finalizer")
                     details.setdefault("graph_id", graph_id)
@@ -968,7 +968,7 @@ class DefaultTaskService(TaskApi):
                 *(asyncio.shield(task) for task in pending),
                 return_exceptions=True,
             )
-        failure = getattr(self, "_detached_finalizer_failure", None)
+        failure = self._detached_finalizer_failure
         if failure is not None:
             raise AIError(
                 failure.code,

--- a/tests/ai/test_cancellation_close_failures.py
+++ b/tests/ai/test_cancellation_close_failures.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Regression coverage for cancellation close failure propagation."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from linktools.ai.errors import AIError, ErrorCode
+from linktools.ai.runtime._local import LocalExecutionBackend, _WorkerFailure
+
+
+@pytest.mark.asyncio
+async def test_local_execution_close_surfaces_recorded_worker_failure() -> None:
+    backend = object.__new__(LocalExecutionBackend)
+    backend._accepting = True
+    backend._tasks = {}
+    backend._executor = SimpleNamespace(pending_background_tasks=())
+    backend._subagent_dispatcher = None
+    backend._checkpoint_tasks = set()
+    backend._execution_durable_tasks = {}
+    backend._worker_failures = {
+        "execution": _WorkerFailure(
+            ErrorCode.STORAGE_INTEGRITY_ERROR,
+            {"phase": "local_execution_worker", "execution_id": "execution"},
+        )
+    }
+
+    with pytest.raises(AIError) as error:
+        await backend.close()
+
+    assert error.value.code is ErrorCode.STORAGE_INTEGRITY_ERROR
+    assert error.value.safe_details == {
+        "phase": "local_execution_worker",
+        "execution_id": "execution",
+    }
+    assert backend._worker_failures

--- a/tests/ai/test_cancellation_quiescence.py
+++ b/tests/ai/test_cancellation_quiescence.py
@@ -9,7 +9,10 @@ import pytest
 
 from linktools.ai.core import ExecutionStatus
 from linktools.ai.errors import AIError, ErrorCode
-from linktools.ai.runtime._execution import CancelEffectOutcome
+from linktools.ai.runtime._execution import (
+    CancelEffectOutcome,
+    DefaultExecutionService,
+)
 from linktools.ai.runtime._local import LocalExecutionBackend
 from linktools.ai.task._local import LocalTaskGraphLauncher
 from linktools.ai.task._service_impl import DefaultTaskService
@@ -56,6 +59,15 @@ def _local_backend(current: object) -> LocalExecutionBackend:
     backend._subagent_dispatcher = None
     backend._accepting = True
     return backend
+
+
+def _execution_service() -> DefaultExecutionService:
+    service = object.__new__(DefaultExecutionService)
+    service._handoff_states = {}
+    service._handoff_condition = asyncio.Condition()
+    service._detached_cancel_finalizers = set()
+    service._detached_cancel_failure = None
+    return service
 
 
 @pytest.mark.asyncio
@@ -227,6 +239,54 @@ async def test_local_close_drains_owned_worker_and_finalizer_before_guarding_bac
     release_finalizer.set()
     await close_task
     assert backend._tasks == {}
+
+
+@pytest.mark.asyncio
+async def test_execution_service_caller_cancel_detaches_owned_finalizer_until_preflight() -> None:
+    service = _execution_service()
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def finalizer(execution_id: str, request: object) -> object:
+        del execution_id, request
+        started.set()
+        await release.wait()
+        return SimpleNamespace(cancelled=True)
+
+    service._cancel_finalizer_with_handoff = finalizer
+    request = SimpleNamespace(principal=SimpleNamespace(tenant_id="tenant"))
+    caller = asyncio.create_task(service.cancel("execution", request))
+    await started.wait()
+    caller.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await caller
+
+    preflight = asyncio.create_task(service.preflight_close())
+    await asyncio.sleep(0)
+    assert not preflight.done()
+
+    release.set()
+    await preflight
+    assert service._detached_cancel_finalizers == set()
+
+
+@pytest.mark.asyncio
+async def test_execution_service_preflight_surfaces_detached_cancel_failure() -> None:
+    service = _execution_service()
+
+    async def fail() -> object:
+        raise RuntimeError("cancel finalizer failed")
+
+    task = asyncio.create_task(fail())
+    service._detach_cancel_finalizer(task, "execution")
+    await asyncio.gather(task, return_exceptions=True)
+    await asyncio.sleep(0)
+
+    with pytest.raises(AIError) as error:
+        await service.preflight_close()
+    assert error.value.code is ErrorCode.STORAGE_RECOVERY_REQUIRED
+    assert error.value.safe_details["phase"] == "execution_cancel_finalizer"
 
 
 @pytest.mark.asyncio

--- a/tests/ai/test_cancellation_quiescence.py
+++ b/tests/ai/test_cancellation_quiescence.py
@@ -290,7 +290,7 @@ async def test_execution_service_preflight_surfaces_detached_cancel_failure() ->
 
 
 @pytest.mark.asyncio
-async def test_task_service_preflight_drains_owned_finalizers() -> None:
+async def test_task_service_drains_owned_finalizers_before_preflight() -> None:
     service = object.__new__(DefaultTaskService)
     release = asyncio.Event()
 
@@ -301,12 +301,13 @@ async def test_task_service_preflight_drains_owned_finalizers() -> None:
     service._detached_finalizers = {task}
     service._detached_finalizer_failure = None
 
-    preflight = asyncio.create_task(service.preflight_close())
+    drain = asyncio.create_task(service.drain_owned_finalizers())
     await asyncio.sleep(0)
-    assert not preflight.done()
+    assert not drain.done()
 
     release.set()
-    await preflight
+    await drain
+    await service.preflight_close()
 
 
 @pytest.mark.asyncio
@@ -363,24 +364,47 @@ async def test_task_launcher_shutdown_drains_runner_owned_cancellation_cleanup()
 
 
 @pytest.mark.asyncio
-async def test_task_launcher_shutdown_drains_detached_owned_cleanup() -> None:
+async def test_task_launcher_shutdown_rejects_runner_cancelled_leftover() -> None:
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def cleanup() -> None:
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            await release.wait()
+
+    task = asyncio.create_task(cleanup())
+    await started.wait()
+    task.cancel()
+    await asyncio.sleep(0)
+
+    class Runner:
+        @property
+        def pending_background_tasks(self) -> tuple[asyncio.Task[object], ...]:
+            return ()
+
+        @property
+        def pending_cancelled_tasks(self) -> tuple[asyncio.Task[object], ...]:
+            return () if task.done() else (task,)
+
+        @property
+        def background_failure(self) -> None:
+            return None
+
     launcher = object.__new__(LocalTaskGraphLauncher)
     launcher._accepting = True
     launcher._graphs = {}
     launcher._wait_observations = {}
     launcher._detached_tasks = set()
-    launcher._runner = SimpleNamespace()
-    release = asyncio.Event()
+    launcher._runner = Runner()
 
-    async def cleanup() -> None:
-        await release.wait()
-
-    task = asyncio.create_task(cleanup())
-    launcher._detach(task, "owned cleanup")
-
-    shutdown = asyncio.create_task(launcher.shutdown())
-    await asyncio.sleep(0)
-    assert not shutdown.done()
-
-    release.set()
-    await shutdown
+    try:
+        with pytest.raises(AIError) as error:
+            await launcher.shutdown()
+        assert error.value.code is ErrorCode.STORAGE_RECOVERY_REQUIRED
+        assert error.value.safe_details["phase"] == "task_graph_shutdown"
+    finally:
+        release.set()
+        await task

--- a/tests/ai/test_cancellation_quiescence.py
+++ b/tests/ai/test_cancellation_quiescence.py
@@ -370,21 +370,13 @@ async def test_task_launcher_shutdown_drains_detached_owned_cleanup() -> None:
     launcher._wait_observations = {}
     launcher._detached_tasks = set()
     launcher._runner = SimpleNamespace()
-    cancelled = asyncio.Event()
     release = asyncio.Event()
 
     async def cleanup() -> None:
-        try:
-            await asyncio.Event().wait()
-        except asyncio.CancelledError:
-            cancelled.set()
-            await release.wait()
-            raise
+        await release.wait()
 
     task = asyncio.create_task(cleanup())
     launcher._detach(task, "owned cleanup")
-    task.cancel()
-    await cancelled.wait()
 
     shutdown = asyncio.create_task(launcher.shutdown())
     await asyncio.sleep(0)

--- a/tests/ai/test_cancellation_quiescence.py
+++ b/tests/ai/test_cancellation_quiescence.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Regression coverage for Runtime-owned cancellation quiescence."""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from linktools.ai.core import ExecutionStatus
+from linktools.ai.errors import AIError, ErrorCode
+from linktools.ai.runtime._execution import CancelEffectOutcome
+from linktools.ai.runtime._local import LocalExecutionBackend
+from linktools.ai.task._local import LocalTaskGraphLauncher
+from linktools.ai.task._service_impl import DefaultTaskService
+
+
+class _ExecutionRecords:
+    def __init__(self, current: object) -> None:
+        self.current = current
+
+    async def get(self, execution_id: str, *, tenant_id: str) -> object:
+        del execution_id, tenant_id
+        return self.current
+
+
+class _LiveBroker:
+    def complete(self, execution_id: str) -> None:
+        del execution_id
+
+
+class _Executor:
+    @property
+    def pending_background_tasks(self) -> tuple[asyncio.Task[object], ...]:
+        return ()
+
+
+def _local_backend(current: object) -> LocalExecutionBackend:
+    backend = object.__new__(LocalExecutionBackend)
+    backend._execution = SimpleNamespace(executions=_ExecutionRecords(current))
+    backend._tenant_id = "tenant"
+    backend._tasks = {}
+    backend._worker_failures = {}
+    backend._captured_usage = {}
+    backend._terminal_events = {}
+    backend._pending_audit_events = {}
+    backend._pending_audit_locks = {}
+    backend._approval_pause_segments = {}
+    backend._segment_only_worker_exits = set()
+    backend._repository_instruction_provenance = {}
+    backend._checkpoint_tasks = set()
+    backend._execution_durable_tasks = {}
+    backend._live_broker = _LiveBroker()
+    backend._executor = _Executor()
+    backend._subagent_dispatcher = None
+    backend._accepting = True
+    return backend
+
+
+@pytest.mark.asyncio
+async def test_local_checkpoint_wait_settles_owned_commit_before_restoring_cancellation() -> None:
+    backend = _local_backend(SimpleNamespace())
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def commit() -> str:
+        started.set()
+        await release.wait()
+        return "committed"
+
+    owned = asyncio.create_task(commit())
+    caller = asyncio.create_task(
+        backend._await_checkpoint_task(
+            owned,
+            label="test",
+            execution_id="execution",
+        )
+    )
+    await started.wait()
+    caller.cancel()
+    await asyncio.sleep(0)
+
+    assert not caller.done()
+    assert not owned.done()
+
+    release.set()
+    value, cancellation = await caller
+    assert value == "committed"
+    assert isinstance(cancellation, asyncio.CancelledError)
+    assert backend._checkpoint_tasks == set()
+    assert backend._execution_durable_tasks.get("execution", set()) == set()
+
+
+@pytest.mark.asyncio
+async def test_local_cancel_waits_for_owned_worker_durable_settlement() -> None:
+    current = SimpleNamespace(
+        execution_id="execution",
+        tenant_id="tenant",
+        status=ExecutionStatus.CANCELLING,
+    )
+    backend = _local_backend(current)
+    cancelled = asyncio.Event()
+    release = asyncio.Event()
+
+    async def worker() -> None:
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cancelled.set()
+            await release.wait()
+            backend._execution.executions.current = SimpleNamespace(
+                execution_id="execution",
+                tenant_id="tenant",
+                status=ExecutionStatus.CANCELLED,
+            )
+            raise
+
+    worker_task = asyncio.create_task(worker())
+    backend._tasks["execution"] = worker_task
+    cancel_task = asyncio.create_task(backend.cancel(current))
+
+    await cancelled.wait()
+    await asyncio.sleep(0)
+    assert not cancel_task.done()
+
+    release.set()
+    assert await cancel_task is CancelEffectOutcome.CONFIRMED
+    assert backend._tasks == {}
+    assert backend._execution.executions.current.status is ExecutionStatus.CANCELLED
+
+
+@pytest.mark.asyncio
+async def test_local_cancel_does_not_repeat_cancel_during_owned_cleanup() -> None:
+    current = SimpleNamespace(
+        execution_id="execution",
+        tenant_id="tenant",
+        status=ExecutionStatus.CANCELLING,
+    )
+    backend = _local_backend(current)
+    first_cancel = asyncio.Event()
+    release = asyncio.Event()
+    cancellation_count = 0
+
+    async def worker() -> None:
+        nonlocal cancellation_count
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cancellation_count += 1
+            first_cancel.set()
+            try:
+                await release.wait()
+            except asyncio.CancelledError:
+                cancellation_count += 1
+                raise
+            backend._execution.executions.current = SimpleNamespace(
+                execution_id="execution",
+                tenant_id="tenant",
+                status=ExecutionStatus.CANCELLED,
+            )
+            raise
+
+    worker_task = asyncio.create_task(worker())
+    worker_task.cancel()
+    backend._tasks["execution"] = worker_task
+    await first_cancel.wait()
+
+    cancel_task = asyncio.create_task(backend.cancel(current))
+    await asyncio.sleep(0)
+    assert not cancel_task.done()
+    assert cancellation_count == 1
+
+    release.set()
+    assert await cancel_task is CancelEffectOutcome.CONFIRMED
+    assert cancellation_count == 1
+
+
+@pytest.mark.asyncio
+async def test_local_close_drains_owned_worker_and_finalizer_before_guarding_background_work() -> None:
+    current = SimpleNamespace(
+        execution_id="execution",
+        tenant_id="tenant",
+        status=ExecutionStatus.STARTED,
+    )
+    backend = _local_backend(current)
+    worker_cancelled = asyncio.Event()
+    release_worker = asyncio.Event()
+    finalizer_started = asyncio.Event()
+    release_finalizer = asyncio.Event()
+
+    async def worker() -> None:
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            worker_cancelled.set()
+            await release_worker.wait()
+            raise
+
+    async def finalizer() -> None:
+        finalizer_started.set()
+        await release_finalizer.wait()
+
+    worker_task = asyncio.create_task(worker())
+    backend._tasks["execution"] = worker_task
+    finalizer_task = asyncio.create_task(finalizer())
+
+    class Executor:
+        @property
+        def pending_background_tasks(self) -> tuple[asyncio.Task[object], ...]:
+            return () if finalizer_task.done() else (finalizer_task,)
+
+    backend._executor = Executor()
+    close_task = asyncio.create_task(backend.close())
+
+    await worker_cancelled.wait()
+    await finalizer_started.wait()
+    await asyncio.sleep(0)
+    assert not close_task.done()
+
+    release_worker.set()
+    await asyncio.sleep(0)
+    assert not close_task.done()
+
+    release_finalizer.set()
+    await close_task
+    assert backend._tasks == {}
+
+
+@pytest.mark.asyncio
+async def test_task_service_preflight_drains_owned_finalizers() -> None:
+    service = object.__new__(DefaultTaskService)
+    release = asyncio.Event()
+
+    async def finalizer() -> None:
+        await release.wait()
+
+    task = asyncio.create_task(finalizer())
+    service._detached_finalizers = {task}
+    service._detached_finalizer_failure = None
+
+    preflight = asyncio.create_task(service.preflight_close())
+    await asyncio.sleep(0)
+    assert not preflight.done()
+
+    release.set()
+    await preflight
+
+
+@pytest.mark.asyncio
+async def test_task_service_preflight_surfaces_detached_finalizer_failure() -> None:
+    service = object.__new__(DefaultTaskService)
+    service._detached_finalizers = set()
+    service._detached_finalizer_failure = None
+
+    async def fail() -> None:
+        raise RuntimeError("finalizer failed")
+
+    task = asyncio.create_task(fail())
+    service._detach_finalizer(task, "graph")
+    await asyncio.gather(task, return_exceptions=True)
+    await asyncio.sleep(0)
+
+    with pytest.raises(AIError) as error:
+        await service.preflight_close()
+    assert error.value.code is ErrorCode.STORAGE_RECOVERY_REQUIRED
+    assert error.value.safe_details["phase"] == "task_service_finalizer"
+
+
+@pytest.mark.asyncio
+async def test_task_launcher_shutdown_drains_runner_owned_cancellation_cleanup() -> None:
+    release = asyncio.Event()
+
+    async def cleanup() -> None:
+        await release.wait()
+
+    cleanup_task = asyncio.create_task(cleanup())
+
+    class Runner:
+        @property
+        def pending_background_tasks(self) -> tuple[asyncio.Task[object], ...]:
+            return () if cleanup_task.done() else (cleanup_task,)
+
+        @property
+        def background_failure(self) -> None:
+            return None
+
+    launcher = object.__new__(LocalTaskGraphLauncher)
+    launcher._accepting = True
+    launcher._graphs = {}
+    launcher._wait_observations = {}
+    launcher._detached_tasks = set()
+    launcher._runner = Runner()
+
+    shutdown = asyncio.create_task(launcher.shutdown())
+    await asyncio.sleep(0)
+    assert not shutdown.done()
+
+    release.set()
+    await shutdown
+
+
+@pytest.mark.asyncio
+async def test_task_launcher_shutdown_still_rejects_unowned_stuck_cleanup() -> None:
+    launcher = object.__new__(LocalTaskGraphLauncher)
+    launcher._accepting = True
+    launcher._graphs = {}
+    launcher._wait_observations = {}
+    launcher._detached_tasks = set()
+    launcher._runner = SimpleNamespace()
+    release = asyncio.Event()
+
+    async def cleanup() -> None:
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            await release.wait()
+
+    task = asyncio.create_task(cleanup())
+    await asyncio.sleep(0)
+    task.cancel()
+    launcher._detach(task, "unowned cleanup")
+
+    try:
+        with pytest.raises(AIError) as error:
+            await launcher.shutdown()
+        assert error.value.code is ErrorCode.STORAGE_RECOVERY_REQUIRED
+        assert error.value.safe_details["phase"] == "task_graph_shutdown"
+    finally:
+        release.set()
+        await task

--- a/tests/ai/test_cancellation_quiescence.py
+++ b/tests/ai/test_cancellation_quiescence.py
@@ -50,6 +50,7 @@ def _local_backend(current: object) -> LocalExecutionBackend:
     backend._repository_instruction_provenance = {}
     backend._checkpoint_tasks = set()
     backend._execution_durable_tasks = {}
+    backend._worker_cancel_requests = set()
     backend._live_broker = _LiveBroker()
     backend._executor = _Executor()
     backend._subagent_dispatcher = None
@@ -161,17 +162,19 @@ async def test_local_cancel_does_not_repeat_cancel_during_owned_cleanup() -> Non
             raise
 
     worker_task = asyncio.create_task(worker())
-    worker_task.cancel()
     backend._tasks["execution"] = worker_task
+    first = asyncio.create_task(backend.cancel(current))
     await first_cancel.wait()
 
-    cancel_task = asyncio.create_task(backend.cancel(current))
+    second = asyncio.create_task(backend.cancel(current))
     await asyncio.sleep(0)
-    assert not cancel_task.done()
+    assert not first.done()
+    assert not second.done()
     assert cancellation_count == 1
 
     release.set()
-    assert await cancel_task is CancelEffectOutcome.CONFIRMED
+    assert await first is CancelEffectOutcome.CONFIRMED
+    assert await second is CancelEffectOutcome.CONFIRMED
     assert cancellation_count == 1
 
 
@@ -300,31 +303,32 @@ async def test_task_launcher_shutdown_drains_runner_owned_cancellation_cleanup()
 
 
 @pytest.mark.asyncio
-async def test_task_launcher_shutdown_still_rejects_unowned_stuck_cleanup() -> None:
+async def test_task_launcher_shutdown_drains_detached_owned_cleanup() -> None:
     launcher = object.__new__(LocalTaskGraphLauncher)
     launcher._accepting = True
     launcher._graphs = {}
     launcher._wait_observations = {}
     launcher._detached_tasks = set()
     launcher._runner = SimpleNamespace()
+    cancelled = asyncio.Event()
     release = asyncio.Event()
 
     async def cleanup() -> None:
         try:
             await asyncio.Event().wait()
         except asyncio.CancelledError:
+            cancelled.set()
             await release.wait()
+            raise
 
     task = asyncio.create_task(cleanup())
-    await asyncio.sleep(0)
+    launcher._detach(task, "owned cleanup")
     task.cancel()
-    launcher._detach(task, "unowned cleanup")
+    await cancelled.wait()
 
-    try:
-        with pytest.raises(AIError) as error:
-            await launcher.shutdown()
-        assert error.value.code is ErrorCode.STORAGE_RECOVERY_REQUIRED
-        assert error.value.safe_details["phase"] == "task_graph_shutdown"
-    finally:
-        release.set()
-        await task
+    shutdown = asyncio.create_task(launcher.shutdown())
+    await asyncio.sleep(0)
+    assert not shutdown.done()
+
+    release.set()
+    await shutdown

--- a/tests/ai/test_durable_contract_repairs.py
+++ b/tests/ai/test_durable_contract_repairs.py
@@ -377,6 +377,7 @@ async def test_local_execution_close_rejects_pending_command_owned_work() -> Non
     backend._approval_pause_segments = {}
     backend._segment_only_worker_exits = set()
     backend._repository_instruction_provenance = {}
+    backend._worker_cancel_requests = set()
     release = asyncio.Event()
     task = asyncio.create_task(release.wait())
     backend._checkpoint_tasks = {task}
@@ -409,6 +410,7 @@ async def test_runtime_release_waits_for_execution_scoped_durable_task() -> None
     backend._approval_pause_segments = {}
     backend._segment_only_worker_exits = set()
     backend._repository_instruction_provenance = {}
+    backend._worker_cancel_requests = set()
     release = asyncio.Event()
     task = asyncio.create_task(release.wait())
     backend._execution_durable_tasks = {"execution": {task}}
@@ -653,6 +655,9 @@ async def test_standalone_task_api_preflights_before_launcher_shutdown(
         def __init__(self, persistence: object, authorization: object, launcher: object) -> None:
             del persistence, authorization
             self.launcher = launcher
+
+        async def drain_owned_finalizers(self) -> None:
+            return None
 
         async def preflight_close(self) -> None:
             raise AIError(ErrorCode.STORAGE_RECOVERY_REQUIRED)

--- a/tests/ai/test_history_projection_conformance.py
+++ b/tests/ai/test_history_projection_conformance.py
@@ -439,9 +439,8 @@ async def test_terminal_commit_cancellation_still_finalizes_after_durable_commit
     )
     await started.wait()
     task.cancel()
-    with pytest.raises(AIError) as error:
+    with pytest.raises(asyncio.CancelledError):
         await task
-    assert error.value.code is ErrorCode.STORAGE_COMMIT_UNKNOWN
     await lifecycle.finalized.wait()
     await asyncio.sleep(0)
     assert not backend._checkpoint_tasks

--- a/tests/ai/test_runtime_stream_order.py
+++ b/tests/ai/test_runtime_stream_order.py
@@ -365,13 +365,14 @@ async def test_cancel_local_bookkeeping_survives_caller_cancellation() -> None:
     )
     await commands.started.wait()
     task.cancel()
-    with pytest.raises(AIError) as raised:
-        await task
-    assert raised.value.code is ErrorCode.STORAGE_COMMIT_UNKNOWN
+    await asyncio.sleep(0)
+    assert not task.done()
     owners = tuple(backend._checkpoint_tasks)
     assert len(owners) == 1
     assert "execution" in backend._pending_audit_events
     commands.release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
     await asyncio.gather(*owners)
     assert not backend._checkpoint_tasks
     assert "execution" not in backend._pending_audit_events
@@ -448,13 +449,14 @@ async def test_terminal_local_bookkeeping_survives_caller_cancellation() -> None
     task = asyncio.create_task(backend.commit_terminal_checkpoint(commit, session_id=None))
     await commands.started.wait()
     task.cancel()
-    with pytest.raises(AIError) as raised:
-        await task
-    assert raised.value.code is ErrorCode.STORAGE_COMMIT_UNKNOWN
+    await asyncio.sleep(0)
+    assert not task.done()
     owners = tuple(backend._checkpoint_tasks)
     assert len(owners) == 1
     assert "execution" in backend._pending_audit_events
     commands.release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
     await asyncio.gather(*owners)
     assert not backend._checkpoint_tasks
     assert "execution" not in backend._pending_audit_events


### PR DESCRIPTION
## Summary

Fix false `STORAGE_RECOVERY_REQUIRED` outcomes during normal cancellation and Runtime shutdown by waiting for Runtime-owned durable cleanup to reach quiescence before declaring an unknown effect.

Current scope includes:
- durable checkpoint settlement under caller cancellation
- LocalExecutionBackend worker cancellation and close draining
- TaskService detached finalizer draining/failure propagation
- TaskGraph launcher shutdown draining owned cleanup
- regression coverage for cancellation quiescence

This PR is still under active review; additional service-level cancellation ownership fixes may be pushed before marking it ready.

## Invariants

- Caller cancellation does not determine durable truth.
- True external-effect / lost-ownership unknown outcomes remain fail-closed.
- No pessimistic DB locking.
- No CI workflow changes.