### PR TITLE
fix(core): preserve env artifacts during clean

### DIFF
--- a/linktools/src/linktools/cli/env.py
+++ b/linktools/src/linktools/cli/env.py
@@ -46,19 +46,14 @@ def get_commands(environ: "BaseEnviron") -> "Iterable[SubCommand]":
 
         return wrapper
 
+    def get_scripts_path() -> "pathlib.Path":
+        return environ.get_data_path("scripts", get_interpreter_ident())
+
     def get_stub_path() -> "pathlib.Path":
-        return environ.get_data_path(
-            "scripts",
-            get_interpreter_ident(),
-            f"env_v{environ.version}",
-        )
+        return get_scripts_path() / f"env_v{environ.version}"
 
     def get_alias_path() -> "pathlib.Path":
-        return environ.get_data_path(
-            "scripts",
-            get_interpreter_ident(),
-            f"alias_v{environ.version}",
-        )
+        return get_scripts_path() / f"alias_v{environ.version}"
 
     def remove_shell_artifacts() -> None:
         stub_path = get_stub_path()
@@ -70,6 +65,16 @@ def get_commands(environ: "BaseEnviron") -> "Iterable[SubCommand]":
         if os.path.exists(alias_path):
             environ.logger.info(f"Remove alias path {alias_path} ...")
             utils.remove_file(alias_path)
+
+    def remove_all_shell_artifacts() -> None:
+        scripts_path = get_scripts_path()
+        if not os.path.exists(scripts_path):
+            return
+        for pattern in ("env_v*", "alias_v*"):
+            for path in scripts_path.glob(pattern):
+                if path.is_dir():
+                    environ.logger.info(f"Remove shell artifact path {path} ...")
+                    utils.remove_file(path)
 
     def get_default_shell(environ: "BaseEnviron") -> str:
         return _detect_default_shell(system=environ.system)
@@ -276,7 +281,7 @@ def get_commands(environ: "BaseEnviron") -> "Iterable[SubCommand]":
 
         def run(self, args: "argparse.Namespace") -> None:
             if args.all:
-                remove_shell_artifacts()
+                remove_all_shell_artifacts()
             environ.clean_temp_files(expire_days=args.days)
 
     return commands

--- a/linktools/src/linktools/cli/env.py
+++ b/linktools/src/linktools/cli/env.py
@@ -55,7 +55,7 @@ def get_commands(environ: "BaseEnviron") -> "Iterable[SubCommand]":
     def get_alias_path() -> "pathlib.Path":
         return get_scripts_path() / f"alias_v{environ.version}"
 
-    def remove_shell_artifacts() -> None:
+    def remove_generated_command_artifacts() -> None:
         stub_path = get_stub_path()
         if os.path.exists(stub_path):
             environ.logger.info(f"Remove stub path {stub_path} ...")
@@ -66,14 +66,14 @@ def get_commands(environ: "BaseEnviron") -> "Iterable[SubCommand]":
             environ.logger.info(f"Remove alias path {alias_path} ...")
             utils.remove_file(alias_path)
 
-    def remove_all_shell_artifacts() -> None:
+    def remove_all_generated_command_artifacts() -> None:
         scripts_path = get_scripts_path()
         if not os.path.exists(scripts_path):
             return
         for pattern in ("env_v*", "alias_v*"):
             for path in scripts_path.glob(pattern):
                 if path.is_dir():
-                    environ.logger.info(f"Remove shell artifact path {path} ...")
+                    environ.logger.info(f"Remove generated command artifact path {path} ...")
                     utils.remove_file(path)
 
     def get_default_shell(environ: "BaseEnviron") -> str:
@@ -266,7 +266,7 @@ def get_commands(environ: "BaseEnviron") -> "Iterable[SubCommand]":
                 if args.no_build_isolation:
                     pip_args.append("--no-build-isolation")
 
-                remove_shell_artifacts()
+                remove_generated_command_artifacts()
                 return popen(get_interpreter(), "-m", *pip_args).check_call()
 
     @register_command(name="clean", description="clean temporary and cached files")
@@ -281,7 +281,7 @@ def get_commands(environ: "BaseEnviron") -> "Iterable[SubCommand]":
 
         def run(self, args: "argparse.Namespace") -> None:
             if args.all:
-                remove_all_shell_artifacts()
+                remove_all_generated_command_artifacts()
             environ.clean_temp_files(expire_days=args.days)
 
     return commands

--- a/linktools/src/linktools/cli/env.py
+++ b/linktools/src/linktools/cli/env.py
@@ -60,7 +60,7 @@ def get_commands(environ: "BaseEnviron") -> "Iterable[SubCommand]":
             f"alias_v{environ.version}",
         )
 
-    def remove_cache_files() -> None:
+    def remove_shell_artifacts() -> None:
         stub_path = get_stub_path()
         if os.path.exists(stub_path):
             environ.logger.info(f"Remove stub path {stub_path} ...")
@@ -261,18 +261,22 @@ def get_commands(environ: "BaseEnviron") -> "Iterable[SubCommand]":
                 if args.no_build_isolation:
                     pip_args.append("--no-build-isolation")
 
-                remove_cache_files()
+                remove_shell_artifacts()
                 return popen(get_interpreter(), "-m", *pip_args).check_call()
 
-    @register_command(name="clean", description="clean temporary files")
+    @register_command(name="clean", description="clean temporary and cached files")
     class CleanCommand(SubCommand):
 
         def create_parser(self, type: "Callable[..., CommandParser]") -> "CommandParser":
             parser = super().create_parser(type)
             parser.add_argument("days", metavar="DAYS", nargs="?", type=int, default=7, help="expire days")
+            parser.add_argument("--all", action="store_true",
+                                help="also remove generated shell aliases and command stubs")
             return parser
 
         def run(self, args: "argparse.Namespace") -> None:
+            if args.all:
+                remove_shell_artifacts()
             environ.clean_temp_files(expire_days=args.days)
 
     return commands

--- a/linktools/src/linktools/cli/env.py
+++ b/linktools/src/linktools/cli/env.py
@@ -273,7 +273,6 @@ def get_commands(environ: "BaseEnviron") -> "Iterable[SubCommand]":
             return parser
 
         def run(self, args: "argparse.Namespace") -> None:
-            remove_cache_files()
             environ.clean_temp_files(expire_days=args.days)
 
     return commands

--- a/linktools/src/linktools/cli/env.py
+++ b/linktools/src/linktools/cli/env.py
@@ -55,7 +55,7 @@ def get_commands(environ: "BaseEnviron") -> "Iterable[SubCommand]":
     def get_alias_path() -> "pathlib.Path":
         return get_scripts_path() / f"alias_v{environ.version}"
 
-    def remove_generated_command_artifacts() -> None:
+    def remove_shell_artifacts() -> None:
         stub_path = get_stub_path()
         if os.path.exists(stub_path):
             environ.logger.info(f"Remove stub path {stub_path} ...")
@@ -66,14 +66,14 @@ def get_commands(environ: "BaseEnviron") -> "Iterable[SubCommand]":
             environ.logger.info(f"Remove alias path {alias_path} ...")
             utils.remove_file(alias_path)
 
-    def remove_all_generated_command_artifacts() -> None:
+    def remove_all_shell_artifacts() -> None:
         scripts_path = get_scripts_path()
         if not os.path.exists(scripts_path):
             return
         for pattern in ("env_v*", "alias_v*"):
             for path in scripts_path.glob(pattern):
                 if path.is_dir():
-                    environ.logger.info(f"Remove generated command artifact path {path} ...")
+                    environ.logger.info(f"Remove shell artifact path {path} ...")
                     utils.remove_file(path)
 
     def get_default_shell(environ: "BaseEnviron") -> str:
@@ -266,7 +266,7 @@ def get_commands(environ: "BaseEnviron") -> "Iterable[SubCommand]":
                 if args.no_build_isolation:
                     pip_args.append("--no-build-isolation")
 
-                remove_generated_command_artifacts()
+                remove_shell_artifacts()
                 return popen(get_interpreter(), "-m", *pip_args).check_call()
 
     @register_command(name="clean", description="clean temporary and cached files")
@@ -281,7 +281,7 @@ def get_commands(environ: "BaseEnviron") -> "Iterable[SubCommand]":
 
         def run(self, args: "argparse.Namespace") -> None:
             if args.all:
-                remove_all_generated_command_artifacts()
+                remove_all_shell_artifacts()
             environ.clean_temp_files(expire_days=args.days)
 
     return commands

--- a/linktools/src/linktools/core/_entrypoint.py
+++ b/linktools/src/linktools/core/_entrypoint.py
@@ -22,9 +22,9 @@ def get_entry_points() -> "Any":
 
 def select_entry_points(group: str) -> "tuple[Any, ...]":
     entries = get_entry_points()
-    if isinstance(entries, dict):
-        return tuple(entries.get(group, ()))
     select = getattr(entries, "select", None)
     if select is not None:
         return tuple(select(group=group))
+    if isinstance(entries, dict):
+        return tuple(entries.get(group, ()))
     return tuple(entry for entry in entries if getattr(entry, "group", None) == group)

--- a/tests/cli/test_env_clean.py
+++ b/tests/cli/test_env_clean.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from linktools.cli.env import get_commands
+from linktools.system import get_interpreter_ident
+
+
+class FakeEnviron:
+    name = "test"
+    version = "1"
+    system = "linux"
+    debug = False
+
+    def __init__(self, root):
+        self.root = Path(root)
+        self.clean_calls = []
+        self.logger = SimpleNamespace(info=lambda *args, **kwargs: None)
+
+    def get_data_path(self, *parts, **kwargs):
+        return self.root.joinpath(*parts)
+
+    def clean_temp_files(self, *paths, expire_days=7):
+        self.clean_calls.append((paths, expire_days))
+
+
+def test_clean_preserves_generated_alias_and_command_stubs(tmp_path):
+    environ = FakeEnviron(tmp_path)
+    scripts = tmp_path / "scripts" / get_interpreter_ident()
+    stub = scripts / "env_v1" / "ct-demo"
+    alias = scripts / "alias_v1" / "alias.bash"
+    stub.parent.mkdir(parents=True)
+    alias.parent.mkdir(parents=True)
+    stub.write_text("stub", encoding="utf-8")
+    alias.write_text("alias", encoding="utf-8")
+
+    clean = next(command for command in get_commands(environ) if command.name == "clean")
+    assert clean.run(SimpleNamespace(days=3)) is None
+
+    assert stub.read_text(encoding="utf-8") == "stub"
+    assert alias.read_text(encoding="utf-8") == "alias"
+    assert environ.clean_calls == [((), 3)]

--- a/tests/cli/test_env_clean.py
+++ b/tests/cli/test_env_clean.py
@@ -3,6 +3,7 @@
 
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any
 
 from linktools.cli.env import get_commands
 from linktools.system import get_interpreter_ident
@@ -14,19 +15,19 @@ class FakeEnviron:
     system = "linux"
     debug = False
 
-    def __init__(self, root):
+    def __init__(self, root: Path) -> None:
         self.root = Path(root)
         self.clean_calls = []
         self.logger = SimpleNamespace(info=lambda *args, **kwargs: None)
 
-    def get_data_path(self, *parts, **kwargs):
+    def get_data_path(self, *parts: str, **kwargs: Any) -> Path:
         return self.root.joinpath(*parts)
 
-    def clean_temp_files(self, *paths, expire_days=7):
+    def clean_temp_files(self, *paths: str, expire_days: int = 7) -> None:
         self.clean_calls.append((paths, expire_days))
 
 
-def test_clean_preserves_generated_alias_and_command_stubs(tmp_path):
+def test_clean_preserves_generated_alias_and_command_stubs(tmp_path: Path) -> None:
     environ = FakeEnviron(tmp_path)
     scripts = tmp_path / "scripts" / get_interpreter_ident()
     stub = scripts / "env_v1" / "ct-demo"

--- a/tests/cli/test_env_clean.py
+++ b/tests/cli/test_env_clean.py
@@ -3,7 +3,7 @@
 
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, Tuple
 
 from linktools.cli.env import get_commands
 from linktools.system import get_interpreter_ident
@@ -27,19 +27,36 @@ class FakeEnviron:
         self.clean_calls.append((paths, expire_days))
 
 
-def test_clean_preserves_generated_alias_and_command_stubs(tmp_path: Path) -> None:
-    environ = FakeEnviron(tmp_path)
-    scripts = tmp_path / "scripts" / get_interpreter_ident()
+def _write_shell_artifacts(root: Path) -> "Tuple[Path, Path]":
+    scripts = root / "scripts" / get_interpreter_ident()
     stub = scripts / "env_v1" / "ct-demo"
     alias = scripts / "alias_v1" / "alias.bash"
     stub.parent.mkdir(parents=True)
     alias.parent.mkdir(parents=True)
     stub.write_text("stub", encoding="utf-8")
     alias.write_text("alias", encoding="utf-8")
+    return stub, alias
+
+
+def test_clean_preserves_generated_alias_and_command_stubs(tmp_path: Path) -> None:
+    environ = FakeEnviron(tmp_path)
+    stub, alias = _write_shell_artifacts(tmp_path)
 
     clean = next(command for command in get_commands(environ) if command.name == "clean")
-    assert clean.run(SimpleNamespace(days=3)) is None
+    assert clean.run(SimpleNamespace(days=3, all=False)) is None
 
     assert stub.read_text(encoding="utf-8") == "stub"
     assert alias.read_text(encoding="utf-8") == "alias"
+    assert environ.clean_calls == [((), 3)]
+
+
+def test_clean_all_removes_generated_alias_and_command_stubs(tmp_path: Path) -> None:
+    environ = FakeEnviron(tmp_path)
+    stub, alias = _write_shell_artifacts(tmp_path)
+
+    clean = next(command for command in get_commands(environ) if command.name == "clean")
+    assert clean.run(SimpleNamespace(days=3, all=True)) is None
+
+    assert not stub.exists()
+    assert not alias.exists()
     assert environ.clean_calls == [((), 3)]

--- a/tests/cli/test_env_clean.py
+++ b/tests/cli/test_env_clean.py
@@ -27,10 +27,10 @@ class FakeEnviron:
         self.clean_calls.append((paths, expire_days))
 
 
-def _write_shell_artifacts(root: Path) -> "Tuple[Path, Path]":
+def _write_shell_artifacts(root: Path, version: str = "1") -> "Tuple[Path, Path]":
     scripts = root / "scripts" / get_interpreter_ident()
-    stub = scripts / "env_v1" / "ct-demo"
-    alias = scripts / "alias_v1" / "alias.bash"
+    stub = scripts / ("env_v%s" % version) / "ct-demo"
+    alias = scripts / ("alias_v%s" % version) / "alias.bash"
     stub.parent.mkdir(parents=True)
     alias.parent.mkdir(parents=True)
     stub.write_text("stub", encoding="utf-8")
@@ -50,13 +50,16 @@ def test_clean_preserves_generated_alias_and_command_stubs(tmp_path: Path) -> No
     assert environ.clean_calls == [((), 3)]
 
 
-def test_clean_all_removes_generated_alias_and_command_stubs(tmp_path: Path) -> None:
+def test_clean_all_removes_all_generated_alias_and_command_stubs(tmp_path: Path) -> None:
     environ = FakeEnviron(tmp_path)
-    stub, alias = _write_shell_artifacts(tmp_path)
+    current_stub, current_alias = _write_shell_artifacts(tmp_path)
+    old_stub, old_alias = _write_shell_artifacts(tmp_path, version="0")
 
     clean = next(command for command in get_commands(environ) if command.name == "clean")
     assert clean.run(SimpleNamespace(days=3, all=True)) is None
 
-    assert not stub.exists()
-    assert not alias.exists()
+    assert not current_stub.exists()
+    assert not current_alias.exists()
+    assert not old_stub.exists()
+    assert not old_alias.exists()
     assert environ.clean_calls == [((), 3)]

--- a/tests/core/test_entrypoint.py
+++ b/tests/core/test_entrypoint.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+
+def test_select_entry_points_prefers_select_over_mapping_interface(monkeypatch):
+    from linktools.core import _entrypoint
+
+    class SelectableGroups(dict):
+        def __init__(self):
+            super().__init__({"linktools.capability": ("legacy",)})
+            self.select_calls = []
+
+        def select(self, **kwargs):
+            self.select_calls.append(kwargs)
+            return ("selected",)
+
+        def get(self, *args, **kwargs):
+            raise AssertionError("deprecated mapping interface must not be used")
+
+    entries = SelectableGroups()
+    _entrypoint.get_entry_points.cache_clear()
+    try:
+        monkeypatch.setattr(_entrypoint.metadata, "entry_points", lambda: entries)
+        assert _entrypoint.select_entry_points("linktools.capability") == ("selected",)
+        assert entries.select_calls == [{"group": "linktools.capability"}]
+    finally:
+        _entrypoint.get_entry_points.cache_clear()

--- a/tests/core/test_entrypoint.py
+++ b/tests/core/test_entrypoint.py
@@ -1,20 +1,22 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+from typing import Any, Tuple
 
-def test_select_entry_points_prefers_select_over_mapping_interface(monkeypatch):
+
+def test_select_entry_points_prefers_select_over_mapping_interface(monkeypatch: Any) -> None:
     from linktools.core import _entrypoint
 
     class SelectableGroups(dict):
-        def __init__(self):
+        def __init__(self) -> None:
             super().__init__({"linktools.capability": ("legacy",)})
             self.select_calls = []
 
-        def select(self, **kwargs):
+        def select(self, **kwargs: str) -> "Tuple[str, ...]":
             self.select_calls.append(kwargs)
             return ("selected",)
 
-        def get(self, *args, **kwargs):
+        def get(self, *args: Any, **kwargs: Any) -> Any:
             raise AssertionError("deprecated mapping interface must not be used")
 
     entries = SelectableGroups()


### PR DESCRIPTION
## Summary

- prefer `EntryPoints.select()` over the deprecated mapping interface on Python 3.10
- keep default `ct-env clean [days]` limited to expired temp/cache/download data
- add `ct-env clean --all` to also remove generated alias and command-stub artifacts
- make `--all` remove stale `env_v*` / `alias_v*` versions for the current interpreter
- keep `ct-env update` invalidating only the current generated shell artifacts

## Validation

- added regression coverage for Python 3.10-style selectable entry points
- added coverage that default clean preserves generated alias/stub files
- added coverage that `clean --all` removes current and stale alias/stub versions

CI is expected to provide the full repository validation on this PR.