### PR TITLE
feat(ai): add OpenAI model route settings

### DIFF
--- a/linktools-ai/linktools.yml
+++ b/linktools-ai/linktools.yml
@@ -4,7 +4,7 @@ version: "0.10.0"
 dependencies:
   - filelock>=3.4.0
   - jsonschema>=4.23.0,<5.0.0
-  - pydantic-ai-slim[mcp,openai]>=2.33.0,<3.0.0
+  - pydantic-ai-slim[mcp,openai,retries]>=2.33.0,<3.0.0
   - pydantic-ai-harness[dynamic-workflow]>=0.26.0
   - PyYAML>=6.0,<7.0
 

--- a/linktools-ai/linktools.yml
+++ b/linktools-ai/linktools.yml
@@ -4,7 +4,7 @@ version: "0.10.0"
 dependencies:
   - filelock>=3.4.0
   - jsonschema>=4.23.0,<5.0.0
-  - pydantic-ai-slim[mcp,openai,retries]>=2.33.0,<3.0.0
+  - pydantic-ai-slim[mcp,openai,retries]>=2.38.0,<3.0.0
   - pydantic-ai-harness[dynamic-workflow]>=0.26.0
   - PyYAML>=6.0,<7.0
 

--- a/linktools-ai/linktools.yml
+++ b/linktools-ai/linktools.yml
@@ -5,7 +5,7 @@ dependencies:
   - filelock>=3.4.0
   - jsonschema>=4.23.0,<5.0.0
   - pydantic-ai-slim[mcp,openai,retries]>=2.38.0,<3.0.0
-  - pydantic-ai-harness[dynamic-workflow]>=0.26.0
+  - pydantic-ai-harness[dynamic-workflow]>=0.28.1
   - PyYAML>=6.0,<7.0
 
 dev-dependencies:

--- a/linktools-ai/linktools.yml
+++ b/linktools-ai/linktools.yml
@@ -4,8 +4,8 @@ version: "0.10.0"
 dependencies:
   - filelock>=3.4.0
   - jsonschema>=4.23.0,<5.0.0
-  - pydantic-ai-slim[mcp,openai]>=2.38.0,<3.0.0
-  - pydantic-ai-harness[dynamic-workflow]>=0.28.1
+  - pydantic-ai-slim[mcp,openai]>=2.33.0,<3.0.0
+  - pydantic-ai-harness[dynamic-workflow]>=0.26.0
   - PyYAML>=6.0,<7.0
 
 dev-dependencies:

--- a/linktools-ai/linktools.yml
+++ b/linktools-ai/linktools.yml
@@ -4,7 +4,7 @@ version: "0.10.0"
 dependencies:
   - filelock>=3.4.0
   - jsonschema>=4.23.0,<5.0.0
-  - pydantic-ai-slim[mcp,openai,retries]>=2.38.0,<3.0.0
+  - pydantic-ai-slim[mcp,openai]>=2.38.0,<3.0.0
   - pydantic-ai-harness[dynamic-workflow]>=0.28.1
   - PyYAML>=6.0,<7.0
 

--- a/linktools-ai/src/linktools/ai/model/_openai.py
+++ b/linktools-ai/src/linktools/ai/model/_openai.py
@@ -187,6 +187,17 @@ class _RetryingOpenAIProvider(Provider[AsyncOpenAI]):
         return http_client, provider
 
 
+class _AsyncClientTransport(httpx2.AsyncBaseTransport):
+    def __init__(self, client: httpx2.AsyncClient) -> None:
+        self._client = client
+
+    async def handle_async_request(self, request: httpx2.Request) -> httpx2.Response:
+        return await self._client.send(request, stream=True)
+
+    async def aclose(self) -> None:
+        await self._client.aclose()
+
+
 def _openai_provider(
     *,
     base_url: "str | None",
@@ -210,6 +221,8 @@ def _openai_provider(
 
 
 def _retry_http_client(*, max_retries: int, retry_delay: float) -> httpx2.AsyncClient:
+    timeout = httpx2.Timeout(timeout=DEFAULT_HTTP_TIMEOUT, connect=5)
+    network_client = httpx2.AsyncClient(timeout=timeout)
     transport = AsyncHTTPX2TenacityTransport(
         config=RetryConfig(
             retry=retry_if_exception_type((httpx2.HTTPStatusError, httpx2.TransportError)),
@@ -217,11 +230,12 @@ def _retry_http_client(*, max_retries: int, retry_delay: float) -> httpx2.AsyncC
             stop=stop_after_attempt(max_retries + 1),
             retry_error_callback=_retry_error_result,
         ),
+        wrapped=_AsyncClientTransport(network_client),
         validate_response=_raise_retryable_status,
     )
     return httpx2.AsyncClient(
         transport=transport,
-        timeout=httpx2.Timeout(timeout=DEFAULT_HTTP_TIMEOUT, connect=5),
+        timeout=timeout,
     )
 
 

--- a/linktools-ai/src/linktools/ai/model/_openai.py
+++ b/linktools-ai/src/linktools/ai/model/_openai.py
@@ -11,7 +11,6 @@ from pydantic_ai import ModelSettings
 from pydantic_ai.exceptions import UserError
 from pydantic_ai.models import Model
 from pydantic_ai.models.openai import OpenAIChatModel
-from pydantic_ai.profiles import ModelProfile
 from pydantic_ai.providers.openai import OpenAIProvider
 
 from ..core import JsonValue, canonical_sha256
@@ -29,7 +28,6 @@ class _OpenAIModelBinding:
     timeout: "float | None" = None
     max_retries: "int | None" = None
     max_tokens: "int | None" = None
-    context_window: "int | None" = None
 
     def __post_init__(self) -> None:
         model = self.model.strip().removeprefix("openai:")
@@ -42,9 +40,6 @@ class _OpenAIModelBinding:
         _validate_positive_number("timeout", self.timeout)
         _validate_non_negative_integer("max_retries", self.max_retries)
         _validate_positive_integer("max_tokens", self.max_tokens)
-        _validate_positive_integer("context_window", self.context_window)
-        if self.max_tokens is not None and self.context_window is not None and self.max_tokens > self.context_window:
-            raise ValueError("max_tokens cannot exceed context_window")
 
     @property
     def provider(self) -> str:
@@ -59,8 +54,6 @@ class _OpenAIModelBinding:
         settings: dict[str, JsonValue] = {}
         if self.max_tokens is not None:
             settings["max_tokens"] = self.max_tokens
-        if self.context_window is not None:
-            settings["context_window"] = self.context_window
         return {
             "version": 1,
             "provider": self.provider,
@@ -84,15 +77,10 @@ class _OpenAIModelBinding:
             if self.max_tokens is not None:
                 settings["max_tokens"] = self.max_tokens
 
-            profile: ModelProfile | None = None
-            if self.context_window is not None:
-                profile = {"context_window": self.context_window}
-
             model = OpenAIChatModel(
                 self.model,
                 provider=provider,
                 settings=settings or None,
-                profile=profile,
             )
         except UserError as error:
             raise AIError(

--- a/linktools-ai/src/linktools/ai/model/_openai.py
+++ b/linktools-ai/src/linktools/ai/model/_openai.py
@@ -25,7 +25,7 @@ class _OpenAIModelBinding:
     model: str
     base_url: "str | None" = None
     api_key: "str | None" = field(default=None, repr=False, compare=False)
-    timeout: "float | None" = None
+    timeout: "int | float | None" = None
     max_retries: "int | None" = None
     max_tokens: "int | None" = None
 
@@ -100,10 +100,15 @@ class _OpenAIModelBinding:
         return model
 
 
-def _validate_positive_number(name: str, value: "float | None") -> None:
+def _validate_positive_number(name: str, value: "int | float | None") -> None:
     if value is None:
         return
-    if isinstance(value, bool) or not isinstance(value, (int, float)) or not math.isfinite(value) or value <= 0:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or (isinstance(value, float) and not math.isfinite(value))
+        or value <= 0
+    ):
         raise ValueError(f"{name} must be a finite positive number")
 
 

--- a/linktools-ai/src/linktools/ai/model/_openai.py
+++ b/linktools-ai/src/linktools/ai/model/_openai.py
@@ -192,7 +192,10 @@ class _AsyncClientTransport(httpx2.AsyncBaseTransport):
         self._client = client
 
     async def handle_async_request(self, request: httpx2.Request) -> httpx2.Response:
-        return await self._client.send(request, stream=True)
+        response = await self._client.send(request, stream=True)
+        if _should_retry_response(response):
+            await response.aread()
+        return response
 
     async def aclose(self) -> None:
         await self._client.aclose()
@@ -252,9 +255,19 @@ def _retry_error_result(state: RetryCallState) -> httpx2.Response:
 
 
 def _raise_retryable_status(response: httpx2.Response) -> None:
-    status_code = response.status_code
-    if status_code in {408, 409, 429} or status_code >= 500:
+    if _should_retry_response(response):
         response.raise_for_status()
+
+
+def _should_retry_response(response: httpx2.Response) -> bool:
+    if response.status_code < 400:
+        return False
+    should_retry = response.headers.get("x-should-retry")
+    if should_retry == "false":
+        return False
+    if should_retry == "true":
+        return True
+    return response.status_code in {408, 409, 429} or response.status_code >= 500
 
 
 def _validate_positive_number(name: str, value: "float | None") -> None:

--- a/linktools-ai/src/linktools/ai/model/_openai.py
+++ b/linktools-ai/src/linktools/ai/model/_openai.py
@@ -2,14 +2,21 @@
 # -*- coding: utf-8 -*-
 """OpenAI model binding."""
 
+import math
 from dataclasses import dataclass, field
+from typing import cast
 from urllib.parse import urlsplit, urlunsplit
 
+import httpx2
 from linktools.core import environ
+from pydantic_ai import ModelSettings
 from pydantic_ai.exceptions import UserError
 from pydantic_ai.models import Model
 from pydantic_ai.models.openai import OpenAIChatModel
+from pydantic_ai.profiles import ModelProfile
 from pydantic_ai.providers.openai import OpenAIProvider
+from pydantic_ai.retries import AsyncHTTPX2TenacityTransport, RetryConfig, wait_retry_after
+from tenacity import retry_if_exception_type, stop_after_attempt, wait_fixed
 
 from ..core import JsonValue, canonical_sha256
 from ..errors import AIError, ErrorCode
@@ -23,6 +30,11 @@ class _OpenAIModelBinding:
     model: str
     base_url: "str | None" = None
     api_key: "str | None" = field(default=None, repr=False, compare=False)
+    timeout_seconds: "float | None" = None
+    max_retries: "int | None" = None
+    retry_delay_seconds: "float | None" = None
+    max_output_tokens: "int | None" = None
+    context_window_tokens: "int | None" = None
 
     def __post_init__(self) -> None:
         model = self.model.strip().removeprefix("openai:")
@@ -32,6 +44,19 @@ class _OpenAIModelBinding:
         object.__setattr__(self, "base_url", _normalize_base_url(self.base_url))
         if self.api_key is not None and not self.api_key.strip():
             object.__setattr__(self, "api_key", None)
+        _validate_positive_number("timeout_seconds", self.timeout_seconds)
+        _validate_non_negative_integer("max_retries", self.max_retries)
+        _validate_non_negative_number("retry_delay_seconds", self.retry_delay_seconds)
+        _validate_positive_integer("max_output_tokens", self.max_output_tokens)
+        _validate_positive_integer("context_window_tokens", self.context_window_tokens)
+        if self.retry_delay_seconds is not None and self.max_retries is None:
+            raise ValueError("retry_delay_seconds requires max_retries")
+        if (
+            self.max_output_tokens is not None
+            and self.context_window_tokens is not None
+            and self.max_output_tokens > self.context_window_tokens
+        ):
+            raise ValueError("max_output_tokens cannot exceed context_window_tokens")
 
     @property
     def provider(self) -> str:
@@ -56,7 +81,26 @@ class _OpenAIModelBinding:
 
     def materialize(self) -> Model:
         try:
-            model = OpenAIChatModel(self.model, provider=OpenAIProvider(base_url=self.base_url, api_key=self.api_key))
+            provider = _openai_provider(
+                base_url=self.base_url,
+                api_key=self.api_key,
+                max_retries=self.max_retries,
+                retry_delay_seconds=self.retry_delay_seconds,
+            )
+            settings: ModelSettings = {}
+            if self.timeout_seconds is not None:
+                settings["timeout"] = self.timeout_seconds
+            if self.max_output_tokens is not None:
+                settings["max_tokens"] = self.max_output_tokens
+            profile = None
+            if self.context_window_tokens is not None:
+                profile = cast(ModelProfile, {"context_window": self.context_window_tokens})
+            model = OpenAIChatModel(
+                self.model,
+                provider=provider,
+                settings=settings or None,
+                profile=profile,
+            )
         except UserError as error:
             raise AIError(
                 ErrorCode.MODEL_CONFIG_INVALID,
@@ -66,8 +110,78 @@ class _OpenAIModelBinding:
                     "reason": "provider_configuration_invalid",
                 },
             ) from error
-        _logger.debug("OpenAI model materialized: route=%s model=%s credential=%s", self.route_id, self.model, self.api_key is not None)
+        _logger.debug(
+            "OpenAI model materialized: route=%s model=%s credential=%s",
+            self.route_id,
+            self.model,
+            self.api_key is not None,
+        )
         return model
+
+
+def _openai_provider(
+    *,
+    base_url: "str | None",
+    api_key: "str | None",
+    max_retries: "int | None",
+    retry_delay_seconds: "float | None",
+) -> OpenAIProvider:
+    if retry_delay_seconds is None:
+        provider = OpenAIProvider(base_url=base_url, api_key=api_key)
+        if max_retries is not None:
+            provider.client.max_retries = max_retries
+        return provider
+
+    transport = AsyncHTTPX2TenacityTransport(
+        config=RetryConfig(
+            retry=retry_if_exception_type((httpx2.HTTPStatusError, httpx2.TransportError)),
+            wait=wait_retry_after(fallback_strategy=wait_fixed(retry_delay_seconds)),
+            stop=stop_after_attempt(cast(int, max_retries) + 1),
+            reraise=True,
+        ),
+        validate_response=_raise_retryable_status,
+    )
+    provider = OpenAIProvider(
+        base_url=base_url,
+        api_key=api_key,
+        http_client=httpx2.AsyncClient(transport=transport),
+    )
+    provider.client.max_retries = 0
+    return provider
+
+
+def _raise_retryable_status(response: httpx2.Response) -> None:
+    status_code = response.status_code
+    if status_code in {408, 409, 429} or status_code >= 500:
+        response.raise_for_status()
+
+
+def _validate_positive_number(name: str, value: "float | None") -> None:
+    if value is None:
+        return
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or not math.isfinite(value) or value <= 0:
+        raise ValueError(f"{name} must be a finite positive number")
+
+
+def _validate_non_negative_number(name: str, value: "float | None") -> None:
+    if value is None:
+        return
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or not math.isfinite(value) or value < 0:
+        raise ValueError(f"{name} must be a finite non-negative number")
+
+
+def _validate_positive_integer(name: str, value: "int | None") -> None:
+    if value is None:
+        return
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ValueError(f"{name} must be a positive integer")
+
+
+def _validate_non_negative_integer(name: str, value: "int | None") -> None:
+    if value is None:
+        return
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(f"{name} must be a non-negative integer")
 
 
 def _normalize_base_url(value: "str | None") -> "str | None":

--- a/linktools-ai/src/linktools/ai/model/_openai.py
+++ b/linktools-ai/src/linktools/ai/model/_openai.py
@@ -4,16 +4,18 @@
 
 import math
 from dataclasses import dataclass, field
-from typing import cast
+from types import TracebackType
 from urllib.parse import urlsplit, urlunsplit
 
 import httpx2
 from linktools.core import environ
+from openai import AsyncOpenAI
 from pydantic_ai import ModelSettings
 from pydantic_ai.exceptions import UserError
-from pydantic_ai.models import Model
+from pydantic_ai.models import DEFAULT_HTTP_TIMEOUT, Model
 from pydantic_ai.models.openai import OpenAIChatModel
 from pydantic_ai.profiles import ModelProfile
+from pydantic_ai.providers import Provider
 from pydantic_ai.providers.openai import OpenAIProvider
 from pydantic_ai.retries import AsyncHTTPX2TenacityTransport, RetryConfig, wait_retry_after
 from tenacity import RetryCallState, retry_if_exception_type, stop_after_attempt, wait_fixed
@@ -30,11 +32,11 @@ class _OpenAIModelBinding:
     model: str
     base_url: "str | None" = None
     api_key: "str | None" = field(default=None, repr=False, compare=False)
-    timeout_seconds: "float | None" = None
+    timeout: "float | None" = None
     max_retries: "int | None" = None
-    retry_delay_seconds: "float | None" = None
-    max_output_tokens: "int | None" = None
-    context_window_tokens: "int | None" = None
+    retry_delay: "float | None" = None
+    max_tokens: "int | None" = None
+    context_window: "int | None" = None
 
     def __post_init__(self) -> None:
         model = self.model.strip().removeprefix("openai:")
@@ -44,19 +46,15 @@ class _OpenAIModelBinding:
         object.__setattr__(self, "base_url", _normalize_base_url(self.base_url))
         if self.api_key is not None and not self.api_key.strip():
             object.__setattr__(self, "api_key", None)
-        _validate_positive_number("timeout_seconds", self.timeout_seconds)
+        _validate_positive_number("timeout", self.timeout)
         _validate_non_negative_integer("max_retries", self.max_retries)
-        _validate_non_negative_number("retry_delay_seconds", self.retry_delay_seconds)
-        _validate_positive_integer("max_output_tokens", self.max_output_tokens)
-        _validate_positive_integer("context_window_tokens", self.context_window_tokens)
-        if self.retry_delay_seconds is not None and self.max_retries is None:
-            raise ValueError("retry_delay_seconds requires max_retries")
-        if (
-            self.max_output_tokens is not None
-            and self.context_window_tokens is not None
-            and self.max_output_tokens > self.context_window_tokens
-        ):
-            raise ValueError("max_output_tokens cannot exceed context_window_tokens")
+        _validate_non_negative_number("retry_delay", self.retry_delay)
+        _validate_positive_integer("max_tokens", self.max_tokens)
+        _validate_positive_integer("context_window", self.context_window)
+        if self.retry_delay is not None and self.max_retries is None:
+            raise ValueError("retry_delay requires max_retries")
+        if self.max_tokens is not None and self.context_window is not None and self.max_tokens > self.context_window:
+            raise ValueError("max_tokens cannot exceed context_window")
 
     @property
     def provider(self) -> str:
@@ -68,11 +66,16 @@ class _OpenAIModelBinding:
 
     @property
     def semantic_payload(self) -> "dict[str, JsonValue]":
+        settings: dict[str, JsonValue] = {}
+        if self.max_tokens is not None:
+            settings["max_tokens"] = self.max_tokens
+        if self.context_window is not None:
+            settings["context_window"] = self.context_window
         return {
             "version": 1,
             "provider": self.provider,
             "model_identity": self.model_identity,
-            "settings": {},
+            "settings": settings,
         }
 
     @property
@@ -85,16 +88,16 @@ class _OpenAIModelBinding:
                 base_url=self.base_url,
                 api_key=self.api_key,
                 max_retries=self.max_retries,
-                retry_delay_seconds=self.retry_delay_seconds,
+                retry_delay=self.retry_delay,
             )
             settings: ModelSettings = {}
-            if self.timeout_seconds is not None:
-                settings["timeout"] = self.timeout_seconds
-            if self.max_output_tokens is not None:
-                settings["max_tokens"] = self.max_output_tokens
-            profile = None
-            if self.context_window_tokens is not None:
-                profile = cast(ModelProfile, {"context_window": self.context_window_tokens})
+            if self.timeout is not None:
+                settings["timeout"] = self.timeout
+            if self.max_tokens is not None:
+                settings["max_tokens"] = self.max_tokens
+            profile: ModelProfile | None = None
+            if self.context_window is not None:
+                profile = {"context_window": self.context_window}
             model = OpenAIChatModel(
                 self.model,
                 provider=provider,
@@ -119,35 +122,107 @@ class _OpenAIModelBinding:
         return model
 
 
+class _RetryingOpenAIProvider(Provider[AsyncOpenAI]):
+    def __init__(
+        self,
+        *,
+        base_url: "str | None",
+        api_key: "str | None",
+        max_retries: int,
+        retry_delay: float,
+    ) -> None:
+        self._base_url = base_url
+        self._api_key = api_key
+        self._max_retries = max_retries
+        self._retry_delay = retry_delay
+        self._entered_count = 0
+        self._http_client, self._delegate = self._build()
+
+    @property
+    def name(self) -> str:
+        return self._delegate.name
+
+    @property
+    def base_url(self) -> str:
+        return self._delegate.base_url
+
+    @property
+    def client(self) -> AsyncOpenAI:
+        return self._delegate.client
+
+    @staticmethod
+    def model_profile(model_name: str) -> ModelProfile | None:
+        return OpenAIProvider.model_profile(model_name)
+
+    async def __aenter__(self) -> "_RetryingOpenAIProvider":
+        if self._entered_count == 0 and self._http_client.is_closed:
+            self._http_client, self._delegate = self._build()
+        self._entered_count += 1
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: "type[BaseException] | None",
+        exc_value: "BaseException | None",
+        traceback: "TracebackType | None",
+    ) -> None:
+        del exc_type, exc_value, traceback
+        if self._entered_count == 0:
+            return
+        self._entered_count -= 1
+        if self._entered_count == 0:
+            await self._delegate.client.close()
+
+    def _build(self) -> "tuple[httpx2.AsyncClient, OpenAIProvider]":
+        http_client = _retry_http_client(
+            max_retries=self._max_retries,
+            retry_delay=self._retry_delay,
+        )
+        provider = OpenAIProvider(
+            base_url=self._base_url,
+            api_key=self._api_key,
+            http_client=http_client,
+        )
+        provider.client.max_retries = 0
+        return http_client, provider
+
+
 def _openai_provider(
     *,
     base_url: "str | None",
     api_key: "str | None",
     max_retries: "int | None",
-    retry_delay_seconds: "float | None",
-) -> OpenAIProvider:
-    if retry_delay_seconds is None:
+    retry_delay: "float | None",
+) -> Provider[AsyncOpenAI]:
+    if retry_delay is None:
         provider = OpenAIProvider(base_url=base_url, api_key=api_key)
         if max_retries is not None:
             provider.client.max_retries = max_retries
         return provider
+    if max_retries is None:
+        raise ValueError("retry_delay requires max_retries")
+    return _RetryingOpenAIProvider(
+        base_url=base_url,
+        api_key=api_key,
+        max_retries=max_retries,
+        retry_delay=retry_delay,
+    )
 
+
+def _retry_http_client(*, max_retries: int, retry_delay: float) -> httpx2.AsyncClient:
     transport = AsyncHTTPX2TenacityTransport(
         config=RetryConfig(
             retry=retry_if_exception_type((httpx2.HTTPStatusError, httpx2.TransportError)),
-            wait=wait_retry_after(fallback_strategy=wait_fixed(retry_delay_seconds)),
-            stop=stop_after_attempt(cast(int, max_retries) + 1),
+            wait=wait_retry_after(fallback_strategy=wait_fixed(retry_delay)),
+            stop=stop_after_attempt(max_retries + 1),
             retry_error_callback=_retry_error_result,
         ),
         validate_response=_raise_retryable_status,
     )
-    provider = OpenAIProvider(
-        base_url=base_url,
-        api_key=api_key,
-        http_client=httpx2.AsyncClient(transport=transport),
+    return httpx2.AsyncClient(
+        transport=transport,
+        timeout=httpx2.Timeout(timeout=DEFAULT_HTTP_TIMEOUT, connect=5),
     )
-    provider.client.max_retries = 0
-    return provider
 
 
 def _retry_error_result(state: RetryCallState) -> httpx2.Response:

--- a/linktools-ai/src/linktools/ai/model/_openai.py
+++ b/linktools-ai/src/linktools/ai/model/_openai.py
@@ -16,7 +16,7 @@ from pydantic_ai.models.openai import OpenAIChatModel
 from pydantic_ai.profiles import ModelProfile
 from pydantic_ai.providers.openai import OpenAIProvider
 from pydantic_ai.retries import AsyncHTTPX2TenacityTransport, RetryConfig, wait_retry_after
-from tenacity import retry_if_exception_type, stop_after_attempt, wait_fixed
+from tenacity import RetryCallState, retry_if_exception_type, stop_after_attempt, wait_fixed
 
 from ..core import JsonValue, canonical_sha256
 from ..errors import AIError, ErrorCode
@@ -137,7 +137,7 @@ def _openai_provider(
             retry=retry_if_exception_type((httpx2.HTTPStatusError, httpx2.TransportError)),
             wait=wait_retry_after(fallback_strategy=wait_fixed(retry_delay_seconds)),
             stop=stop_after_attempt(cast(int, max_retries) + 1),
-            reraise=True,
+            retry_error_callback=_retry_error_result,
         ),
         validate_response=_raise_retryable_status,
     )
@@ -148,6 +148,18 @@ def _openai_provider(
     )
     provider.client.max_retries = 0
     return provider
+
+
+def _retry_error_result(state: RetryCallState) -> httpx2.Response:
+    outcome = state.outcome
+    if outcome is None or not outcome.failed:
+        raise RuntimeError("retry exhausted without a failed attempt")
+    error = outcome.exception()
+    if isinstance(error, httpx2.HTTPStatusError):
+        return error.response
+    if error is None:
+        raise RuntimeError("retry exhausted without an exception")
+    raise error
 
 
 def _raise_retryable_status(response: httpx2.Response) -> None:

--- a/linktools-ai/src/linktools/ai/model/_openai.py
+++ b/linktools-ai/src/linktools/ai/model/_openai.py
@@ -4,21 +4,15 @@
 
 import math
 from dataclasses import dataclass, field
-from types import TracebackType
 from urllib.parse import urlsplit, urlunsplit
 
-import httpx2
 from linktools.core import environ
-from openai import AsyncOpenAI
 from pydantic_ai import ModelSettings
 from pydantic_ai.exceptions import UserError
-from pydantic_ai.models import DEFAULT_HTTP_TIMEOUT, Model
+from pydantic_ai.models import Model
 from pydantic_ai.models.openai import OpenAIChatModel
 from pydantic_ai.profiles import ModelProfile
-from pydantic_ai.providers import Provider
 from pydantic_ai.providers.openai import OpenAIProvider
-from pydantic_ai.retries import AsyncHTTPX2TenacityTransport, RetryConfig, wait_retry_after
-from tenacity import RetryCallState, retry_if_exception_type, stop_after_attempt, wait_fixed
 
 from ..core import JsonValue, canonical_sha256
 from ..errors import AIError, ErrorCode
@@ -34,7 +28,6 @@ class _OpenAIModelBinding:
     api_key: "str | None" = field(default=None, repr=False, compare=False)
     timeout: "float | None" = None
     max_retries: "int | None" = None
-    retry_delay: "float | None" = None
     max_tokens: "int | None" = None
     context_window: "int | None" = None
 
@@ -48,11 +41,8 @@ class _OpenAIModelBinding:
             object.__setattr__(self, "api_key", None)
         _validate_positive_number("timeout", self.timeout)
         _validate_non_negative_integer("max_retries", self.max_retries)
-        _validate_non_negative_number("retry_delay", self.retry_delay)
         _validate_positive_integer("max_tokens", self.max_tokens)
         _validate_positive_integer("context_window", self.context_window)
-        if self.retry_delay is not None and self.max_retries is None:
-            raise ValueError("retry_delay requires max_retries")
         if self.max_tokens is not None and self.context_window is not None and self.max_tokens > self.context_window:
             raise ValueError("max_tokens cannot exceed context_window")
 
@@ -84,20 +74,20 @@ class _OpenAIModelBinding:
 
     def materialize(self) -> Model:
         try:
-            provider = _openai_provider(
-                base_url=self.base_url,
-                api_key=self.api_key,
-                max_retries=self.max_retries,
-                retry_delay=self.retry_delay,
-            )
+            provider = OpenAIProvider(base_url=self.base_url, api_key=self.api_key)
+            if self.max_retries is not None:
+                provider.client.max_retries = self.max_retries
+
             settings: ModelSettings = {}
             if self.timeout is not None:
                 settings["timeout"] = self.timeout
             if self.max_tokens is not None:
                 settings["max_tokens"] = self.max_tokens
+
             profile: ModelProfile | None = None
             if self.context_window is not None:
                 profile = {"context_window": self.context_window}
+
             model = OpenAIChatModel(
                 self.model,
                 provider=provider,
@@ -122,166 +112,11 @@ class _OpenAIModelBinding:
         return model
 
 
-class _RetryingOpenAIProvider(Provider[AsyncOpenAI]):
-    def __init__(
-        self,
-        *,
-        base_url: "str | None",
-        api_key: "str | None",
-        max_retries: int,
-        retry_delay: float,
-    ) -> None:
-        self._base_url = base_url
-        self._api_key = api_key
-        self._max_retries = max_retries
-        self._retry_delay = retry_delay
-        self._entered_count = 0
-        self._http_client, self._delegate = self._build()
-
-    @property
-    def name(self) -> str:
-        return self._delegate.name
-
-    @property
-    def base_url(self) -> str:
-        return self._delegate.base_url
-
-    @property
-    def client(self) -> AsyncOpenAI:
-        return self._delegate.client
-
-    @staticmethod
-    def model_profile(model_name: str) -> ModelProfile | None:
-        return OpenAIProvider.model_profile(model_name)
-
-    async def __aenter__(self) -> "_RetryingOpenAIProvider":
-        if self._entered_count == 0 and self._http_client.is_closed:
-            self._http_client, self._delegate = self._build()
-        self._entered_count += 1
-        return self
-
-    async def __aexit__(
-        self,
-        exc_type: "type[BaseException] | None",
-        exc_value: "BaseException | None",
-        traceback: "TracebackType | None",
-    ) -> None:
-        del exc_type, exc_value, traceback
-        if self._entered_count == 0:
-            return
-        self._entered_count -= 1
-        if self._entered_count == 0:
-            await self._delegate.client.close()
-
-    def _build(self) -> "tuple[httpx2.AsyncClient, OpenAIProvider]":
-        http_client = _retry_http_client(
-            max_retries=self._max_retries,
-            retry_delay=self._retry_delay,
-        )
-        provider = OpenAIProvider(
-            base_url=self._base_url,
-            api_key=self._api_key,
-            http_client=http_client,
-        )
-        provider.client.max_retries = 0
-        return http_client, provider
-
-
-class _AsyncClientTransport(httpx2.AsyncBaseTransport):
-    def __init__(self, client: httpx2.AsyncClient) -> None:
-        self._client = client
-
-    async def handle_async_request(self, request: httpx2.Request) -> httpx2.Response:
-        response = await self._client.send(request, stream=True)
-        if _should_retry_response(response):
-            await response.aread()
-        return response
-
-    async def aclose(self) -> None:
-        await self._client.aclose()
-
-
-def _openai_provider(
-    *,
-    base_url: "str | None",
-    api_key: "str | None",
-    max_retries: "int | None",
-    retry_delay: "float | None",
-) -> Provider[AsyncOpenAI]:
-    if retry_delay is None:
-        provider = OpenAIProvider(base_url=base_url, api_key=api_key)
-        if max_retries is not None:
-            provider.client.max_retries = max_retries
-        return provider
-    if max_retries is None:
-        raise ValueError("retry_delay requires max_retries")
-    return _RetryingOpenAIProvider(
-        base_url=base_url,
-        api_key=api_key,
-        max_retries=max_retries,
-        retry_delay=retry_delay,
-    )
-
-
-def _retry_http_client(*, max_retries: int, retry_delay: float) -> httpx2.AsyncClient:
-    timeout = httpx2.Timeout(timeout=DEFAULT_HTTP_TIMEOUT, connect=5)
-    network_client = httpx2.AsyncClient(timeout=timeout)
-    transport = AsyncHTTPX2TenacityTransport(
-        config=RetryConfig(
-            retry=retry_if_exception_type((httpx2.HTTPStatusError, httpx2.TransportError)),
-            wait=wait_retry_after(fallback_strategy=wait_fixed(retry_delay)),
-            stop=stop_after_attempt(max_retries + 1),
-            retry_error_callback=_retry_error_result,
-        ),
-        wrapped=_AsyncClientTransport(network_client),
-        validate_response=_raise_retryable_status,
-    )
-    return httpx2.AsyncClient(
-        transport=transport,
-        timeout=timeout,
-    )
-
-
-def _retry_error_result(state: RetryCallState) -> httpx2.Response:
-    outcome = state.outcome
-    if outcome is None or not outcome.failed:
-        raise RuntimeError("retry exhausted without a failed attempt")
-    error = outcome.exception()
-    if isinstance(error, httpx2.HTTPStatusError):
-        return error.response
-    if error is None:
-        raise RuntimeError("retry exhausted without an exception")
-    raise error
-
-
-def _raise_retryable_status(response: httpx2.Response) -> None:
-    if _should_retry_response(response):
-        response.raise_for_status()
-
-
-def _should_retry_response(response: httpx2.Response) -> bool:
-    if response.status_code < 400:
-        return False
-    should_retry = response.headers.get("x-should-retry")
-    if should_retry == "false":
-        return False
-    if should_retry == "true":
-        return True
-    return response.status_code in {408, 409, 429} or response.status_code >= 500
-
-
 def _validate_positive_number(name: str, value: "float | None") -> None:
     if value is None:
         return
     if isinstance(value, bool) or not isinstance(value, (int, float)) or not math.isfinite(value) or value <= 0:
         raise ValueError(f"{name} must be a finite positive number")
-
-
-def _validate_non_negative_number(name: str, value: "float | None") -> None:
-    if value is None:
-        return
-    if isinstance(value, bool) or not isinstance(value, (int, float)) or not math.isfinite(value) or value < 0:
-        raise ValueError(f"{name} must be a finite non-negative number")
 
 
 def _validate_positive_integer(name: str, value: "int | None") -> None:

--- a/linktools-ai/src/linktools/ai/model/_registry.py
+++ b/linktools-ai/src/linktools/ai/model/_registry.py
@@ -29,7 +29,7 @@ class ModelRegistry:
         model: str,
         base_url: "str | None" = None,
         api_key: "str | None" = None,
-        timeout: "float | None" = None,
+        timeout: "int | float | None" = None,
         max_retries: "int | None" = None,
         max_tokens: "int | None" = None,
     ) -> "ModelRegistry":
@@ -60,7 +60,7 @@ class ModelRegistry:
         model: str,
         base_url: "str | None" = None,
         api_key: "str | None" = None,
-        timeout: "float | None" = None,
+        timeout: "int | float | None" = None,
         max_retries: "int | None" = None,
         max_tokens: "int | None" = None,
     ) -> None:

--- a/linktools-ai/src/linktools/ai/model/_registry.py
+++ b/linktools-ai/src/linktools/ai/model/_registry.py
@@ -7,16 +7,13 @@ from threading import RLock
 from types import MappingProxyType
 
 from linktools.core import environ
-from pydantic_ai.models import Model
 
-from ..core import JsonValue, canonical_sha256
+from ..core import JsonValue
 from ..errors import AIError, ErrorCode
 from ._contract import ModelBinding, ModelResolver
 from ._openai import _OpenAIModelBinding
 
 _logger = environ.get_logger("ai.model.registry")
-_MODEL_PAYLOAD_FIELDS = frozenset({"version", "provider", "model_identity", "settings"})
-_MODEL_SETTINGS_FIELDS = frozenset({"max_tokens", "context_window"})
 
 
 class ModelRegistry:
@@ -34,7 +31,6 @@ class ModelRegistry:
         api_key: "str | None" = None,
         timeout: "float | None" = None,
         max_retries: "int | None" = None,
-        retry_delay: "float | None" = None,
         max_tokens: "int | None" = None,
         context_window: "int | None" = None,
     ) -> "ModelRegistry":
@@ -46,7 +42,6 @@ class ModelRegistry:
             api_key=api_key,
             timeout=timeout,
             max_retries=max_retries,
-            retry_delay=retry_delay,
             max_tokens=max_tokens,
             context_window=context_window,
         )
@@ -69,7 +64,6 @@ class ModelRegistry:
         api_key: "str | None" = None,
         timeout: "float | None" = None,
         max_retries: "int | None" = None,
-        retry_delay: "float | None" = None,
         max_tokens: "int | None" = None,
         context_window: "int | None" = None,
     ) -> None:
@@ -81,7 +75,6 @@ class ModelRegistry:
                 api_key=api_key,
                 timeout=timeout,
                 max_retries=max_retries,
-                retry_delay=retry_delay,
                 max_tokens=max_tokens,
                 context_window=context_window,
             )
@@ -119,76 +112,16 @@ class _ModelRegistrySnapshot:
         semantic = dict(payload)
         if route_id is not None:
             preferred = self._bindings.get(route_id)
-            if preferred is not None:
-                restored = _restore_binding(preferred, semantic)
-                if restored is not None:
-                    return restored
+            if preferred is not None and dict(preferred.semantic_payload) == semantic:
+                return preferred
         matches = tuple(
-            restored
+            binding
             for _name, binding in sorted(self._bindings.items())
-            if (restored := _restore_binding(binding, semantic)) is not None
+            if dict(binding.semantic_payload) == semantic
         )
         if not matches:
             raise AIError(ErrorCode.MODEL_CONNECTION_NOT_FOUND)
         return matches[0]
-
-
-class _HistoricalModelBinding:
-    def __init__(self, current: ModelBinding, semantic_payload: "Mapping[str, JsonValue]") -> None:
-        self._current = current
-        self._semantic_payload = MappingProxyType(dict(semantic_payload))
-
-    @property
-    def route_id(self) -> str:
-        return self._current.route_id
-
-    @property
-    def provider(self) -> str:
-        return self._current.provider
-
-    @property
-    def model_identity(self) -> str:
-        return self._current.model_identity
-
-    @property
-    def semantic_payload(self) -> "Mapping[str, JsonValue]":
-        return self._semantic_payload
-
-    @property
-    def fingerprint(self) -> str:
-        return canonical_sha256({"contract": "model-v1", **self._semantic_payload})
-
-    def materialize(self) -> Model:
-        return self._current.materialize()
-
-
-def _restore_binding(binding: ModelBinding, semantic: "Mapping[str, JsonValue]") -> "ModelBinding | None":
-    current = dict(binding.semantic_payload)
-    if current == dict(semantic):
-        return binding
-    if _legacy_model_payload_matches(current, semantic):
-        return _HistoricalModelBinding(binding, semantic)
-    return None
-
-
-def _legacy_model_payload_matches(
-    current: "Mapping[str, JsonValue]",
-    historical: "Mapping[str, JsonValue]",
-) -> bool:
-    if set(current) != _MODEL_PAYLOAD_FIELDS or set(historical) != _MODEL_PAYLOAD_FIELDS:
-        return False
-    if current.get("version") != 1 or historical.get("version") != 1:
-        return False
-    if current.get("provider") != historical.get("provider") or current.get("model_identity") != historical.get("model_identity"):
-        return False
-    historical_settings = historical.get("settings")
-    current_settings = current.get("settings")
-    return (
-        isinstance(historical_settings, Mapping)
-        and not historical_settings
-        and isinstance(current_settings, Mapping)
-        and set(current_settings).issubset(_MODEL_SETTINGS_FIELDS)
-    )
 
 
 __all__ = ["ModelRegistry"]

--- a/linktools-ai/src/linktools/ai/model/_registry.py
+++ b/linktools-ai/src/linktools/ai/model/_registry.py
@@ -7,13 +7,16 @@ from threading import RLock
 from types import MappingProxyType
 
 from linktools.core import environ
+from pydantic_ai.models import Model
 
-from ..core import JsonValue
+from ..core import JsonValue, canonical_sha256
 from ..errors import AIError, ErrorCode
 from ._contract import ModelBinding, ModelResolver
 from ._openai import _OpenAIModelBinding
 
 _logger = environ.get_logger("ai.model.registry")
+_MODEL_PAYLOAD_FIELDS = frozenset({"version", "provider", "model_identity", "settings"})
+_MODEL_SETTINGS_FIELDS = frozenset({"max_tokens", "context_window"})
 
 
 class ModelRegistry:
@@ -29,11 +32,11 @@ class ModelRegistry:
         model: str,
         base_url: "str | None" = None,
         api_key: "str | None" = None,
-        timeout_seconds: "float | None" = None,
+        timeout: "float | None" = None,
         max_retries: "int | None" = None,
-        retry_delay_seconds: "float | None" = None,
-        max_output_tokens: "int | None" = None,
-        context_window_tokens: "int | None" = None,
+        retry_delay: "float | None" = None,
+        max_tokens: "int | None" = None,
+        context_window: "int | None" = None,
     ) -> "ModelRegistry":
         registry = cls()
         registry.register_openai(
@@ -41,11 +44,11 @@ class ModelRegistry:
             model=model,
             base_url=base_url,
             api_key=api_key,
-            timeout_seconds=timeout_seconds,
+            timeout=timeout,
             max_retries=max_retries,
-            retry_delay_seconds=retry_delay_seconds,
-            max_output_tokens=max_output_tokens,
-            context_window_tokens=context_window_tokens,
+            retry_delay=retry_delay,
+            max_tokens=max_tokens,
+            context_window=context_window,
         )
         return registry
 
@@ -64,11 +67,11 @@ class ModelRegistry:
         model: str,
         base_url: "str | None" = None,
         api_key: "str | None" = None,
-        timeout_seconds: "float | None" = None,
+        timeout: "float | None" = None,
         max_retries: "int | None" = None,
-        retry_delay_seconds: "float | None" = None,
-        max_output_tokens: "int | None" = None,
-        context_window_tokens: "int | None" = None,
+        retry_delay: "float | None" = None,
+        max_tokens: "int | None" = None,
+        context_window: "int | None" = None,
     ) -> None:
         self.register(
             _OpenAIModelBinding(
@@ -76,11 +79,11 @@ class ModelRegistry:
                 model=model,
                 base_url=base_url,
                 api_key=api_key,
-                timeout_seconds=timeout_seconds,
+                timeout=timeout,
                 max_retries=max_retries,
-                retry_delay_seconds=retry_delay_seconds,
-                max_output_tokens=max_output_tokens,
-                context_window_tokens=context_window_tokens,
+                retry_delay=retry_delay,
+                max_tokens=max_tokens,
+                context_window=context_window,
             )
         )
 
@@ -116,16 +119,76 @@ class _ModelRegistrySnapshot:
         semantic = dict(payload)
         if route_id is not None:
             preferred = self._bindings.get(route_id)
-            if preferred is not None and dict(preferred.semantic_payload) == semantic:
-                return preferred
+            if preferred is not None:
+                restored = _restore_binding(preferred, semantic)
+                if restored is not None:
+                    return restored
         matches = tuple(
-            binding
+            restored
             for _name, binding in sorted(self._bindings.items())
-            if dict(binding.semantic_payload) == semantic
+            if (restored := _restore_binding(binding, semantic)) is not None
         )
         if not matches:
             raise AIError(ErrorCode.MODEL_CONNECTION_NOT_FOUND)
         return matches[0]
+
+
+class _HistoricalModelBinding:
+    def __init__(self, current: ModelBinding, semantic_payload: "Mapping[str, JsonValue]") -> None:
+        self._current = current
+        self._semantic_payload = MappingProxyType(dict(semantic_payload))
+
+    @property
+    def route_id(self) -> str:
+        return self._current.route_id
+
+    @property
+    def provider(self) -> str:
+        return self._current.provider
+
+    @property
+    def model_identity(self) -> str:
+        return self._current.model_identity
+
+    @property
+    def semantic_payload(self) -> "Mapping[str, JsonValue]":
+        return self._semantic_payload
+
+    @property
+    def fingerprint(self) -> str:
+        return canonical_sha256({"contract": "model-v1", **self._semantic_payload})
+
+    def materialize(self) -> Model:
+        return self._current.materialize()
+
+
+def _restore_binding(binding: ModelBinding, semantic: "Mapping[str, JsonValue]") -> "ModelBinding | None":
+    current = dict(binding.semantic_payload)
+    if current == dict(semantic):
+        return binding
+    if _legacy_model_payload_matches(current, semantic):
+        return _HistoricalModelBinding(binding, semantic)
+    return None
+
+
+def _legacy_model_payload_matches(
+    current: "Mapping[str, JsonValue]",
+    historical: "Mapping[str, JsonValue]",
+) -> bool:
+    if set(current) != _MODEL_PAYLOAD_FIELDS or set(historical) != _MODEL_PAYLOAD_FIELDS:
+        return False
+    if current.get("version") != 1 or historical.get("version") != 1:
+        return False
+    if current.get("provider") != historical.get("provider") or current.get("model_identity") != historical.get("model_identity"):
+        return False
+    historical_settings = historical.get("settings")
+    current_settings = current.get("settings")
+    return (
+        isinstance(historical_settings, Mapping)
+        and not historical_settings
+        and isinstance(current_settings, Mapping)
+        and set(current_settings).issubset(_MODEL_SETTINGS_FIELDS)
+    )
 
 
 __all__ = ["ModelRegistry"]

--- a/linktools-ai/src/linktools/ai/model/_registry.py
+++ b/linktools-ai/src/linktools/ai/model/_registry.py
@@ -29,9 +29,24 @@ class ModelRegistry:
         model: str,
         base_url: "str | None" = None,
         api_key: "str | None" = None,
+        timeout_seconds: "float | None" = None,
+        max_retries: "int | None" = None,
+        retry_delay_seconds: "float | None" = None,
+        max_output_tokens: "int | None" = None,
+        context_window_tokens: "int | None" = None,
     ) -> "ModelRegistry":
         registry = cls()
-        registry.register_openai("default", model=model, base_url=base_url, api_key=api_key)
+        registry.register_openai(
+            "default",
+            model=model,
+            base_url=base_url,
+            api_key=api_key,
+            timeout_seconds=timeout_seconds,
+            max_retries=max_retries,
+            retry_delay_seconds=retry_delay_seconds,
+            max_output_tokens=max_output_tokens,
+            context_window_tokens=context_window_tokens,
+        )
         return registry
 
     def register(self, binding: ModelBinding) -> None:
@@ -49,8 +64,25 @@ class ModelRegistry:
         model: str,
         base_url: "str | None" = None,
         api_key: "str | None" = None,
+        timeout_seconds: "float | None" = None,
+        max_retries: "int | None" = None,
+        retry_delay_seconds: "float | None" = None,
+        max_output_tokens: "int | None" = None,
+        context_window_tokens: "int | None" = None,
     ) -> None:
-        self.register(_OpenAIModelBinding(route_id, model, base_url, api_key))
+        self.register(
+            _OpenAIModelBinding(
+                route_id=route_id,
+                model=model,
+                base_url=base_url,
+                api_key=api_key,
+                timeout_seconds=timeout_seconds,
+                max_retries=max_retries,
+                retry_delay_seconds=retry_delay_seconds,
+                max_output_tokens=max_output_tokens,
+                context_window_tokens=context_window_tokens,
+            )
+        )
 
     def remove(self, route_id: str) -> None:
         with self._lock:

--- a/linktools-ai/src/linktools/ai/model/_registry.py
+++ b/linktools-ai/src/linktools/ai/model/_registry.py
@@ -32,7 +32,6 @@ class ModelRegistry:
         timeout: "float | None" = None,
         max_retries: "int | None" = None,
         max_tokens: "int | None" = None,
-        context_window: "int | None" = None,
     ) -> "ModelRegistry":
         registry = cls()
         registry.register_openai(
@@ -43,7 +42,6 @@ class ModelRegistry:
             timeout=timeout,
             max_retries=max_retries,
             max_tokens=max_tokens,
-            context_window=context_window,
         )
         return registry
 
@@ -65,7 +63,6 @@ class ModelRegistry:
         timeout: "float | None" = None,
         max_retries: "int | None" = None,
         max_tokens: "int | None" = None,
-        context_window: "int | None" = None,
     ) -> None:
         self.register(
             _OpenAIModelBinding(
@@ -76,7 +73,6 @@ class ModelRegistry:
                 timeout=timeout,
                 max_retries=max_retries,
                 max_tokens=max_tokens,
-                context_window=context_window,
             )
         )
 

--- a/tests/ai/test_model_route_settings.py
+++ b/tests/ai/test_model_route_settings.py
@@ -6,9 +6,11 @@ from typing import Any
 
 import httpx2
 import pytest
+from linktools.ai.agent import AgentCompiler
 from linktools.ai.errors import AIError, ErrorCode
 from linktools.ai.model import ModelRegistry
 from linktools.ai.model._openai import _RetryingOpenAIProvider, _raise_retryable_status, _retry_error_result
+from linktools.ai.spec import AgentSpec
 from pydantic_ai.models.openai import OpenAIChatModel
 from pydantic_ai.providers.openai import OpenAIProvider
 from tenacity import RetryCallState, Retrying
@@ -72,6 +74,34 @@ def test_legacy_model_binding_restores_with_current_semantic_settings() -> None:
     assert dict(restored.semantic_payload) == dict(legacy.semantic_payload)
     assert restored.fingerprint == legacy.fingerprint
     model = restored.materialize()
+    assert model.settings == {"max_tokens": 2048}
+    assert model.profile.get("context_window") == 8192
+
+
+def test_legacy_agent_binding_restores_with_current_model_settings() -> None:
+    spec = AgentSpec("agent")
+    legacy_compiler = AgentCompiler(
+        model_resolver=ModelRegistry.openai(model="gpt-test").snapshot(),
+        candidates=(),
+        agents={"agent": spec},
+    )
+    legacy_binding = legacy_compiler.bind(legacy_compiler.compile(spec))
+    current_compiler = AgentCompiler(
+        model_resolver=ModelRegistry.openai(
+            model="gpt-test",
+            api_key="test-key",
+            max_tokens=2048,
+            context_window=8192,
+        ).snapshot(),
+        candidates=(),
+        agents={"agent": spec},
+    )
+
+    restored = current_compiler.restore(legacy_binding.snapshot)
+
+    assert restored.digest == legacy_binding.digest
+    assert restored.snapshot == legacy_binding.snapshot
+    model = restored.definition.model.materialize()
     assert model.settings == {"max_tokens": 2048}
     assert model.profile.get("context_window") == 8192
 

--- a/tests/ai/test_model_route_settings.py
+++ b/tests/ai/test_model_route_settings.py
@@ -4,21 +4,11 @@
 
 from typing import Any
 
-import httpx2
 import pytest
-from linktools.ai.agent import AgentCompiler
 from linktools.ai.errors import AIError, ErrorCode
 from linktools.ai.model import ModelRegistry
-from linktools.ai.model._openai import (
-    _AsyncClientTransport,
-    _RetryingOpenAIProvider,
-    _raise_retryable_status,
-    _retry_error_result,
-)
-from linktools.ai.spec import AgentSpec
 from pydantic_ai.models.openai import OpenAIChatModel
 from pydantic_ai.providers.openai import OpenAIProvider
-from tenacity import RetryCallState, Retrying
 
 
 def test_openai_operational_settings_do_not_change_durable_identity() -> None:
@@ -37,7 +27,6 @@ def test_openai_operational_settings_do_not_change_durable_identity() -> None:
         api_key="second-key",
         timeout=60,
         max_retries=3,
-        retry_delay=1,
         max_tokens=2048,
         context_window=8192,
     ).snapshot().resolve("default")
@@ -47,71 +36,22 @@ def test_openai_operational_settings_do_not_change_durable_identity() -> None:
 
 
 def test_openai_semantic_settings_change_durable_identity() -> None:
-    legacy = ModelRegistry.openai(model="gpt-test").snapshot().resolve("default")
+    plain = ModelRegistry.openai(model="gpt-test").snapshot().resolve("default")
     configured = ModelRegistry.openai(
         model="gpt-test",
         max_tokens=2048,
         context_window=8192,
     ).snapshot().resolve("default")
 
-    assert dict(legacy.semantic_payload)["settings"] == {}
+    assert dict(plain.semantic_payload)["settings"] == {}
     assert dict(configured.semantic_payload)["settings"] == {
         "max_tokens": 2048,
         "context_window": 8192,
     }
-    assert legacy.fingerprint != configured.fingerprint
+    assert plain.fingerprint != configured.fingerprint
 
 
-def test_legacy_model_binding_restores_with_current_semantic_settings() -> None:
-    legacy = ModelRegistry.openai(model="gpt-test").snapshot().resolve("default")
-    registry = ModelRegistry.openai(
-        model="gpt-test",
-        api_key="test-key",
-        max_tokens=2048,
-        context_window=8192,
-    )
-
-    restored = registry.snapshot().restore(
-        dict(legacy.semantic_payload),
-        route_id="default",
-    )
-
-    assert dict(restored.semantic_payload) == dict(legacy.semantic_payload)
-    assert restored.fingerprint == legacy.fingerprint
-    model = restored.materialize()
-    assert model.settings == {"max_tokens": 2048}
-    assert model.profile.get("context_window") == 8192
-
-
-def test_legacy_agent_binding_restores_with_current_model_settings() -> None:
-    spec = AgentSpec("agent")
-    legacy_compiler = AgentCompiler(
-        model_resolver=ModelRegistry.openai(model="gpt-test").snapshot(),
-        candidates=(),
-        agents={"agent": spec},
-    )
-    legacy_binding = legacy_compiler.bind(legacy_compiler.compile(spec))
-    current_compiler = AgentCompiler(
-        model_resolver=ModelRegistry.openai(
-            model="gpt-test",
-            api_key="test-key",
-            max_tokens=2048,
-            context_window=8192,
-        ).snapshot(),
-        candidates=(),
-        agents={"agent": spec},
-    )
-
-    restored = current_compiler.restore(legacy_binding.snapshot)
-
-    assert restored.digest == legacy_binding.digest
-    assert restored.snapshot == legacy_binding.snapshot
-    model = restored.definition.model.materialize()
-    assert model.settings == {"max_tokens": 2048}
-    assert model.profile.get("context_window") == 8192
-
-
-def test_new_model_binding_requires_exact_semantic_settings() -> None:
+def test_model_registry_restore_requires_exact_semantic_settings() -> None:
     historical = ModelRegistry.openai(
         model="gpt-test",
         max_tokens=1024,
@@ -130,7 +70,7 @@ def test_new_model_binding_requires_exact_semantic_settings() -> None:
     assert raised.value.code is ErrorCode.MODEL_CONNECTION_NOT_FOUND
 
 
-def test_openai_route_materializes_model_settings_and_profile() -> None:
+def test_openai_route_materializes_settings_profile_and_retries() -> None:
     binding = ModelRegistry.openai(
         model="gpt-test",
         api_key="test-key",
@@ -150,52 +90,6 @@ def test_openai_route_materializes_model_settings_and_profile() -> None:
     assert provider.client.max_retries == 1
 
 
-@pytest.mark.asyncio
-async def test_openai_retry_provider_owns_client_and_preserves_default_timeout() -> None:
-    binding = ModelRegistry.openai(
-        model="gpt-test",
-        api_key="test-key",
-        max_retries=2,
-        retry_delay=0,
-    ).snapshot().resolve("default")
-    model = binding.materialize()
-    provider = model.provider
-
-    assert isinstance(provider, _RetryingOpenAIProvider)
-    first_client = provider._http_client
-    assert provider.client.max_retries == 0
-    assert first_client.timeout.connect == 5
-    assert first_client.timeout.read == 600
-    assert not first_client.is_closed
-
-    async with model:
-        assert not first_client.is_closed
-    assert first_client.is_closed
-
-    async with model:
-        second_client = provider._http_client
-        assert second_client is not first_client
-        assert not second_client.is_closed
-    assert second_client.is_closed
-
-
-@pytest.mark.asyncio
-async def test_retryable_error_body_is_buffered_before_transport_closes_response() -> None:
-    async def handler(request: httpx2.Request) -> httpx2.Response:
-        return httpx2.Response(429, request=request, json={"error": "rate limited"})
-
-    client = httpx2.AsyncClient(transport=httpx2.MockTransport(handler))
-    transport = _AsyncClientTransport(client)
-    try:
-        response = await transport.handle_async_request(
-            httpx2.Request("POST", "https://example.test/v1/chat/completions")
-        )
-        assert response.is_stream_consumed
-        assert response.json() == {"error": "rate limited"}
-    finally:
-        await transport.aclose()
-
-
 @pytest.mark.parametrize(
     "kwargs",
     [
@@ -204,9 +98,6 @@ async def test_retryable_error_body_is_buffered_before_transport_closes_response
         {"timeout": True},
         {"max_retries": -1},
         {"max_retries": True},
-        {"retry_delay": -0.1, "max_retries": 1},
-        {"retry_delay": float("nan"), "max_retries": 1},
-        {"retry_delay": 1},
         {"max_tokens": 0},
         {"max_tokens": True},
         {"context_window": 0},
@@ -217,58 +108,3 @@ async def test_retryable_error_body_is_buffered_before_transport_closes_response
 def test_openai_route_rejects_invalid_settings(kwargs: dict[str, Any]) -> None:
     with pytest.raises(ValueError):
         ModelRegistry.openai(model="gpt-test", **kwargs)
-
-
-@pytest.mark.parametrize("status_code", [408, 409, 429, 500, 503])
-def test_retryable_http_statuses_raise(status_code: int) -> None:
-    request = httpx2.Request("POST", "https://example.test/v1/chat/completions")
-    response = httpx2.Response(status_code, request=request)
-
-    with pytest.raises(httpx2.HTTPStatusError):
-        _raise_retryable_status(response)
-
-
-@pytest.mark.parametrize("status_code", [400, 401, 403, 404, 422])
-def test_non_retryable_http_statuses_pass_through(status_code: int) -> None:
-    request = httpx2.Request("POST", "https://example.test/v1/chat/completions")
-    response = httpx2.Response(status_code, request=request)
-
-    _raise_retryable_status(response)
-
-
-def test_openai_retry_header_overrides_default_status_policy() -> None:
-    request = httpx2.Request("POST", "https://example.test/v1/chat/completions")
-    disabled = httpx2.Response(503, request=request, headers={"x-should-retry": "false"})
-    enabled = httpx2.Response(400, request=request, headers={"x-should-retry": "true"})
-
-    _raise_retryable_status(disabled)
-    with pytest.raises(httpx2.HTTPStatusError):
-        _raise_retryable_status(enabled)
-
-
-def test_exhausted_http_retry_returns_last_response() -> None:
-    request = httpx2.Request("POST", "https://example.test/v1/chat/completions")
-    response = httpx2.Response(429, request=request)
-    error = httpx2.HTTPStatusError(
-        "rate limited",
-        request=request,
-        response=response,
-    )
-
-    assert _retry_error_result(_failed_retry_state(error)) is response
-
-
-def test_exhausted_transport_retry_reraises_last_error() -> None:
-    request = httpx2.Request("POST", "https://example.test/v1/chat/completions")
-    error = httpx2.ConnectError("connection failed", request=request)
-
-    with pytest.raises(httpx2.ConnectError) as raised:
-        _retry_error_result(_failed_retry_state(error))
-
-    assert raised.value is error
-
-
-def _failed_retry_state(error: BaseException) -> RetryCallState:
-    state = RetryCallState(Retrying(), fn=None, args=(), kwargs={})
-    state.set_exception((type(error), error, None))
-    return state

--- a/tests/ai/test_model_route_settings.py
+++ b/tests/ai/test_model_route_settings.py
@@ -19,7 +19,6 @@ def test_openai_operational_settings_do_not_change_durable_identity() -> None:
         timeout=30,
         max_retries=1,
         max_tokens=2048,
-        context_window=8192,
     ).snapshot().resolve("default")
     second = ModelRegistry.openai(
         model="openai:gpt-test",
@@ -28,26 +27,21 @@ def test_openai_operational_settings_do_not_change_durable_identity() -> None:
         timeout=60,
         max_retries=3,
         max_tokens=2048,
-        context_window=8192,
     ).snapshot().resolve("default")
 
     assert dict(first.semantic_payload) == dict(second.semantic_payload)
     assert first.fingerprint == second.fingerprint
 
 
-def test_openai_semantic_settings_change_durable_identity() -> None:
+def test_openai_max_tokens_changes_durable_identity() -> None:
     plain = ModelRegistry.openai(model="gpt-test").snapshot().resolve("default")
     configured = ModelRegistry.openai(
         model="gpt-test",
         max_tokens=2048,
-        context_window=8192,
     ).snapshot().resolve("default")
 
     assert dict(plain.semantic_payload)["settings"] == {}
-    assert dict(configured.semantic_payload)["settings"] == {
-        "max_tokens": 2048,
-        "context_window": 8192,
-    }
+    assert dict(configured.semantic_payload)["settings"] == {"max_tokens": 2048}
     assert plain.fingerprint != configured.fingerprint
 
 
@@ -70,21 +64,19 @@ def test_model_registry_restore_requires_exact_semantic_settings() -> None:
     assert raised.value.code is ErrorCode.MODEL_CONNECTION_NOT_FOUND
 
 
-def test_openai_route_materializes_settings_profile_and_retries() -> None:
+def test_openai_route_materializes_settings_and_retries() -> None:
     binding = ModelRegistry.openai(
         model="gpt-test",
         api_key="test-key",
         timeout=30,
         max_retries=1,
         max_tokens=2048,
-        context_window=8192,
     ).snapshot().resolve("default")
 
     model = binding.materialize()
 
     assert isinstance(model, OpenAIChatModel)
     assert model.settings == {"timeout": 30, "max_tokens": 2048}
-    assert model.profile.get("context_window") == 8192
     provider = model.provider
     assert isinstance(provider, OpenAIProvider)
     assert provider.client.max_retries == 1
@@ -100,9 +92,6 @@ def test_openai_route_materializes_settings_profile_and_retries() -> None:
         {"max_retries": True},
         {"max_tokens": 0},
         {"max_tokens": True},
-        {"context_window": 0},
-        {"context_window": True},
-        {"max_tokens": 8193, "context_window": 8192},
     ],
 )
 def test_openai_route_rejects_invalid_settings(kwargs: dict[str, Any]) -> None:

--- a/tests/ai/test_model_route_settings.py
+++ b/tests/ai/test_model_route_settings.py
@@ -9,7 +9,12 @@ import pytest
 from linktools.ai.agent import AgentCompiler
 from linktools.ai.errors import AIError, ErrorCode
 from linktools.ai.model import ModelRegistry
-from linktools.ai.model._openai import _RetryingOpenAIProvider, _raise_retryable_status, _retry_error_result
+from linktools.ai.model._openai import (
+    _AsyncClientTransport,
+    _RetryingOpenAIProvider,
+    _raise_retryable_status,
+    _retry_error_result,
+)
 from linktools.ai.spec import AgentSpec
 from pydantic_ai.models.openai import OpenAIChatModel
 from pydantic_ai.providers.openai import OpenAIProvider
@@ -174,6 +179,23 @@ async def test_openai_retry_provider_owns_client_and_preserves_default_timeout()
     assert second_client.is_closed
 
 
+@pytest.mark.asyncio
+async def test_retryable_error_body_is_buffered_before_transport_closes_response() -> None:
+    async def handler(request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(429, request=request, json={"error": "rate limited"})
+
+    client = httpx2.AsyncClient(transport=httpx2.MockTransport(handler))
+    transport = _AsyncClientTransport(client)
+    try:
+        response = await transport.handle_async_request(
+            httpx2.Request("POST", "https://example.test/v1/chat/completions")
+        )
+        assert response.is_stream_consumed
+        assert response.json() == {"error": "rate limited"}
+    finally:
+        await transport.aclose()
+
+
 @pytest.mark.parametrize(
     "kwargs",
     [
@@ -212,6 +234,16 @@ def test_non_retryable_http_statuses_pass_through(status_code: int) -> None:
     response = httpx2.Response(status_code, request=request)
 
     _raise_retryable_status(response)
+
+
+def test_openai_retry_header_overrides_default_status_policy() -> None:
+    request = httpx2.Request("POST", "https://example.test/v1/chat/completions")
+    disabled = httpx2.Response(503, request=request, headers={"x-should-retry": "false"})
+    enabled = httpx2.Response(400, request=request, headers={"x-should-retry": "true"})
+
+    _raise_retryable_status(disabled)
+    with pytest.raises(httpx2.HTTPStatusError):
+        _raise_retryable_status(enabled)
 
 
 def test_exhausted_http_retry_returns_last_response() -> None:

--- a/tests/ai/test_model_route_settings.py
+++ b/tests/ai/test_model_route_settings.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Model route configuration coverage."""
+
+from typing import Any
+
+import httpx2
+import pytest
+from linktools.ai.model import ModelRegistry
+from linktools.ai.model._openai import _raise_retryable_status
+from pydantic_ai.models.openai import OpenAIChatModel
+from pydantic_ai.providers.openai import OpenAIProvider
+
+
+def test_openai_route_settings_do_not_change_durable_identity() -> None:
+    legacy = ModelRegistry.openai(
+        model="gpt-test",
+        base_url="https://legacy.example/v1",
+        api_key="legacy-key",
+    ).snapshot().resolve("default")
+    registry = ModelRegistry.openai(
+        model="openai:gpt-test",
+        base_url="https://current.example/v1",
+        api_key="current-key",
+        timeout_seconds=60,
+        max_retries=3,
+        retry_delay_seconds=1,
+        max_output_tokens=8192,
+        context_window_tokens=128000,
+    )
+    configured = registry.snapshot().resolve("default")
+
+    assert dict(configured.semantic_payload) == dict(legacy.semantic_payload)
+    assert configured.fingerprint == legacy.fingerprint
+    assert registry.snapshot().restore(
+        dict(legacy.semantic_payload),
+        route_id="default",
+    ) is configured
+
+
+def test_openai_route_materializes_model_settings_and_profile() -> None:
+    binding = ModelRegistry.openai(
+        model="gpt-test",
+        api_key="test-key",
+        timeout_seconds=30,
+        max_retries=1,
+        max_output_tokens=2048,
+        context_window_tokens=8192,
+    ).snapshot().resolve("default")
+
+    model = binding.materialize()
+
+    assert isinstance(model, OpenAIChatModel)
+    assert model.settings == {"timeout": 30, "max_tokens": 2048}
+    assert model.profile.get("context_window") == 8192
+    provider = model.provider
+    assert isinstance(provider, OpenAIProvider)
+    assert provider.client.max_retries == 1
+
+
+def test_openai_retry_delay_disables_sdk_retry_layer() -> None:
+    binding = ModelRegistry.openai(
+        model="gpt-test",
+        api_key="test-key",
+        max_retries=2,
+        retry_delay_seconds=0,
+    ).snapshot().resolve("default")
+
+    model = binding.materialize()
+
+    provider = model.provider
+    assert isinstance(provider, OpenAIProvider)
+    assert provider.client.max_retries == 0
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"timeout_seconds": 0},
+        {"timeout_seconds": float("inf")},
+        {"timeout_seconds": True},
+        {"max_retries": -1},
+        {"max_retries": True},
+        {"retry_delay_seconds": -0.1, "max_retries": 1},
+        {"retry_delay_seconds": float("nan"), "max_retries": 1},
+        {"retry_delay_seconds": 1},
+        {"max_output_tokens": 0},
+        {"max_output_tokens": True},
+        {"context_window_tokens": 0},
+        {"context_window_tokens": True},
+        {"max_output_tokens": 8193, "context_window_tokens": 8192},
+    ],
+)
+def test_openai_route_rejects_invalid_settings(kwargs: dict[str, Any]) -> None:
+    with pytest.raises(ValueError):
+        ModelRegistry.openai(model="gpt-test", **kwargs)
+
+
+@pytest.mark.parametrize("status_code", [408, 409, 429, 500, 503])
+def test_retryable_http_statuses_raise(status_code: int) -> None:
+    request = httpx2.Request("POST", "https://example.test/v1/chat/completions")
+    response = httpx2.Response(status_code, request=request)
+
+    with pytest.raises(httpx2.HTTPStatusError):
+        _raise_retryable_status(response)
+
+
+@pytest.mark.parametrize("status_code", [400, 401, 403, 404, 422])
+def test_non_retryable_http_statuses_pass_through(status_code: int) -> None:
+    request = httpx2.Request("POST", "https://example.test/v1/chat/completions")
+    response = httpx2.Response(status_code, request=request)
+
+    _raise_retryable_status(response)

--- a/tests/ai/test_model_route_settings.py
+++ b/tests/ai/test_model_route_settings.py
@@ -6,47 +6,103 @@ from typing import Any
 
 import httpx2
 import pytest
+from linktools.ai.errors import AIError, ErrorCode
 from linktools.ai.model import ModelRegistry
-from linktools.ai.model._openai import _raise_retryable_status, _retry_error_result
+from linktools.ai.model._openai import _RetryingOpenAIProvider, _raise_retryable_status, _retry_error_result
 from pydantic_ai.models.openai import OpenAIChatModel
 from pydantic_ai.providers.openai import OpenAIProvider
 from tenacity import RetryCallState, Retrying
 
 
-def test_openai_route_settings_do_not_change_durable_identity() -> None:
-    legacy = ModelRegistry.openai(
+def test_openai_operational_settings_do_not_change_durable_identity() -> None:
+    first = ModelRegistry.openai(
         model="gpt-test",
-        base_url="https://legacy.example/v1",
-        api_key="legacy-key",
+        base_url="https://first.example/v1",
+        api_key="first-key",
+        timeout=30,
+        max_retries=1,
+        max_tokens=2048,
+        context_window=8192,
     ).snapshot().resolve("default")
-    registry = ModelRegistry.openai(
+    second = ModelRegistry.openai(
         model="openai:gpt-test",
-        base_url="https://current.example/v1",
-        api_key="current-key",
-        timeout_seconds=60,
+        base_url="https://second.example/v1",
+        api_key="second-key",
+        timeout=60,
         max_retries=3,
-        retry_delay_seconds=1,
-        max_output_tokens=8192,
-        context_window_tokens=128000,
-    )
-    configured = registry.snapshot().resolve("default")
+        retry_delay=1,
+        max_tokens=2048,
+        context_window=8192,
+    ).snapshot().resolve("default")
 
-    assert dict(configured.semantic_payload) == dict(legacy.semantic_payload)
-    assert configured.fingerprint == legacy.fingerprint
-    assert registry.snapshot().restore(
+    assert dict(first.semantic_payload) == dict(second.semantic_payload)
+    assert first.fingerprint == second.fingerprint
+
+
+def test_openai_semantic_settings_change_durable_identity() -> None:
+    legacy = ModelRegistry.openai(model="gpt-test").snapshot().resolve("default")
+    configured = ModelRegistry.openai(
+        model="gpt-test",
+        max_tokens=2048,
+        context_window=8192,
+    ).snapshot().resolve("default")
+
+    assert dict(legacy.semantic_payload)["settings"] == {}
+    assert dict(configured.semantic_payload)["settings"] == {
+        "max_tokens": 2048,
+        "context_window": 8192,
+    }
+    assert legacy.fingerprint != configured.fingerprint
+
+
+def test_legacy_model_binding_restores_with_current_semantic_settings() -> None:
+    legacy = ModelRegistry.openai(model="gpt-test").snapshot().resolve("default")
+    registry = ModelRegistry.openai(
+        model="gpt-test",
+        api_key="test-key",
+        max_tokens=2048,
+        context_window=8192,
+    )
+
+    restored = registry.snapshot().restore(
         dict(legacy.semantic_payload),
         route_id="default",
-    ) is configured
+    )
+
+    assert dict(restored.semantic_payload) == dict(legacy.semantic_payload)
+    assert restored.fingerprint == legacy.fingerprint
+    model = restored.materialize()
+    assert model.settings == {"max_tokens": 2048}
+    assert model.profile.get("context_window") == 8192
+
+
+def test_new_model_binding_requires_exact_semantic_settings() -> None:
+    historical = ModelRegistry.openai(
+        model="gpt-test",
+        max_tokens=1024,
+    ).snapshot().resolve("default")
+    registry = ModelRegistry.openai(
+        model="gpt-test",
+        max_tokens=2048,
+    )
+
+    with pytest.raises(AIError) as raised:
+        registry.snapshot().restore(
+            dict(historical.semantic_payload),
+            route_id="default",
+        )
+
+    assert raised.value.code is ErrorCode.MODEL_CONNECTION_NOT_FOUND
 
 
 def test_openai_route_materializes_model_settings_and_profile() -> None:
     binding = ModelRegistry.openai(
         model="gpt-test",
         api_key="test-key",
-        timeout_seconds=30,
+        timeout=30,
         max_retries=1,
-        max_output_tokens=2048,
-        context_window_tokens=8192,
+        max_tokens=2048,
+        context_window=8192,
     ).snapshot().resolve("default")
 
     model = binding.materialize()
@@ -59,37 +115,51 @@ def test_openai_route_materializes_model_settings_and_profile() -> None:
     assert provider.client.max_retries == 1
 
 
-def test_openai_retry_delay_disables_sdk_retry_layer() -> None:
+@pytest.mark.asyncio
+async def test_openai_retry_provider_owns_client_and_preserves_default_timeout() -> None:
     binding = ModelRegistry.openai(
         model="gpt-test",
         api_key="test-key",
         max_retries=2,
-        retry_delay_seconds=0,
+        retry_delay=0,
     ).snapshot().resolve("default")
-
     model = binding.materialize()
-
     provider = model.provider
-    assert isinstance(provider, OpenAIProvider)
+
+    assert isinstance(provider, _RetryingOpenAIProvider)
+    first_client = provider._http_client
     assert provider.client.max_retries == 0
+    assert first_client.timeout.connect == 5
+    assert first_client.timeout.read == 600
+    assert not first_client.is_closed
+
+    async with model:
+        assert not first_client.is_closed
+    assert first_client.is_closed
+
+    async with model:
+        second_client = provider._http_client
+        assert second_client is not first_client
+        assert not second_client.is_closed
+    assert second_client.is_closed
 
 
 @pytest.mark.parametrize(
     "kwargs",
     [
-        {"timeout_seconds": 0},
-        {"timeout_seconds": float("inf")},
-        {"timeout_seconds": True},
+        {"timeout": 0},
+        {"timeout": float("inf")},
+        {"timeout": True},
         {"max_retries": -1},
         {"max_retries": True},
-        {"retry_delay_seconds": -0.1, "max_retries": 1},
-        {"retry_delay_seconds": float("nan"), "max_retries": 1},
-        {"retry_delay_seconds": 1},
-        {"max_output_tokens": 0},
-        {"max_output_tokens": True},
-        {"context_window_tokens": 0},
-        {"context_window_tokens": True},
-        {"max_output_tokens": 8193, "context_window_tokens": 8192},
+        {"retry_delay": -0.1, "max_retries": 1},
+        {"retry_delay": float("nan"), "max_retries": 1},
+        {"retry_delay": 1},
+        {"max_tokens": 0},
+        {"max_tokens": True},
+        {"context_window": 0},
+        {"context_window": True},
+        {"max_tokens": 8193, "context_window": 8192},
     ],
 )
 def test_openai_route_rejects_invalid_settings(kwargs: dict[str, Any]) -> None:

--- a/tests/ai/test_model_route_settings.py
+++ b/tests/ai/test_model_route_settings.py
@@ -7,9 +7,10 @@ from typing import Any
 import httpx2
 import pytest
 from linktools.ai.model import ModelRegistry
-from linktools.ai.model._openai import _raise_retryable_status
+from linktools.ai.model._openai import _raise_retryable_status, _retry_error_result
 from pydantic_ai.models.openai import OpenAIChatModel
 from pydantic_ai.providers.openai import OpenAIProvider
+from tenacity import RetryCallState, Retrying
 
 
 def test_openai_route_settings_do_not_change_durable_identity() -> None:
@@ -111,3 +112,31 @@ def test_non_retryable_http_statuses_pass_through(status_code: int) -> None:
     response = httpx2.Response(status_code, request=request)
 
     _raise_retryable_status(response)
+
+
+def test_exhausted_http_retry_returns_last_response() -> None:
+    request = httpx2.Request("POST", "https://example.test/v1/chat/completions")
+    response = httpx2.Response(429, request=request)
+    error = httpx2.HTTPStatusError(
+        "rate limited",
+        request=request,
+        response=response,
+    )
+
+    assert _retry_error_result(_failed_retry_state(error)) is response
+
+
+def test_exhausted_transport_retry_reraises_last_error() -> None:
+    request = httpx2.Request("POST", "https://example.test/v1/chat/completions")
+    error = httpx2.ConnectError("connection failed", request=request)
+
+    with pytest.raises(httpx2.ConnectError) as raised:
+        _retry_error_result(_failed_retry_state(error))
+
+    assert raised.value is error
+
+
+def _failed_retry_state(error: BaseException) -> RetryCallState:
+    state = RetryCallState(Retrying(), fn=None, args=(), kwargs={})
+    state.set_exception((type(error), error, None))
+    return state


### PR DESCRIPTION
## Summary

- add `timeout`, `max_retries`, and `max_tokens` to OpenAI model route registration
- map `timeout` and `max_tokens` to Pydantic AI model-level settings
- map `max_retries` to the OpenAI SDK client retry policy
- keep operational route settings out of durable model identity while treating `max_tokens` as semantic
- preserve strict semantic restore behavior without compatibility wrappers or transport abstractions

## Tests

- cover operational settings keeping a stable durable identity
- cover `max_tokens` changing durable identity and strict restore matching
- cover materialization into Pydantic AI / OpenAI SDK settings
- cover invalid route setting validation

No dependency version changes are included.