### PR TITLE
fix(ai): adapt step persistence to latest harness

### DIFF
--- a/linktools-ai/linktools.yml
+++ b/linktools-ai/linktools.yml
@@ -5,7 +5,7 @@ dependencies:
   - filelock>=3.4.0
   - jsonschema>=4.23.0,<5.0.0
   - pydantic-ai-slim[mcp,openai]>=2.33.0,<3.0.0
-  - pydantic-ai-harness[dynamic-workflow]>=0.26.0
+  - pydantic-ai-harness[dynamic-workflow]>=0.26.0,<0.28.1
   - PyYAML>=6.0,<7.0
 
 dev-dependencies:

--- a/linktools-ai/linktools.yml
+++ b/linktools-ai/linktools.yml
@@ -5,7 +5,7 @@ dependencies:
   - filelock>=3.4.0
   - jsonschema>=4.23.0,<5.0.0
   - pydantic-ai-slim[mcp,openai]>=2.33.0,<3.0.0
-  - pydantic-ai-harness[dynamic-workflow]>=0.26.0,<0.28.1
+  - pydantic-ai-harness[dynamic-workflow]>=0.26.0
   - PyYAML>=6.0,<7.0
 
 dev-dependencies:

--- a/linktools-ai/src/linktools/ai/runtime/_capabilities.py
+++ b/linktools-ai/src/linktools/ai/runtime/_capabilities.py
@@ -210,31 +210,40 @@ class _MissingToolOperationBridge:
         raise AIError(ErrorCode.RUNTIME_DEPENDENCY_NOT_READY)
 
 
+@dataclass(kw_only=True)
 class _RuntimeStepPersistence(StepPersistence[None]):
-    def __init__(
-        self,
-        *,
-        tool_operations: ToolOperationBridge,
-        plan_mode: bool = False,
-        trusted_tool_classes: "tuple[tuple[str, str], ...]" = (),
-        trusted_mcp_selectors: "tuple[str, ...]" = (),
-        background_tasks: "set[asyncio.Task[Any]] | None" = None,
-        deferred_pause_sink: "Callable[[int], None] | None" = None,
-        **kwargs: Any,
-    ) -> None:
-        if not isinstance(plan_mode, bool):
+    tool_operations: ToolOperationBridge = field(repr=False, compare=False)
+    plan_mode: bool = False
+    trusted_tool_classes: "tuple[tuple[str, str], ...]" = ()
+    trusted_mcp_selectors: "tuple[str, ...]" = ()
+    background_tasks: "set[asyncio.Task[Any]]" = field(
+        default_factory=set,
+        repr=False,
+        compare=False,
+    )
+    deferred_pause_sink: "Callable[[int], None] | None" = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
+    _calls: "dict[tuple[str, str], _ToolCallState]" = field(
+        default_factory=dict,
+        init=False,
+        repr=False,
+        compare=False,
+    )
+    _last_observed_step_index: "int | None" = field(
+        default=None,
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.plan_mode, bool):
             raise AIError(ErrorCode.REQUEST_FIELD_INVALID)
-        _validate_trusted_tool_classes(trusted_tool_classes)
-        _validate_trusted_mcp_selectors(trusted_mcp_selectors)
-        super().__init__(**kwargs)
-        self._tool_operations = tool_operations
-        self._plan_mode = plan_mode
-        self._trusted_tool_classes = trusted_tool_classes
-        self._trusted_mcp_selectors = trusted_mcp_selectors
-        self._calls: dict[tuple[str, str], _ToolCallState] = {}
-        self._background_tasks = set() if background_tasks is None else background_tasks
-        self._deferred_pause_sink = deferred_pause_sink
-        self._last_observed_step_index: int | None = None
+        _validate_trusted_tool_classes(self.trusted_tool_classes)
+        _validate_trusted_mcp_selectors(self.trusted_mcp_selectors)
 
     async def after_node_run(
         self,
@@ -259,9 +268,9 @@ class _RuntimeStepPersistence(StepPersistence[None]):
                 raise AIError(ErrorCode.CAPABILITY_POLICY_CONFLICT)
             if self._last_observed_step_index is None:
                 raise AIError(ErrorCode.STORAGE_INTEGRITY_ERROR)
-            if self._deferred_pause_sink is None:
+            if self.deferred_pause_sink is None:
                 raise AIError(ErrorCode.RUNTIME_DEPENDENCY_NOT_READY)
-            self._deferred_pause_sink(self._last_observed_step_index)
+            self.deferred_pause_sink(self._last_observed_step_index)
         return await super().after_run(ctx, result=result)
 
     async def after_model_request(
@@ -299,10 +308,10 @@ class _RuntimeStepPersistence(StepPersistence[None]):
         args: dict[str, Any],
     ) -> dict[str, Any]:
         del ctx, call
-        if self._plan_mode and not tool_allowed_in_planning(
+        if self.plan_mode and not tool_allowed_in_planning(
             tool_def,
-            trusted_tool_classes=self._trusted_tool_classes,
-            trusted_mcp_selectors=self._trusted_mcp_selectors,
+            trusted_tool_classes=self.trusted_tool_classes,
+            trusted_mcp_selectors=self.trusted_mcp_selectors,
         ):
             raise AIError(
                 ErrorCode.CAPABILITY_POLICY_CONFLICT,
@@ -322,10 +331,10 @@ class _RuntimeStepPersistence(StepPersistence[None]):
     ) -> Any:
         policy = _tool_effect_policy(
             tool_def,
-            trusted_tool_classes=self._trusted_tool_classes,
+            trusted_tool_classes=self.trusted_tool_classes,
         )
         try:
-            decision = await self._tool_operations.begin(
+            decision = await self.tool_operations.begin(
                 ctx,
                 call,
                 tool_def,
@@ -414,7 +423,7 @@ class _RuntimeStepPersistence(StepPersistence[None]):
             finally:
                 state.handler_observed = True
             try:
-                cancelled = await self._tool_operations.complete(
+                cancelled = await self.tool_operations.complete(
                     state.decision,
                     result,
                 )
@@ -430,7 +439,7 @@ class _RuntimeStepPersistence(StepPersistence[None]):
             return result
         except SkipToolExecution as signal:
             state.preserve_started = True
-            cancelled = await self._tool_operations.complete(
+            cancelled = await self.tool_operations.complete(
                 state.decision,
                 signal.result,
             )
@@ -611,7 +620,7 @@ class _RuntimeStepPersistence(StepPersistence[None]):
                 await self._mark_unknown(state, error)
                 raise ToolFailed(_MODEL_EFFECT_UNKNOWN_MESSAGE) from error
             state.preserve_started = True
-            cancelled = await self._tool_operations.fail(state.decision, error)
+            cancelled = await self.tool_operations.fail(state.decision, error)
             state.operation_terminalized = True
             state.preserve_started = False
             if cancelled:
@@ -638,7 +647,7 @@ class _RuntimeStepPersistence(StepPersistence[None]):
             await asyncio.sleep(15)
             if handler_task.done():
                 return
-            state.decision = await self._tool_operations.renew(state.decision)
+            state.decision = await self.tool_operations.renew(state.decision)
 
     async def _stop_heartbeat(self, state: _ToolCallState) -> None:
         task = state.heartbeat_task
@@ -655,15 +664,15 @@ class _RuntimeStepPersistence(StepPersistence[None]):
         if task.done():
             self._consume_task(task, label)
             return
-        if task in self._background_tasks:
+        if task in self.background_tasks:
             return
-        self._background_tasks.add(task)
+        self.background_tasks.add(task)
 
         def consume(done: asyncio.Task[Any]) -> None:
             try:
                 self._consume_task(done, label)
             finally:
-                self._background_tasks.discard(done)
+                self.background_tasks.discard(done)
 
         task.add_done_callback(consume)
 
@@ -690,7 +699,7 @@ class _RuntimeStepPersistence(StepPersistence[None]):
     ) -> Any:
         state.preserve_started = True
         durable_error = _durable_failure_error(error, call=call, tool_def=tool_def)
-        cancelled = await self._tool_operations.fail(state.decision, durable_error)
+        cancelled = await self.tool_operations.fail(state.decision, durable_error)
         state.operation_terminalized = True
         state.preserve_started = False
         if cancelled:
@@ -769,7 +778,7 @@ class _RuntimeStepPersistence(StepPersistence[None]):
     async def _mark_unknown(self, state: _ToolCallState, error: BaseException) -> None:
         state.preserve_started = True
         state.operation_terminalized = True
-        await self._tool_operations.unknown(state.decision, error)
+        await self.tool_operations.unknown(state.decision, error)
 
     def _decision_key(self, ctx: "RunContext[None]", call: ToolCallPart) -> tuple[str, str]:
         return self._effective_run_id(ctx), call.tool_call_id

--- a/linktools-ai/src/linktools/ai/runtime/_capabilities.py
+++ b/linktools-ai/src/linktools/ai/runtime/_capabilities.py
@@ -210,7 +210,7 @@ class _MissingToolOperationBridge:
         raise AIError(ErrorCode.RUNTIME_DEPENDENCY_NOT_READY)
 
 
-@dataclass(kw_only=True)
+@dataclass(kw_only=True, eq=False)
 class _RuntimeStepPersistence(StepPersistence[None]):
     tool_operations: ToolOperationBridge = field(repr=False, compare=False)
     plan_mode: bool = False

--- a/tests/ai/test_step_persistence_harness_compat.py
+++ b/tests/ai/test_step_persistence_harness_compat.py
@@ -1,6 +1,8 @@
 from types import SimpleNamespace
+from typing import Any, cast
 
 import pytest
+from pydantic_ai.tools import RunContext
 
 from linktools.ai.runtime._capabilities import (
     _MissingToolOperationBridge,
@@ -11,14 +13,14 @@ from linktools.ai.runtime._capabilities import (
 @pytest.mark.asyncio
 async def test_runtime_step_persistence_for_run_preserves_config_and_resets_state() -> None:
     bridge = _MissingToolOperationBridge()
-    background_tasks: set[object] = set()
+    background_tasks: set[Any] = set()
     pauses: list[int] = []
     pause_sink = pauses.append
     persistence = _RuntimeStepPersistence(
         tool_operations=bridge,
         run_id="run",
         plan_mode=True,
-        background_tasks=background_tasks,  # type: ignore[arg-type]
+        background_tasks=background_tasks,
         deferred_pause_sink=pause_sink,
     )
     calls = persistence._calls
@@ -26,7 +28,8 @@ async def test_runtime_step_persistence_for_run_preserves_config_and_resets_stat
     persistence._event_sequence = 3
     persistence._snapshot_sequence = 4
 
-    materialized = await persistence.for_run(SimpleNamespace(run_id="ignored"))  # type: ignore[arg-type]
+    ctx = cast(RunContext[None], SimpleNamespace(run_id="ignored"))
+    materialized = await persistence.for_run(ctx)
 
     assert isinstance(materialized, _RuntimeStepPersistence)
     assert materialized is not persistence

--- a/tests/ai/test_step_persistence_harness_compat.py
+++ b/tests/ai/test_step_persistence_harness_compat.py
@@ -18,7 +18,6 @@ async def test_runtime_step_persistence_for_run_preserves_config_and_resets_stat
     pause_sink = pauses.append
     persistence = _RuntimeStepPersistence(
         tool_operations=bridge,
-        run_id="run",
         plan_mode=True,
         background_tasks=background_tasks,
         deferred_pause_sink=pause_sink,
@@ -26,11 +25,12 @@ async def test_runtime_step_persistence_for_run_preserves_config_and_resets_stat
     calls = persistence._calls
     persistence._last_observed_step_index = 7
 
-    ctx = cast(RunContext[None], SimpleNamespace(run_id="ignored"))
+    ctx = cast(RunContext[None], SimpleNamespace(run_id="run"))
     materialized = await persistence.for_run(ctx)
 
     assert isinstance(materialized, _RuntimeStepPersistence)
     assert materialized is not persistence
+    assert materialized.run_id == "run"
     assert materialized.tool_operations is bridge
     assert materialized.plan_mode is True
     assert materialized.background_tasks is background_tasks

--- a/tests/ai/test_step_persistence_harness_compat.py
+++ b/tests/ai/test_step_persistence_harness_compat.py
@@ -1,0 +1,40 @@
+from types import SimpleNamespace
+
+import pytest
+
+from linktools.ai.runtime._capabilities import (
+    _MissingToolOperationBridge,
+    _RuntimeStepPersistence,
+)
+
+
+@pytest.mark.asyncio
+async def test_runtime_step_persistence_for_run_preserves_config_and_resets_state() -> None:
+    bridge = _MissingToolOperationBridge()
+    background_tasks: set[object] = set()
+    pauses: list[int] = []
+    persistence = _RuntimeStepPersistence(
+        tool_operations=bridge,
+        run_id="run",
+        plan_mode=True,
+        background_tasks=background_tasks,  # type: ignore[arg-type]
+        deferred_pause_sink=pauses.append,
+    )
+    calls = persistence._calls
+    persistence._last_observed_step_index = 7
+    persistence._event_sequence = 3
+    persistence._snapshot_sequence = 4
+
+    materialized = await persistence.for_run(SimpleNamespace(run_id="ignored"))  # type: ignore[arg-type]
+
+    assert isinstance(materialized, _RuntimeStepPersistence)
+    assert materialized is not persistence
+    assert materialized.tool_operations is bridge
+    assert materialized.plan_mode is True
+    assert materialized.background_tasks is background_tasks
+    assert materialized.deferred_pause_sink is pauses.append
+    assert materialized._calls == {}
+    assert materialized._calls is not calls
+    assert materialized._last_observed_step_index is None
+    assert materialized._event_sequence == 0
+    assert materialized._snapshot_sequence == 0

--- a/tests/ai/test_step_persistence_harness_compat.py
+++ b/tests/ai/test_step_persistence_harness_compat.py
@@ -13,12 +13,13 @@ async def test_runtime_step_persistence_for_run_preserves_config_and_resets_stat
     bridge = _MissingToolOperationBridge()
     background_tasks: set[object] = set()
     pauses: list[int] = []
+    pause_sink = pauses.append
     persistence = _RuntimeStepPersistence(
         tool_operations=bridge,
         run_id="run",
         plan_mode=True,
         background_tasks=background_tasks,  # type: ignore[arg-type]
-        deferred_pause_sink=pauses.append,
+        deferred_pause_sink=pause_sink,
     )
     calls = persistence._calls
     persistence._last_observed_step_index = 7
@@ -32,7 +33,7 @@ async def test_runtime_step_persistence_for_run_preserves_config_and_resets_stat
     assert materialized.tool_operations is bridge
     assert materialized.plan_mode is True
     assert materialized.background_tasks is background_tasks
-    assert materialized.deferred_pause_sink is pauses.append
+    assert materialized.deferred_pause_sink is pause_sink
     assert materialized._calls == {}
     assert materialized._calls is not calls
     assert materialized._last_observed_step_index is None

--- a/tests/ai/test_step_persistence_harness_compat.py
+++ b/tests/ai/test_step_persistence_harness_compat.py
@@ -25,8 +25,6 @@ async def test_runtime_step_persistence_for_run_preserves_config_and_resets_stat
     )
     calls = persistence._calls
     persistence._last_observed_step_index = 7
-    persistence._event_sequence = 3
-    persistence._snapshot_sequence = 4
 
     ctx = cast(RunContext[None], SimpleNamespace(run_id="ignored"))
     materialized = await persistence.for_run(ctx)
@@ -40,5 +38,3 @@ async def test_runtime_step_persistence_for_run_preserves_config_and_resets_stat
     assert materialized._calls == {}
     assert materialized._calls is not calls
     assert materialized._last_observed_step_index is None
-    assert materialized._event_sequence == 0
-    assert materialized._snapshot_sequence == 0


### PR DESCRIPTION
## Summary

- adapt `_RuntimeStepPersistence` to the `StepPersistence` dataclass copy contract used by `pydantic-ai-harness` 0.28.1
- keep the existing open-ended `pydantic-ai-harness[dynamic-workflow]>=0.26.0` dependency so fresh installs resolve the latest release
- preserve runtime-owned configuration across `for_run()` copies while resetting linktools-owned run-local state
- add a regression test covering the run-scoped copy behavior without depending on harness private fields

## Root cause

`pydantic-ai-harness` 0.28.1 changed `StepPersistence.for_run()` to always materialize a replay-safe run-scoped copy with `dataclasses.replace()`. Linktools' `_RuntimeStepPersistence` inherited from that dataclass but used a custom initializer for additional required runtime configuration, so `replace()` could not reconstruct the subclass.

The fix makes `_RuntimeStepPersistence` a normal keyword-only dataclass subclass. Runtime configuration is represented as dataclass fields, while `_calls` and the last observed step index remain linktools-owned run-local `init=False` state and are reinitialized on each copy.

## Tests

- assert `for_run()` returns a distinct `_RuntimeStepPersistence`
- assert runtime configuration and shared background-task ownership are preserved
- assert linktools-owned tool-call state and observed step index reset on the run-scoped copy
- avoid assertions against `pydantic-ai-harness` private sequence fields
- full Python CI runs against the latest resolvable harness release