### PR TITLE
fix(ai): preserve tool and execution error semantics

### DIFF
--- a/linktools-ai/src/linktools/ai/runtime/_capabilities.py
+++ b/linktools-ai/src/linktools/ai/runtime/_capabilities.py
@@ -507,7 +507,7 @@ class _RuntimeStepPersistence(StepPersistence[None]):
             if state.policy.replay_safe:
                 state.preserve_started = True
                 raise AIError(
-                    ErrorCode.STORAGE_RECOVERY_REQUIRED,
+                    ErrorCode.TOOL_EFFECT_UNKNOWN,
                     safe_details={"phase": "tool_effect_replay"},
                 ) from error
             await self._mark_unknown(state, error)
@@ -590,7 +590,7 @@ class _RuntimeStepPersistence(StepPersistence[None]):
                 if state.policy.replay_safe:
                     state.preserve_started = True
                     raise AIError(
-                        ErrorCode.STORAGE_RECOVERY_REQUIRED,
+                        ErrorCode.TOOL_EFFECT_UNKNOWN,
                         safe_details={"phase": "tool_effect_replay"},
                     ) from error
                 await self._mark_unknown(state, error)

--- a/linktools-ai/src/linktools/ai/runtime/_capabilities.py
+++ b/linktools-ai/src/linktools/ai/runtime/_capabilities.py
@@ -446,7 +446,12 @@ class _RuntimeStepPersistence(StepPersistence[None]):
             ToolFailed,
             ToolFailedError,
         ) as error:
-            if state.handler_entered and not state.policy.effect_free and not state.policy.replay_safe:
+            if (
+                isinstance(error, ValidationError)
+                and state.handler_entered
+                and not state.policy.effect_free
+                and not state.policy.replay_safe
+            ):
                 await self._mark_unknown(state, error)
                 raise AIError(ErrorCode.TOOL_EFFECT_UNKNOWN) from error
             try:
@@ -565,7 +570,12 @@ class _RuntimeStepPersistence(StepPersistence[None]):
                 error,
                 (ValidationError, ModelRetry, ToolRetryError, ToolFailed, ToolFailedError),
             ):
-                if state.handler_entered and not state.policy.effect_free and not state.policy.replay_safe:
+                if (
+                    isinstance(error, ValidationError)
+                    and state.handler_entered
+                    and not state.policy.effect_free
+                    and not state.policy.replay_safe
+                ):
                     await self._mark_unknown(state, error)
                     raise AIError(ErrorCode.TOOL_EFFECT_UNKNOWN) from error
                 return await self._fail_known_effect(

--- a/linktools-ai/src/linktools/ai/runtime/_planner.py
+++ b/linktools-ai/src/linktools/ai/runtime/_planner.py
@@ -233,7 +233,7 @@ class _AgentTaskNodeHandler:
             if launch_task.done() and self._active_launch_tasks.get(key) is launch_task:
                 self._active_launch_tasks.pop(key, None)
         if not handle.execution_id:
-            raise AIError(ErrorCode.STORAGE_RECOVERY_REQUIRED)
+            raise AIError(ErrorCode.EXECUTION_START_UNKNOWN)
         await self._bind_execution(
             control,
             handle.execution_id,
@@ -326,7 +326,7 @@ class _AgentTaskNodeHandler:
             if not handle.execution_id:
                 raise self._record_background_failure(
                     key,
-                    AIError(ErrorCode.STORAGE_RECOVERY_REQUIRED),
+                    AIError(ErrorCode.EXECUTION_START_UNKNOWN),
                     phase="task_execution_resolve_cancel",
                 )
             execution_id = handle.execution_id
@@ -466,7 +466,7 @@ class _AgentTaskNodeHandler:
         try:
             handle = await launch_task
             if not handle.execution_id:
-                raise AIError(ErrorCode.STORAGE_RECOVERY_REQUIRED)
+                raise AIError(ErrorCode.EXECUTION_START_UNKNOWN)
             await control.bind_execution(handle.execution_id)
         except asyncio.CancelledError:
             raise
@@ -503,7 +503,8 @@ class _AgentTaskNodeHandler:
         details.setdefault("phase", phase)
         details.setdefault("graph_id", key[1])
         details.setdefault("node_id", key[2])
-        failure = AIError(ErrorCode.STORAGE_RECOVERY_REQUIRED, safe_details=details)
+        code = error.code if isinstance(error, AIError) else ErrorCode.INTERNAL_ERROR
+        failure = AIError(code, safe_details=details)
         self._background_failures[key] = failure
         return failure
 

--- a/linktools-ai/src/linktools/ai/task/_local.py
+++ b/linktools-ai/src/linktools/ai/task/_local.py
@@ -660,7 +660,7 @@ class LocalTaskGraphLauncher:
                 if isinstance(heartbeat_error, AIError):
                     if heartbeat_error.code in _RECOVERY_UNKNOWN_CODES:
                         await self._defer_recovery(
-                            run, node, cause_code=heartbeat_error.code
+                            run, node, cause=heartbeat_error
                         )
                         return
                     if heartbeat_error.code in {
@@ -677,7 +677,7 @@ class LocalTaskGraphLauncher:
             except BaseException as error:  # noqa: BLE001
                 await _stop_heartbeat(heartbeat_stop, heartbeat)
                 if isinstance(error, AIError) and error.code in _RECOVERY_UNKNOWN_CODES:
-                    await self._defer_recovery(run, node, cause_code=error.code)
+                    await self._defer_recovery(run, node, cause=error)
                     return
                 if isinstance(error, AIError) and error.code in {
                     ErrorCode.TASK_FENCE_STALE,
@@ -730,7 +730,7 @@ class LocalTaskGraphLauncher:
                         tenant_id=tenant_id,
                     ):
                         return
-                    await self._defer_recovery(run, node, cause_code=error.code)
+                    await self._defer_recovery(run, node, cause=error)
         except asyncio.CancelledError:
             if not runner_task.done():
                 runner_task.cancel()
@@ -775,18 +775,15 @@ class LocalTaskGraphLauncher:
         run: _GraphRun,
         node: TaskNode,
         *,
-        cause_code: ErrorCode,
+        cause: AIError,
     ) -> None:
         graph_id = run.request.graph.graph_id
-        failure = AIError(
-            ErrorCode.STORAGE_RECOVERY_REQUIRED,
-            safe_details={
-                "phase": "task_node_recovery",
-                "graph_id": graph_id,
-                "node_id": node.node_id,
-                "cause_code": cause_code.value,
-            },
-        )
+        details = dict(cause.safe_details)
+        details.setdefault("phase", "task_node_recovery")
+        details.setdefault("graph_id", graph_id)
+        details.setdefault("node_id", node.node_id)
+        details.setdefault("cause_code", cause.code.value)
+        failure = AIError(cause.code, safe_details=details)
         async with self._lock:
             current = self._graphs.get((run.request.principal.tenant_id, graph_id))
             if current is run:

--- a/tests/ai/test_closure_fix.py
+++ b/tests/ai/test_closure_fix.py
@@ -5,6 +5,7 @@
 import asyncio
 from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -275,6 +276,39 @@ def _task_request() -> TaskGraphRequest:
         Principal("user", "tenant"),
         idempotency_key="request",
     )
+
+
+@pytest.mark.parametrize(
+    "code",
+    (
+        ErrorCode.STORAGE_COMMIT_UNKNOWN,
+        ErrorCode.EXECUTION_START_UNKNOWN,
+        ErrorCode.TOOL_EFFECT_UNKNOWN,
+    ),
+)
+async def test_task_recovery_preserves_original_error_code(code: ErrorCode) -> None:
+    launcher = object.__new__(LocalTaskGraphLauncher)
+    launcher._lock = asyncio.Lock()
+    request = _task_request()
+    run = SimpleNamespace(
+        request=request,
+        condition=asyncio.Condition(),
+        generation=0,
+        failure=None,
+        closed=False,
+    )
+    launcher._graphs = {(request.principal.tenant_id, request.graph.graph_id): run}
+    cause = AIError(code, safe_details={"source": "original"})
+
+    await launcher._defer_recovery(run, request.graph.nodes[0], cause=cause)
+
+    assert run.failure is not None
+    assert run.failure.code is code
+    assert run.failure.safe_details["source"] == "original"
+    assert run.failure.safe_details["graph_id"] == "graph"
+    assert run.failure.safe_details["node_id"] == "node"
+    assert run.failure.safe_details["cause_code"] == code.value
+    assert run.closed is True
 
 
 async def test_local_scheduler_terminal_exit_wakes_waiter_and_cleans_entry() -> None:

--- a/tests/ai/test_closure_fix.py
+++ b/tests/ai/test_closure_fix.py
@@ -221,13 +221,13 @@ async def _capability(replay_safe: bool):
 
 
 @pytest.mark.parametrize("replay_safe", [True, False])
-async def test_model_retry_respects_effect_replay_safety(replay_safe: bool) -> None:
+async def test_model_retry_is_known_failure_regardless_of_replay_safety(replay_safe: bool) -> None:
     capability, bridge, store, context, call, definition = await _capability(replay_safe)
 
     async def handler(_args: dict[str, Any]) -> None:
         raise ModelRetry("retry")
 
-    with pytest.raises((ModelRetry, AIError)) as raised:
+    with pytest.raises(ModelRetry):
         await capability.wrap_tool_execute(
             context,
             call=call,
@@ -235,23 +235,8 @@ async def test_model_retry_respects_effect_replay_safety(replay_safe: bool) -> N
             args={},
             handler=handler,
         )
-    if replay_safe:
-        assert isinstance(raised.value, ModelRetry)
-        assert bridge.calls == ["begin", "fail"]
-        assert [effect.status for effect in store.effects] == ["started", "failed"]
-    else:
-        assert isinstance(raised.value, AIError)
-        assert raised.value.code is ErrorCode.TOOL_EFFECT_UNKNOWN
-        with pytest.raises(AIError):
-            await capability.on_tool_execute_error(
-                context,
-                call=call,
-                tool_def=definition,
-                args={},
-                error=raised.value,
-            )
-        assert bridge.calls == ["begin", "unknown"]
-        assert [effect.status for effect in store.effects] == ["started"]
+    assert bridge.calls == ["begin", "fail"]
+    assert [effect.status for effect in store.effects] == ["started", "failed"]
 
 
 class _TaskRepository:

--- a/tests/ai/test_error_cancellation_contract.py
+++ b/tests/ai/test_error_cancellation_contract.py
@@ -284,7 +284,7 @@ async def test_task_runner_start_unknown_after_caller_cancel_blocks_shutdown() -
     assert handler.pending_background_tasks == ()
     failure = handler.background_failure
     assert failure is not None
-    assert failure.code is ErrorCode.STORAGE_RECOVERY_REQUIRED
+    assert failure.code is ErrorCode.EXECUTION_START_UNKNOWN
 
     launcher = object.__new__(LocalTaskGraphLauncher)
     launcher._accepting = True
@@ -293,7 +293,7 @@ async def test_task_runner_start_unknown_after_caller_cancel_blocks_shutdown() -
     launcher._runner = handler
     with pytest.raises(AIError) as shutdown_error:
         await launcher.shutdown()
-    assert shutdown_error.value.code is ErrorCode.STORAGE_RECOVERY_REQUIRED
+    assert shutdown_error.value.code is ErrorCode.EXECUTION_START_UNKNOWN
 
 
 @pytest.mark.asyncio

--- a/tests/ai/test_tool_effect_harness_regression.py
+++ b/tests/ai/test_tool_effect_harness_regression.py
@@ -22,7 +22,8 @@ pytestmark = pytest.mark.asyncio
 
 
 class _Bridge:
-    def __init__(self) -> None:
+    def __init__(self, replay_safe: bool) -> None:
+        self.replay_safe = replay_safe
         self.transitions: list[str] = []
 
     async def begin(
@@ -34,9 +35,9 @@ class _Bridge:
         replay_safe: bool,
     ) -> ToolOperationDecision:
         del ctx, call, tool_def, args
-        assert replay_safe is True
+        assert replay_safe is self.replay_safe
         self.transitions.append("begin")
-        return ToolOperationDecision("operation", "owner", 1, True)
+        return ToolOperationDecision("operation", "owner", 1, replay_safe)
 
     async def renew(self, decision: ToolOperationDecision) -> ToolOperationDecision:
         return decision
@@ -68,7 +69,7 @@ def _context() -> RunContext[None]:
 async def test_missing_harness_file_is_failed_retry_not_unknown(tmp_path: Path) -> None:
     filesystem = FileSystem(root_dir=tmp_path, id="workspace-filesystem")
     toolset = filesystem.get_toolset()
-    bridge = _Bridge()
+    bridge = _Bridge(True)
     store = InMemoryStepStore()
     capability = _RuntimeStepPersistence(
         tool_operations=bridge,
@@ -102,6 +103,56 @@ async def test_missing_harness_file_is_failed_retry_not_unknown(tmp_path: Path) 
             validated_args,
             context,
             tools["read_file"],
+        )
+
+    with pytest.raises(ModelRetry):
+        await capability.wrap_tool_execute(
+            context,
+            call=call,
+            tool_def=definition,
+            args=args,
+            handler=handler,
+        )
+
+    assert bridge.transitions == ["begin", "fail"]
+    effect = await store.get_tool_effect(run_id="run", tool_call_id="call")
+    assert effect is not None
+    assert effect.status == "failed"
+
+
+async def test_missing_write_parent_is_failed_retry_not_unknown(tmp_path: Path) -> None:
+    filesystem = FileSystem(root_dir=tmp_path, id="workspace-filesystem")
+    toolset = filesystem.get_toolset()
+    bridge = _Bridge(False)
+    store = InMemoryStepStore()
+    capability = _RuntimeStepPersistence(
+        tool_operations=bridge,
+        store=store,
+        agent_name="agent",
+        run_id="run",
+        trusted_tool_classes=(("write_file", "filesystem.write"),),
+    )
+    context = _context()
+    args = {"path": "worker/personnel_context/report.md", "content": "report"}
+    call = ToolCallPart("write_file", args, tool_call_id="call")
+    definition = ToolDefinition(
+        name="write_file",
+        capability_id="workspace-filesystem",
+    )
+    await capability.before_tool_execute(
+        context,
+        call=call,
+        tool_def=definition,
+        args=args,
+    )
+    tools = await toolset.get_tools(context)
+
+    async def handler(validated_args: dict[str, Any]) -> Any:
+        return await toolset.call_tool(
+            "write_file",
+            validated_args,
+            context,
+            tools["write_file"],
         )
 
     with pytest.raises(ModelRetry):

--- a/tests/ai/test_tool_effect_semantics.py
+++ b/tests/ai/test_tool_effect_semantics.py
@@ -230,6 +230,37 @@ async def test_custom_wrap_failure_is_inside_durable_effect_boundary() -> None:
     assert [effect.status for effect in store.effects] == ["started"]
 
 
+async def test_replay_safe_handler_failure_reports_tool_effect_unknown() -> None:
+    capability, bridge, store, context, call, definition = await _capability(True)
+
+    async def handler(_args: dict[str, Any]) -> None:
+        raise RuntimeError("tool outcome is unknown")
+
+    with pytest.raises(AIError) as raised:
+        await capability.wrap_tool_execute(
+            context,
+            call=call,
+            tool_def=definition,
+            args={},
+            handler=handler,
+        )
+
+    assert raised.value.code is ErrorCode.TOOL_EFFECT_UNKNOWN
+    assert raised.value.safe_details == {"phase": "tool_effect_replay"}
+    with pytest.raises(AIError) as propagated:
+        await capability.on_tool_execute_error(
+            context,
+            call=call,
+            tool_def=definition,
+            args={},
+            error=raised.value,
+        )
+    assert propagated.value is raised.value
+    assert bridge.calls == ["begin"]
+    assert [effect.status for effect in store.effects] == ["started"]
+    assert not capability._calls
+
+
 async def test_skip_tool_execution_terminalizes_as_success() -> None:
     capability, bridge, store, context, call, definition = await _capability(True)
     result = {"skipped": True}


### PR DESCRIPTION
## Summary

Fix AI Runtime/TaskGraph error propagation so recovery handling no longer rewrites the underlying error domain.

### Changes

- Keep model-correctable tool failures (`ModelRetry`, `ToolRetryError`, `ToolFailed`) as durable tool failures that remain visible to the model instead of escalating them to recovery errors.
- Report uncertain tool effects as `TOOL_EFFECT_UNKNOWN`, including replay-safe tools; replay safety now only controls recovery strategy, not error identity.
- Preserve original recovery error codes in TaskGraph defer/recovery handling instead of flattening them to `STORAGE_RECOVERY_REQUIRED`.
- Report missing/unknown execution launch identity as `EXECUTION_START_UNKNOWN` rather than a storage recovery error.
- Preserve existing `AIError` codes in task-runner background failure handling.

## Resulting semantics

- model-correctable tool failure -> durable `FAILED` -> retry/failed tool result returned to model
- uncertain tool effect -> `TOOL_EFFECT_UNKNOWN`
- unknown execution start -> `EXECUTION_START_UNKNOWN`
- unknown storage commit -> `STORAGE_COMMIT_UNKNOWN`
- genuine storage recovery condition -> `STORAGE_RECOVERY_REQUIRED`

Recovery behavior remains fail-closed: TaskGraph still defers recovery for the same set of unknown conditions, but it no longer changes the error identity while doing so.

## Tests

Added/updated regression coverage for:

- model retry semantics independent of replay safety
- replay-unsafe filesystem write failures surfaced by the harness
- structured tool retry/failure persistence round-trips
- TaskGraph recovery preserving the original error code
- execution-start-unknown propagation through cancelled/background task cleanup

No schema, persisted enum, or public API changes are required.