### PR TITLE
chore(ci): make check output concise

### DIFF
--- a/.github/workflows/python-check.yml
+++ b/.github/workflows/python-check.yml
@@ -53,7 +53,7 @@ jobs:
         run: |
           python -m pip install --quiet --upgrade pip
           python -m pip install --quiet -U -r requirements.txt
-          python manage.py install --editable --silent
+          python manage.py install --editable --quiet
       - name: Run checks
         run: python manage.py check --skip-compatibility
 
@@ -70,6 +70,6 @@ jobs:
         run: |
           python -m pip install --quiet --upgrade pip
           python -m pip install --quiet -U -r requirements.txt
-          python manage.py install --editable --silent
+          python manage.py install --editable --quiet
       - name: Run checks
         run: python manage.py check --skip-compatibility

--- a/.github/workflows/python-check.yml
+++ b/.github/workflows/python-check.yml
@@ -35,7 +35,7 @@ jobs:
             -w /workspace \
             python:3.6.15 \
             bash -lc '
-              set -euo pipefail
+              set -eu
               python -m pip install --quiet "tomlkit==0.11.6" "PyYAML==6.0.1"
               python -m py_compile manage.py scripts/check/python36.py
               python manage.py check --compatibility
@@ -55,11 +55,7 @@ jobs:
           python -m pip install --quiet -U -r requirements.txt
           python manage.py install --editable --silent
       - name: Run checks
-        shell: bash
-        run: |
-          set -o pipefail
-          python manage.py check --skip-compatibility \
-            | awk '!/^[.[:space:]]+\[[[:space:]]*[0-9]+%\]$/'
+        run: python manage.py check --skip-compatibility
 
   python_latest:
     name: Python latest checks
@@ -76,8 +72,4 @@ jobs:
           python -m pip install --quiet -U -r requirements.txt
           python manage.py install --editable --silent
       - name: Run checks
-        shell: bash
-        run: |
-          set -o pipefail
-          python manage.py check --skip-compatibility \
-            | awk '!/^[.[:space:]]+\[[[:space:]]*[0-9]+%\]$/'
+        run: python manage.py check --skip-compatibility

--- a/.github/workflows/python-check.yml
+++ b/.github/workflows/python-check.yml
@@ -13,8 +13,6 @@ permissions:
 
 env:
   PIP_DISABLE_PIP_VERSION_CHECK: "1"
-  PIP_PROGRESS_BAR: "off"
-  PIP_QUIET: "1"
   PYTHONUNBUFFERED: "1"
 
 concurrency:
@@ -32,15 +30,13 @@ jobs:
         run: |
           docker run --rm \
             -e PIP_DISABLE_PIP_VERSION_CHECK \
-            -e PIP_PROGRESS_BAR \
-            -e PIP_QUIET \
             -e PYTHONUNBUFFERED \
             -v "$PWD:/workspace" \
             -w /workspace \
             python:3.6.15 \
             bash -lc '
               set -euo pipefail
-              python -m pip install "tomlkit==0.11.6" "PyYAML==6.0.1"
+              python -m pip install --quiet "tomlkit==0.11.6" "PyYAML==6.0.1"
               python -m py_compile manage.py scripts/check/python36.py
               python manage.py check --compatibility
             '
@@ -55,9 +51,9 @@ jobs:
           python-version: '3.10'
       - name: Install tooling
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install -U -r requirements.txt
-          python manage.py install --editable
+          python -m pip install --quiet --upgrade pip
+          python -m pip install --quiet -U -r requirements.txt
+          python manage.py install --editable --silent
       - name: Run checks
         shell: bash
         run: |
@@ -76,9 +72,9 @@ jobs:
           check-latest: true
       - name: Install tooling
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install -U -r requirements.txt
-          python manage.py install --editable
+          python -m pip install --quiet --upgrade pip
+          python -m pip install --quiet -U -r requirements.txt
+          python manage.py install --editable --silent
       - name: Run checks
         shell: bash
         run: |

--- a/.github/workflows/python-check.yml
+++ b/.github/workflows/python-check.yml
@@ -13,7 +13,9 @@ permissions:
 
 env:
   PIP_DISABLE_PIP_VERSION_CHECK: "1"
+  PIP_PROGRESS_BAR: "off"
   PIP_QUIET: "1"
+  PYTHONUNBUFFERED: "1"
 
 concurrency:
   group: python-check-${{ github.event_name }}-${{ github.ref }}
@@ -21,16 +23,18 @@ concurrency:
 
 jobs:
   python36:
-    name: Python 3.6 compatibility
+    name: Python 3.6 static compatibility
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: Run compatibility gates
+      - uses: actions/checkout@v7
+      - name: Run static compatibility scan
         shell: bash
         run: |
           docker run --rm \
             -e PIP_DISABLE_PIP_VERSION_CHECK \
+            -e PIP_PROGRESS_BAR \
             -e PIP_QUIET \
+            -e PYTHONUNBUFFERED \
             -v "$PWD:/workspace" \
             -w /workspace \
             python:3.6.15 \
@@ -38,15 +42,15 @@ jobs:
               set -euo pipefail
               python -m pip install "tomlkit==0.11.6" "PyYAML==6.0.1"
               python -m py_compile manage.py scripts/check/python36.py
-              python -u manage.py check --compatibility | sed "/^\[+\] Running: /d"
+              python manage.py check --compatibility
             '
 
   python310:
     name: Python 3.10 checks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.10'
       - name: Install tooling
@@ -58,14 +62,15 @@ jobs:
         shell: bash
         run: |
           set -o pipefail
-          python -u manage.py check | sed '/^\[+\] Running: /d'
+          python manage.py check --skip-compatibility \
+            | awk '!/^[.[:space:]]+\[[[:space:]]*[0-9]+%\]$/'
 
   python_latest:
     name: Python latest checks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.x'
           check-latest: true
@@ -78,4 +83,5 @@ jobs:
         shell: bash
         run: |
           set -o pipefail
-          python -u manage.py check | sed '/^\[+\] Running: /d'
+          python manage.py check --skip-compatibility \
+            | awk '!/^[.[:space:]]+\[[[:space:]]*[0-9]+%\]$/'

--- a/.github/workflows/python-check.yml
+++ b/.github/workflows/python-check.yml
@@ -11,6 +11,10 @@ on:
 permissions:
   contents: read
 
+env:
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+  PIP_QUIET: "1"
+
 concurrency:
   group: python-check-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
@@ -25,14 +29,16 @@ jobs:
         shell: bash
         run: |
           docker run --rm \
+            -e PIP_DISABLE_PIP_VERSION_CHECK \
+            -e PIP_QUIET \
             -v "$PWD:/workspace" \
             -w /workspace \
             python:3.6.15 \
             bash -lc '
-              set -eu
+              set -euo pipefail
               python -m pip install "tomlkit==0.11.6" "PyYAML==6.0.1"
               python -m py_compile manage.py scripts/check/python36.py
-              python manage.py check --compatibility
+              python -u manage.py check --compatibility | sed "/^\[+\] Running: /d"
             '
 
   python310:
@@ -49,7 +55,10 @@ jobs:
           python -m pip install -U -r requirements.txt
           python manage.py install --editable
       - name: Run checks
-        run: python manage.py check
+        shell: bash
+        run: |
+          set -o pipefail
+          python -u manage.py check | sed '/^\[+\] Running: /d'
 
   python_latest:
     name: Python latest checks
@@ -66,4 +75,7 @@ jobs:
           python -m pip install -U -r requirements.txt
           python manage.py install --editable
       - name: Run checks
-        run: python manage.py check
+        shell: bash
+        run: |
+          set -o pipefail
+          python -u manage.py check | sed '/^\[+\] Running: /d'

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -86,7 +86,7 @@ jobs:
         python -m pip install --quiet --upgrade pip
         python -m pip install --quiet -U -r requirements.txt
     - name: Install projects
-      run: python manage.py install --editable --silent
+      run: python manage.py install --editable --quiet
     - name: Clean package
       run: python manage.py clean
     - name: Build package

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -18,11 +18,15 @@ on:
 permissions:
   contents: write
 
+env:
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+  PYTHONUNBUFFERED: "1"
+
 jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v7
     - name: Validate version
       run: |
         VERSION="${{ inputs.version }}"
@@ -46,12 +50,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v7
 
     # build frida.min.js
     - name: Set up Node
       if: ${{ !env.ACT }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v7
       with:
         node-version: 20
     - name: Build frida scripts
@@ -61,28 +65,28 @@ jobs:
     # build android-tools.apk
     - name: Set up JDK 17
       if: ${{ !env.ACT }}
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v6
       with:
         distribution: temurin
         java-version: 17
     - name: Setup Android SDK
       if: ${{ !env.ACT }}
-      uses: android-actions/setup-android@v3
+      uses: android-actions/setup-android@v4
     - name: Build android tools
       if: ${{ !env.ACT }}
       run: cd linktools-mobile/agents/android && ./gradlew --no-daemon :tools:buildTools
 
     # build python package
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v7
       with:
         python-version: '3.10'
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install -U -r requirements.txt
+        python -m pip install --quiet --upgrade pip
+        python -m pip install --quiet -U -r requirements.txt
     - name: Install projects
-      run: python manage.py install --editable
+      run: python manage.py install --editable --silent
     - name: Clean package
       run: python manage.py clean
     - name: Build package

--- a/manage.py
+++ b/manage.py
@@ -206,6 +206,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     install_parser.add_argument("-e", "--editable", action="store_true", help="Install in editable mode")
     install_parser.add_argument("--no-isolation", action="store_true", help="Disable build isolation")
+    install_parser.add_argument("--silent", action="store_true", help="Suppress routine pip output")
     install_parser.set_defaults(func=handle_install)
 
     check_parser = subparsers.add_parser("check", help="Run source and test release gates")
@@ -432,7 +433,7 @@ def _run_python36_gate(
     scanner = os.path.join(PROJECT_PATH, "scripts", "check", "python36.py")
     paths = [os.path.join(PROJECT_PATH, "manage.py"), scanner]
     paths.extend(os.path.join(modules[project]["path"], "src") for project in compatible)
-    print("[+] Python 3.6 compatibility: %s" % ", ".join(compatible))
+    print("[+] Python 3.6 static compatibility: %s" % ", ".join(compatible))
     _run_check([sys.executable, scanner] + paths, environment)
 
 
@@ -555,6 +556,8 @@ def handle_init(args: argparse.Namespace) -> None:
 def handle_install(args: argparse.Namespace) -> None:
     requirements = _install_requirements(args, get_modules())
     pip_args = [sys.executable, "-m", "pip", "install"]
+    if args.silent:
+        pip_args.append("--quiet")
     for _, requirement in requirements:
         if args.editable:
             pip_args.append("-e")

--- a/manage.py
+++ b/manage.py
@@ -206,7 +206,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     install_parser.add_argument("-e", "--editable", action="store_true", help="Install in editable mode")
     install_parser.add_argument("--no-isolation", action="store_true", help="Disable build isolation")
-    install_parser.add_argument("--silent", action="store_true", help="Suppress routine pip output")
+    install_parser.add_argument("--quiet", action="store_true", help="Suppress routine pip output")
     install_parser.set_defaults(func=handle_install)
 
     check_parser = subparsers.add_parser("check", help="Run source and test release gates")
@@ -556,7 +556,7 @@ def handle_init(args: argparse.Namespace) -> None:
 def handle_install(args: argparse.Namespace) -> None:
     requirements = _install_requirements(args, get_modules())
     pip_args = [sys.executable, "-m", "pip", "install"]
-    if args.silent:
+    if args.quiet:
         pip_args.append("--quiet")
     for _, requirement in requirements:
         if args.editable:

--- a/manage.py
+++ b/manage.py
@@ -449,7 +449,7 @@ def _run_ruff(project: str, check: "typing.Dict[str, typing.Any]", environment: 
         print("[-] ruff is required; install repository requirements first", file=sys.stderr)
         raise SystemExit(1)
     print("[+] %s: ruff" % project)
-    command = [ruff, "check", "--no-cache", "--select", ",".join(check["select"])]
+    command = [ruff, "check", "--quiet", "--no-cache", "--select", ",".join(check["select"])]
     command.extend(check["paths"])
     _run_check(command, environment)
 

--- a/manage.py
+++ b/manage.py
@@ -361,7 +361,7 @@ def _load_project_checks(project: str, project_path: str) -> "typing.Dict[str, t
 
     if "ruff" in checks:
         ruff = _require_mapping(checks["ruff"], "%s checks.ruff" % project)
-        unknown = _unknown_fields(ruff, _RUFF_FIELDS, "%s checks.ruff")
+        unknown = _unknown_fields(ruff, _RUFF_FIELDS, "%s checks.ruff" % project)
         if unknown:
             print("[-] %s checks.ruff has unknown field(s): %s" % (project, ", ".join(unknown)), file=sys.stderr)
             raise SystemExit(1)

--- a/manage.py
+++ b/manage.py
@@ -210,10 +210,16 @@ def build_parser() -> argparse.ArgumentParser:
 
     check_parser = subparsers.add_parser("check", help="Run source and test release gates")
     _add_project_argument(check_parser, modules)
-    check_parser.add_argument(
+    compatibility_group = check_parser.add_mutually_exclusive_group()
+    compatibility_group.add_argument(
         "--compatibility",
         action="store_true",
         help="Run Python compatibility gates only",
+    )
+    compatibility_group.add_argument(
+        "--skip-compatibility",
+        action="store_true",
+        help="Skip Python compatibility gates",
     )
     check_parser.set_defaults(func=handle_check)
 
@@ -355,7 +361,7 @@ def _load_project_checks(project: str, project_path: str) -> "typing.Dict[str, t
 
     if "ruff" in checks:
         ruff = _require_mapping(checks["ruff"], "%s checks.ruff" % project)
-        unknown = _unknown_fields(ruff, _RUFF_FIELDS, "%s checks.ruff" % project)
+        unknown = _unknown_fields(ruff, _RUFF_FIELDS, "%s checks.ruff")
         if unknown:
             print("[-] %s checks.ruff has unknown field(s): %s" % (project, ", ".join(unknown)), file=sys.stderr)
             raise SystemExit(1)
@@ -411,7 +417,6 @@ def _check_environment() -> "typing.Dict[str, str]":
 
 
 def _run_check(command: "typing.Sequence[str]", environment: "typing.Dict[str, str]") -> None:
-    print("[+] Running: %s" % " ".join(command))
     subprocess.check_call(list(command), cwd=PROJECT_PATH, env=environment)
 
 
@@ -550,14 +555,13 @@ def handle_init(args: argparse.Namespace) -> None:
 def handle_install(args: argparse.Namespace) -> None:
     requirements = _install_requirements(args, get_modules())
     pip_args = [sys.executable, "-m", "pip", "install"]
-    for name, requirement in requirements:
-        print("[+] Adding module to install list: %s" % name)
+    for _, requirement in requirements:
         if args.editable:
             pip_args.append("-e")
         pip_args.append(requirement)
     if args.no_isolation:
         pip_args.append("--no-build-isolation")
-    print("[+] Running pip install with arguments: %s" % " ".join(pip_args))
+    print("[+] Installing projects: %s" % ", ".join(name for name, _ in requirements))
     subprocess.check_call(pip_args)
 
 
@@ -573,7 +577,8 @@ def handle_check(args: argparse.Namespace) -> None:
 
     compatible = _compatible_projects(args, projects, requirements)
     environment = _check_environment()
-    _run_python36_gate(compatible, requirements, modules, environment)
+    if not args.skip_compatibility:
+        _run_python36_gate(compatible, requirements, modules, environment)
 
     if not args.compatibility:
         for project in compatible:

--- a/scripts/check/python36.py
+++ b/scripts/check/python36.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-"""Static scan for Python 3.7+-only syntax and stdlib usage."""
+"""Static scan for Python 3.6 compatibility issues in syntax and stdlib usage."""
 
 import argparse
 import ast
@@ -218,9 +218,10 @@ def main() -> int:
     elif violations:
         for violation in violations:
             print(str(violation))
-        print("\n%d potential Python 3.6 incompatibilit%s found." % (len(violations), "y" if len(violations) == 1 else "ies"))
+        suffix = "issue" if len(violations) == 1 else "issues"
+        print("\n%d potential Python 3.6 static compatibility %s found." % (len(violations), suffix))
     else:
-        print("No Python 3.6-incompatible syntax found in %d file(s)." % len(files))
+        print("No Python 3.6 static compatibility issues found in %d file(s)." % len(files))
     return 1 if violations else 0
 
 

--- a/tests/ai/conftest.py
+++ b/tests/ai/conftest.py
@@ -20,8 +20,7 @@ def pytest_runtest_protocol(
     item: pytest.Item,
     nextitem: pytest.Item | None,
 ) -> Generator[None, None, None]:
-    del nextitem
-    print(f"DIAGNOSTIC TEST START: {item.nodeid}", flush=True)
+    del item, nextitem
     previous = signal.signal(signal.SIGALRM, _raise_timeout)
     signal.alarm(_TIMEOUT_SECONDS)
     try:


### PR DESCRIPTION
## Summary

- reduce routine pip/install noise with explicit `--quiet` handling
- separate Python 3.6 static compatibility from Python 3.10/latest checks
- remove per-test diagnostic start spam while preserving timeout protection
- keep Ruff/pytest failure diagnostics visible while making successful checks concise
- refresh GitHub Actions versions used by check/publish workflows

## Behavior

- `manage.py install --quiet` forwards quiet mode to pip
- Python 3.10/latest run `manage.py check --skip-compatibility`
- Python 3.6 compatibility remains a dedicated static compatibility job
- no `sed`/`awk` log filtering is used

## Validation

- reviewed the final workflow and `manage.py` wiring for consistent `--quiet` usage
- confirmed `--silent` has been removed from the branch
- branch changes remain scoped to CI/check output and related test diagnostics