### PR TITLE
refactor(ai): unify runtime observation api

### DIFF
--- a/linktools-ai/src/linktools/ai/acp.py
+++ b/linktools-ai/src/linktools/ai/acp.py
@@ -130,7 +130,10 @@ class ACPAgent:
             session_id=session_id,
             memory_scope=self._memory_scope,
         )
-        async for event in execution.stream():
+        async for item in execution.watch():
+            if item.depth != 0:
+                continue
+            event = item.event
             if self._connection is not None:
                 update = _acp_update(schema, event.event_type, event.payload)
                 if update is not None:

--- a/linktools-ai/src/linktools/ai/runtime/__init__.py
+++ b/linktools-ai/src/linktools/ai/runtime/__init__.py
@@ -17,6 +17,7 @@ from ._object import RuntimeObjectKeyFactory, put_runtime_object, read_runtime_o
 from ._planner import DefaultTaskService, RuntimeTaskNodeRunner
 from ._runtime_history import RuntimeHistory
 from ._runtime_service import Runtime
+from ._task import TaskGraphRun
 from ._session import DefaultSessionService
 from ._snapshot import RunSnapshot, snapshot_digest
 from .service_api import (
@@ -69,6 +70,7 @@ from .service_api import (
     SessionView,
     TaskEvent,
     TaskEventType,
+    TaskGraphRunEvent,
     TaskService,
     TranscriptItem,
     UpdateSessionRequest,
@@ -163,6 +165,8 @@ __all__ = [
     "StoredUserInput",
     "TaskEvent",
     "TaskEventType",
+    "TaskGraphRun",
+    "TaskGraphRunEvent",
     "TaskService",
     "TranscriptItem",
     "UpdateSessionRequest",

--- a/linktools-ai/src/linktools/ai/runtime/_agent.py
+++ b/linktools-ai/src/linktools/ai/runtime/_agent.py
@@ -16,7 +16,6 @@ from .service_api import (
     EvaluationHandle,
     ExecutionHistoryItem,
     ExecutionResult,
-    ExecutionStreamEvent,
     ExecutionTraceItem,
     ExecutionTreeEvent,
     ReplayEvaluationRequest,
@@ -47,14 +46,7 @@ class Execution(Generic[AppT]):
             timeout_seconds=timeout_seconds,
         )
 
-    def stream(self, *, after_sequence: int = 0) -> AsyncIterator[ExecutionStreamEvent]:
-        return self._runtime._execution_stream(
-            self.execution_id,
-            principal=self._principal,
-            after_sequence=after_sequence,
-        )
-
-    def stream_tree(
+    def watch(
         self,
         *,
         after_sequences: "Mapping[str, int] | None" = None,

--- a/linktools-ai/src/linktools/ai/runtime/_evaluation.py
+++ b/linktools-ai/src/linktools/ai/runtime/_evaluation.py
@@ -157,7 +157,7 @@ class DefaultEvaluationService:
             if record is None:
                 if existing is not None and existing.status is IdempotencyStatus.COMPLETED:
                     raise AIError(ErrorCode.STORAGE_INTEGRITY_ERROR)
-                execution = await self._execution.run(
+                execution = await self._execution.start(
                     binding_digest,
                     ExecutionRequest(
                         user_prompt=f"evaluation:{request.dataset_digest}",
@@ -267,7 +267,7 @@ class DefaultEvaluationService:
             record = await self._synchronize(await self._authorized(snapshot_id, request.principal, AuthorizationAction.EVALUATION_READ), principal=request.principal)
             if record.binding_digest != binding_digest:
                 raise AIError(ErrorCode.EVALUATION_INCOMPATIBLE)
-            handle = await self._execution.run(
+            handle = await self._execution.start(
                 binding_digest,
                 ExecutionRequest(
                     user_prompt=f"replay:{record.evaluation_id}",

--- a/linktools-ai/src/linktools/ai/runtime/_execution.py
+++ b/linktools-ai/src/linktools/ai/runtime/_execution.py
@@ -577,7 +577,7 @@ class DefaultExecutionService:
             if owner:
                 await self._run_handoff_cleanup(execution_id, tenant_id, state)
 
-    async def run(self, binding_digest: str, request: ExecutionRequest) -> ExecutionHandle:
+    async def start(self, binding_digest: str, request: ExecutionRequest) -> ExecutionHandle:
         return await self._start(
             binding_digest,
             request,
@@ -672,7 +672,7 @@ class DefaultExecutionService:
             return ExecutionHandle(execution.execution_id)
         raise AIError(ErrorCode.STORAGE_INTEGRITY_ERROR)
 
-    async def run_for_session(
+    async def start_for_session(
         self,
         agent_id: str,
         binding_digest: str,
@@ -1518,8 +1518,8 @@ class DefaultExecutionService:
         except asyncio.TimeoutError as error:
             raise AIError(ErrorCode.EXECUTION_WAIT_TIMEOUT) from error
 
-    async def run_and_wait(self, binding_digest: str, request: ExecutionRequest, *, timeout_seconds: "float | None" = None) -> ExecutionResult:
-        handle = await self.run(binding_digest, request)
+    async def run(self, binding_digest: str, request: ExecutionRequest, *, timeout_seconds: "float | None" = None) -> ExecutionResult:
+        handle = await self.start(binding_digest, request)
         return await self.wait(handle.execution_id, principal=request.principal, timeout_seconds=timeout_seconds)
 
     async def retry(self, binding_digest: str, execution_id: str, request: RetryExecutionRequest) -> ExecutionHandle:

--- a/linktools-ai/src/linktools/ai/runtime/_factory.py
+++ b/linktools-ai/src/linktools/ai/runtime/_factory.py
@@ -92,7 +92,6 @@ class _RuntimeComponents:
     artifact: DefaultArtifactService
     tenant_id: str
     close_callback: Callable[[], Awaitable[None]]
-    local_coordinator: _LocalRuntimeCoordinator
     task_node_runtime: RuntimeTaskNodeRunner[object]
     metric_control: _RuntimeMetricBuffer | None
 
@@ -731,7 +730,6 @@ async def _build_local_components(
         artifact=artifact,
         tenant_id=tenant_id,
         close_callback=coordinator.close,
-        local_coordinator=local_coordinator,
         task_node_runtime=cast("RuntimeTaskNodeRunner[object]", task_runner),
         metric_control=metric_buffer,
     )

--- a/linktools-ai/src/linktools/ai/runtime/_planner.py
+++ b/linktools-ai/src/linktools/ai/runtime/_planner.py
@@ -232,7 +232,7 @@ class _AgentTaskNodeHandler:
         )
         key = (principal.tenant_id, graph_id, node.node_id)
         launch_task = asyncio.create_task(
-            self._execution.run(binding_digest, request),
+            self._execution.start(binding_digest, request),
             name=f"task-execution-launch-{graph_id}-{node.node_id}",
         )
         self._active_launch_tasks[key] = launch_task

--- a/linktools-ai/src/linktools/ai/runtime/_runtime_service.py
+++ b/linktools-ai/src/linktools/ai/runtime/_runtime_service.py
@@ -52,6 +52,7 @@ from ..task import (
 )
 from ..workspace import Workspace
 from ._agent import Agent, Execution, Session
+from ._task import TaskGraphRun
 from ._context import RuntimeContext
 from ._input import CanonicalUserInput, task_prompt_draft
 from ._metrics import (
@@ -71,7 +72,6 @@ from .service_api import (
     EventService,
     ExecutionRequest,
     ExecutionService,
-    ExecutionStreamEvent,
     ForkExecutionRequest,
     ForkSessionRequest,
     ReplayEvaluationRequest,
@@ -87,16 +87,6 @@ from .state import RuntimeState
 
 _logger = environ.get_logger("ai.runtime")
 AppT = TypeVar("AppT")
-
-
-class _LocalRuntimeCoordinatorPort(Protocol):
-    def stream(
-        self,
-        execution_id: str,
-        *,
-        principal: Principal,
-        after_sequence: int = 0,
-    ) -> AsyncIterator[ExecutionStreamEvent]: ...
 
 
 class _TaskNodeRuntimePort(Protocol):
@@ -170,7 +160,6 @@ class Runtime(Generic[AppT]):
         workspace: Workspace,
         context: RuntimeContext[AppT],
         close_callback: "Callable[[], Awaitable[None]] | None" = None,
-        local_coordinator: "_LocalRuntimeCoordinatorPort | None" = None,
         task_node_runtime: "_TaskNodeRuntimePort | None" = None,
         metric_control: "_RuntimeMetricControl | None" = None,
     ) -> None:
@@ -209,7 +198,6 @@ class Runtime(Generic[AppT]):
             kind=PrincipalKind.LOCAL_TRUSTED.value,
         )
         self._close_callback = close_callback
-        self._local_coordinator = local_coordinator
         self._task_node_runtime = task_node_runtime
         self._metric_control = metric_control
         self._closed = False
@@ -394,7 +382,7 @@ class Runtime(Generic[AppT]):
             files=resolved_files,
         )
         if session_id is None:
-            handle = await self.execution.run(binding.digest, request)
+            handle = await self.execution.start(binding.digest, request)
         else:
             if not isinstance(session_id, str) or not session_id.strip():
                 raise AIError(ErrorCode.REQUEST_FIELD_INVALID)
@@ -426,27 +414,6 @@ class Runtime(Generic[AppT]):
             resolved_thinking,
         )
         return Execution(self, handle.execution_id, binding.digest, resolved_principal)
-
-    def _execution_stream(
-        self,
-        execution_id: str,
-        *,
-        principal: Principal,
-        after_sequence: int = 0,
-    ) -> AsyncIterator[ExecutionStreamEvent]:
-        self._ensure_open()
-        validate_resource_id(execution_id)
-        if self._local_coordinator is not None:
-            return self._local_coordinator.stream(
-                execution_id,
-                principal=principal,
-                after_sequence=after_sequence,
-            )
-        return self.event.stream(
-            execution_id,
-            principal=principal,
-            after_sequence=after_sequence,
-        )
 
     async def _retry_execution(
         self,
@@ -668,7 +635,7 @@ class Runtime(Generic[AppT]):
             budget_cost=budget_cost,
         )
 
-    async def run_graph(
+    async def start_graph(
         self,
         graph: TaskGraph,
         *,
@@ -676,7 +643,7 @@ class Runtime(Generic[AppT]):
         idempotency_key: str,
         limits: "TaskGraphLimits | None" = None,
         correlation: "Mapping[str, object] | None" = None,
-    ) -> TaskGraphResult:
+    ) -> "TaskGraphRun[AppT]":
         request = await self._admit_graph(
             graph,
             principal=principal,
@@ -684,9 +651,10 @@ class Runtime(Generic[AppT]):
             limits=limits,
             correlation=correlation,
         )
-        return await self.task.run_graph(request)
+        await self.task.start_graph(request)
+        return TaskGraphRun(self, graph.graph_id, request.principal)
 
-    async def run_graph_and_wait(
+    async def run_graph(
         self,
         graph: TaskGraph,
         *,
@@ -696,17 +664,14 @@ class Runtime(Generic[AppT]):
         timeout_seconds: "float | None" = None,
         correlation: "Mapping[str, object] | None" = None,
     ) -> TaskGraphResult:
-        request = await self._admit_graph(
+        run = await self.start_graph(
             graph,
             principal=principal,
             idempotency_key=idempotency_key,
             limits=limits,
             correlation=correlation,
         )
-        return await self.task.run_graph_and_wait(
-            request,
-            timeout_seconds=timeout_seconds,
-        )
+        return await run.wait(timeout_seconds=timeout_seconds)
 
     async def read_task_result(
         self,
@@ -717,7 +682,7 @@ class Runtime(Generic[AppT]):
     ) -> JsonValue:
         self._ensure_open()
         resolved_principal = self._resolve_principal(principal)
-        snapshot = await self.task.inspect_graph_state(
+        snapshot = await self.task.snapshot_graph(
             graph_id,
             principal=resolved_principal,
         )
@@ -966,7 +931,6 @@ async def _open_runtime(
             workspace=workspace,
             context=context,
             close_callback=components.close_callback,
-            local_coordinator=components.local_coordinator,
             task_node_runtime=components.task_node_runtime,
             metric_control=components.metric_control,
         )

--- a/linktools-ai/src/linktools/ai/runtime/_session.py
+++ b/linktools-ai/src/linktools/ai/runtime/_session.py
@@ -70,7 +70,7 @@ class _SessionReleaseCallback(Protocol):
 
 
 class _SessionExecutionService(ExecutionService, Protocol):
-    async def run_for_session(
+    async def start_for_session(
         self,
         agent_id: str,
         binding_digest: str,
@@ -377,7 +377,7 @@ class DefaultSessionService:
                 files=request.files,
             )
             try:
-                return await self._execution.run_for_session(
+                return await self._execution.start_for_session(
                     agent_id,
                     binding_digest,
                     session_id,

--- a/linktools-ai/src/linktools/ai/runtime/_task.py
+++ b/linktools-ai/src/linktools/ai/runtime/_task.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Runtime-bound TaskGraph behavior and complete observation projection."""
+
+import asyncio
+import secrets
+from collections.abc import AsyncIterator, Mapping
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Generic, TypeVar
+
+from ..core import Principal
+from ..errors import AIError, ErrorCode
+from ..task import (
+    CancelGraphRequest,
+    TaskEvent,
+    TaskGraphResult,
+    TaskGraphSnapshot,
+    TaskGraphView,
+)
+from .service_api import ExecutionTreeEvent, TaskGraphRunEvent
+
+if TYPE_CHECKING:
+    from ._runtime_service import Runtime
+
+AppT = TypeVar("AppT")
+
+
+@dataclass(frozen=True, slots=True)
+class TaskGraphRun(Generic[AppT]):
+    _runtime: "Runtime[AppT]"
+    graph_id: str
+    _principal: Principal
+
+    async def wait(
+        self,
+        *,
+        timeout_seconds: "float | None" = None,
+    ) -> TaskGraphResult:
+        return await self._runtime.task.wait_graph(
+            self.graph_id,
+            principal=self._principal,
+            timeout_seconds=timeout_seconds,
+        )
+
+    async def inspect(self) -> TaskGraphView:
+        return await self._runtime.task.inspect_graph(
+            self.graph_id,
+            principal=self._principal,
+        )
+
+    async def snapshot(self) -> TaskGraphSnapshot:
+        return await self._runtime.task.snapshot_graph(
+            self.graph_id,
+            principal=self._principal,
+        )
+
+    async def cancel(
+        self,
+        *,
+        idempotency_key: "str | None" = None,
+        force: bool = False,
+    ) -> TaskGraphView:
+        return await self._runtime.task.cancel_graph(
+            self.graph_id,
+            CancelGraphRequest(
+                self._principal,
+                idempotency_key or secrets.token_urlsafe(32),
+                force,
+            ),
+        )
+
+    def watch(
+        self,
+        *,
+        after_graph_sequence: int = 0,
+        after_execution_sequences: (
+            "Mapping[str, Mapping[str, int]] | None"
+        ) = None,
+    ) -> AsyncIterator[TaskGraphRunEvent]:
+        if (
+            isinstance(after_graph_sequence, bool)
+            or not isinstance(after_graph_sequence, int)
+            or after_graph_sequence < 0
+        ):
+            raise AIError(ErrorCode.REQUEST_FIELD_INVALID)
+        return self._watch(
+            after_graph_sequence=after_graph_sequence,
+            after_execution_sequences=_normalize_execution_sequences(
+                after_execution_sequences
+            ),
+        )
+
+    async def _watch(
+        self,
+        *,
+        after_graph_sequence: int,
+        after_execution_sequences: Mapping[str, Mapping[str, int]],
+    ) -> AsyncIterator[TaskGraphRunEvent]:
+        snapshot = await self.snapshot()
+        states = {state.node_id: state for state in snapshot.node_states}
+        if len(states) != len(snapshot.node_states):
+            raise AIError(ErrorCode.STORAGE_INTEGRITY_ERROR)
+        if set(after_execution_sequences) - set(states):
+            raise AIError(ErrorCode.REQUEST_FIELD_INVALID)
+
+        graph_stream = self._runtime.task.stream_graph_events(
+            self.graph_id,
+            principal=self._principal,
+            after_sequence=after_graph_sequence,
+        )
+        graph_task: "asyncio.Task[TaskEvent] | None" = asyncio.create_task(
+            graph_stream.__anext__(),
+            name=f"task-run-graph-{self.graph_id}",
+        )
+        execution_ids: dict[str, str] = {}
+        execution_streams: dict[str, AsyncIterator[ExecutionTreeEvent]] = {}
+        execution_tasks: dict[str, asyncio.Task[ExecutionTreeEvent]] = {}
+
+        def start_execution(node_id: str, execution_id: str) -> None:
+            current = execution_ids.get(node_id)
+            if current is not None:
+                if current != execution_id:
+                    raise AIError(ErrorCode.STORAGE_INTEGRITY_ERROR)
+                return
+            execution_ids[node_id] = execution_id
+            stream = self._runtime.execution.stream_tree(
+                execution_id,
+                principal=self._principal,
+                after_sequences=after_execution_sequences.get(node_id),
+            )
+            execution_streams[node_id] = stream
+            execution_tasks[node_id] = asyncio.create_task(
+                stream.__anext__(),
+                name=f"task-run-execution-{self.graph_id}-{node_id}",
+            )
+
+        if after_graph_sequence > 0 or after_execution_sequences:
+            for node_id, state in states.items():
+                sequences = after_execution_sequences.get(node_id)
+                if sequences and state.execution_id is None:
+                    raise AIError(ErrorCode.REQUEST_FIELD_INVALID)
+                if state.execution_id is not None:
+                    start_execution(node_id, state.execution_id)
+
+        try:
+            while graph_task is not None or execution_tasks:
+                waiters = list(execution_tasks.values())
+                if graph_task is not None:
+                    waiters.append(graph_task)
+                done, _ = await asyncio.wait(
+                    waiters,
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+
+                if graph_task is not None and graph_task in done:
+                    task = graph_task
+                    graph_task = None
+                    try:
+                        event = task.result()
+                    except StopAsyncIteration:
+                        pass
+                    else:
+                        yield TaskGraphRunEvent(self.graph_id, event.node_id, event)
+                        if event.execution_id is not None:
+                            if event.node_id is None:
+                                raise AIError(ErrorCode.STORAGE_INTEGRITY_ERROR)
+                            start_execution(event.node_id, event.execution_id)
+                        graph_task = asyncio.create_task(
+                            graph_stream.__anext__(),
+                            name=f"task-run-graph-{self.graph_id}",
+                        )
+
+                ready = sorted(
+                    (node_id, task)
+                    for node_id, task in execution_tasks.items()
+                    if task in done
+                )
+                for node_id, task in ready:
+                    execution_tasks.pop(node_id, None)
+                    try:
+                        event = task.result()
+                    except StopAsyncIteration:
+                        execution_streams.pop(node_id, None)
+                        continue
+                    yield TaskGraphRunEvent(self.graph_id, node_id, event)
+                    stream = execution_streams[node_id]
+                    execution_tasks[node_id] = asyncio.create_task(
+                        stream.__anext__(),
+                        name=f"task-run-execution-{self.graph_id}-{node_id}",
+                    )
+        finally:
+            tasks = list(execution_tasks.values())
+            if graph_task is not None:
+                tasks.append(graph_task)
+            for task in tasks:
+                if not task.done():
+                    task.cancel()
+            if tasks:
+                await asyncio.gather(*tasks, return_exceptions=True)
+            close = getattr(graph_stream, "aclose", None)
+            if close is not None:
+                await close()
+            for stream in tuple(execution_streams.values()):
+                close = getattr(stream, "aclose", None)
+                if close is not None:
+                    await close()
+
+
+def _normalize_execution_sequences(
+    value: "Mapping[str, Mapping[str, int]] | None",
+) -> Mapping[str, Mapping[str, int]]:
+    if value is None:
+        return {}
+    if not isinstance(value, Mapping):
+        raise AIError(ErrorCode.REQUEST_FIELD_INVALID)
+    result: dict[str, Mapping[str, int]] = {}
+    for node_id, sequences in value.items():
+        if (
+            not isinstance(node_id, str)
+            or not node_id
+            or not isinstance(sequences, Mapping)
+        ):
+            raise AIError(ErrorCode.REQUEST_FIELD_INVALID)
+        normalized: dict[str, int] = {}
+        for execution_id, sequence in sequences.items():
+            if (
+                not isinstance(execution_id, str)
+                or not execution_id
+                or isinstance(sequence, bool)
+                or not isinstance(sequence, int)
+                or sequence < 0
+            ):
+                raise AIError(ErrorCode.REQUEST_FIELD_INVALID)
+            normalized[execution_id] = sequence
+        result[node_id] = normalized
+    return result
+
+
+__all__ = ["TaskGraphRun"]

--- a/linktools-ai/src/linktools/ai/runtime/service_api.py
+++ b/linktools-ai/src/linktools/ai/runtime/service_api.py
@@ -709,6 +709,33 @@ class ExecutionTreeEvent:
 
 
 @dataclass(frozen=True, slots=True)
+class TaskGraphRunEvent:
+    graph_id: str
+    node_id: "str | None"
+    event: "TaskEvent | ExecutionTreeEvent"
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.graph_id, str) or not self.graph_id.strip():
+            raise ValueError("task graph run event graph id is required")
+        if self.node_id is not None and (
+            not isinstance(self.node_id, str) or not self.node_id.strip()
+        ):
+            raise ValueError("task graph run event node id is invalid")
+        if isinstance(self.event, TaskEvent):
+            if (
+                self.event.graph_id != self.graph_id
+                or self.event.node_id != self.node_id
+            ):
+                raise ValueError("task graph run event task identity is invalid")
+            return
+        if isinstance(self.event, ExecutionTreeEvent):
+            if self.node_id is None:
+                raise ValueError("task run execution event requires a node id")
+            return
+        raise TypeError("task graph run event payload is invalid")
+
+
+@dataclass(frozen=True, slots=True)
 class ArtifactView:
     artifact_id: str
     execution_id: str
@@ -752,7 +779,7 @@ class ExecutionHistoryService(Protocol):
 
 
 class ExecutionService(Protocol):
-    async def run(
+    async def start(
         self, binding_digest: str, request: ExecutionRequest
     ) -> ExecutionHandle: ...
     async def resolve_existing(
@@ -780,7 +807,7 @@ class ExecutionService(Protocol):
         principal: Principal,
         timeout_seconds: "float | None" = None,
     ) -> ExecutionResult: ...
-    async def run_and_wait(
+    async def run(
         self,
         binding_digest: str,
         request: ExecutionRequest,
@@ -856,14 +883,14 @@ class SessionService(Protocol):
 
 
 class TaskService(Protocol):
-    async def run_graph(self, request: TaskGraphRequest) -> TaskGraphResult: ...
-    async def run_graph_and_wait(
+    async def start_graph(self, request: TaskGraphRequest) -> TaskGraphResult: ...
+    async def run_graph(
         self, request: TaskGraphRequest, *, timeout_seconds: "float | None" = None
     ) -> TaskGraphResult: ...
     async def inspect_graph(
         self, graph_id: str, *, principal: Principal
     ) -> TaskGraphView: ...
-    async def inspect_graph_state(
+    async def snapshot_graph(
         self,
         graph_id: str,
         *,
@@ -1013,6 +1040,7 @@ __all__ = [
     "SessionView",
     "TaskEvent",
     "TaskEventType",
+    "TaskGraphRunEvent",
     "TaskService",
     "ToolApprovalContext",
     "TranscriptItem",

--- a/linktools-ai/src/linktools/ai/task/_service.py
+++ b/linktools-ai/src/linktools/ai/task/_service.py
@@ -26,7 +26,7 @@ class TaskQueryApi(Protocol):
         principal: Principal,
     ) -> TaskGraphView: ...
 
-    async def inspect_graph_state(
+    async def snapshot_graph(
         self,
         graph_id: str,
         *,
@@ -60,9 +60,9 @@ class TaskQueryApi(Protocol):
 
 
 class TaskApi(TaskQueryApi, Protocol):
-    async def run_graph(self, request: TaskGraphRequest) -> TaskGraphResult: ...
+    async def start_graph(self, request: TaskGraphRequest) -> TaskGraphResult: ...
 
-    async def run_graph_and_wait(
+    async def run_graph(
         self,
         request: TaskGraphRequest,
         *,

--- a/linktools-ai/src/linktools/ai/task/_service_impl.py
+++ b/linktools-ai/src/linktools/ai/task/_service_impl.py
@@ -229,10 +229,10 @@ class DefaultTaskService(TaskApi):
         self._detached_finalizers: set[asyncio.Task[object]] = set()
         self._detached_finalizer_failure: AIError | None = None
 
-    async def run_graph(self, request: TaskGraphRequest) -> TaskGraphResult:
-        return await self._run_graph(request)
+    async def start_graph(self, request: TaskGraphRequest) -> TaskGraphResult:
+        return await self._start_graph(request)
 
-    async def _run_graph(
+    async def _start_graph(
         self,
         request: TaskGraphRequest,
     ) -> TaskGraphResult:
@@ -345,13 +345,13 @@ class DefaultTaskService(TaskApi):
             cursor = page.next_cursor
         _logger.info("task graph recovery scan completed: graphs=%s", recovered)
 
-    async def run_graph_and_wait(
+    async def run_graph(
         self,
         request: TaskGraphRequest,
         *,
         timeout_seconds: "float | None" = None,
     ) -> TaskGraphResult:
-        submitted = await self._run_graph(request)
+        submitted = await self._start_graph(request)
         return await self.wait_graph(
             submitted.graph_id,
             principal=request.principal,
@@ -383,7 +383,7 @@ class DefaultTaskService(TaskApi):
             raise AIError(ErrorCode.STORAGE_INTEGRITY_ERROR)
         return view
 
-    async def inspect_graph_state(
+    async def snapshot_graph(
         self,
         graph_id: str,
         *,

--- a/linktools-ai/src/linktools/commands/ai/run.py
+++ b/linktools-ai/src/linktools/commands/ai/run.py
@@ -168,8 +168,10 @@ async def _emit_result(
     terminal_error_code: object = None
     terminal_safe_details: object = {}
     try:
-        async for event in execution.stream():
-            execution_id = event.execution_id
+        async for item in execution.watch():
+            if item.depth != 0:
+                continue
+            event = item.event
             if event.event_type is ExecutionDeltaType.ASSISTANT_TEXT_DELTA:
                 text = event.payload.get("text") if isinstance(event.payload, dict) else None
                 if isinstance(text, str):

--- a/tests/ai/persistence/test_execution_start_service.py
+++ b/tests/ai/persistence/test_execution_start_service.py
@@ -178,8 +178,8 @@ async def test_execution_start_claim_has_one_launcher_winner() -> None:
             memory_scope="test",
         )
         first, second = await asyncio.gather(
-            service.run("a" * 64, request),
-            service.run("a" * 64, request),
+            service.start("a" * 64, request),
+            service.start("a" * 64, request),
         )
         assert first.execution_id == second.execution_id
         assert launcher.calls == 1
@@ -212,7 +212,7 @@ async def test_sql_execution_start_keeps_attempt_sequence_zero(tmp_path) -> None
     await state.initialize(namespace="sql-start", tenant_id="tenant")
     try:
         service = _service(state, backend=_Launcher(state.execution.executions))
-        handle = await service.run(
+        handle = await service.start(
             "b" * 64,
             _request("hello", Principal("owner", "tenant"), "sql-start-key"),
         )
@@ -230,7 +230,7 @@ async def test_filesystem_execution_start_keeps_attempt_sequence_zero(tmp_path) 
     await state.initialize(namespace="filesystem-start", tenant_id="tenant")
     try:
         service = _service(state, backend=_Launcher(state.execution.executions))
-        handle = await service.run(
+        handle = await service.start(
             "c" * 64,
             _request(
                 "hello",
@@ -299,7 +299,7 @@ async def test_execution_memory_scope_can_be_disabled_but_not_blank() -> None:
     try:
         service = _service(state, backend=_Launcher(state.execution.executions))
         principal = Principal("owner", "tenant")
-        handle = await service.run(
+        handle = await service.start(
             "a" * 64,
             _request("without memory", principal, "without-memory"),
         )
@@ -312,7 +312,7 @@ async def test_execution_memory_scope_can_be_disabled_but_not_blank() -> None:
 
         for value in ("", "  "):
             with pytest.raises(AIError) as error:
-                await service.run(
+                await service.start(
                     "a" * 64,
                     _request(
                         "invalid memory",

--- a/tests/ai/test_agent_composition.py
+++ b/tests/ai/test_agent_composition.py
@@ -129,7 +129,7 @@ class _CaptureSessionExecution:
         self.binding_digest: str | None = None
         self.session_id: str | None = None
 
-    async def run_for_session(
+    async def start_for_session(
         self,
         agent_id: str,
         binding_digest: str,

--- a/tests/ai/test_error_cancellation_contract.py
+++ b/tests/ai/test_error_cancellation_contract.py
@@ -123,7 +123,7 @@ async def test_task_runner_cancellation_does_not_business_cancel_running_executi
             self.wait_cancelled = asyncio.Event()
             self.cancel_called = asyncio.Event()
 
-        async def run(self, *args, **kwargs):
+        async def start(self, *args, **kwargs):
             del args, kwargs
             return SimpleNamespace(execution_id="execution")
 
@@ -185,7 +185,7 @@ async def test_task_runner_binds_execution_that_finishes_launch_after_caller_can
             self.release_launch = asyncio.Event()
             self.cancel_called = asyncio.Event()
 
-        async def run(self, *args, **kwargs):
+        async def start(self, *args, **kwargs):
             del args, kwargs
             self.launch_started.set()
             await self.release_launch.wait()
@@ -249,7 +249,7 @@ async def test_task_runner_start_unknown_after_caller_cancel_blocks_shutdown() -
             self.launch_started = asyncio.Event()
             self.release_launch = asyncio.Event()
 
-        async def run(self, *args, **kwargs):
+        async def start(self, *args, **kwargs):
             del args, kwargs
             self.launch_started.set()
             await self.release_launch.wait()

--- a/tests/ai/test_error_contract_matrix.py
+++ b/tests/ai/test_error_contract_matrix.py
@@ -11,6 +11,7 @@ import pytest
 from linktools.ai.core import (
     ExecutionDeltaType,
     ExecutionEventType,
+    ExecutionLineageKind,
     ExecutionStatus,
     JsonValue,
     Principal,
@@ -27,6 +28,7 @@ from linktools.ai.runtime import (
     DefaultExecutionService,
     ExecutionResult,
     ExecutionStreamEvent,
+    ExecutionTreeEvent,
 )
 from linktools.ai.runtime._agent_executor import (
     DurableBoundary,
@@ -365,20 +367,27 @@ class _FailedRuntime:
 class _StreamingExecution:
     execution_id = "streaming-execution"
 
-    def stream(self) -> AsyncIterator[ExecutionStreamEvent]:
-        async def events() -> AsyncIterator[ExecutionStreamEvent]:
-            yield ExecutionStreamEvent(
-                self.execution_id,
-                1,
-                ExecutionDeltaType.ASSISTANT_TEXT_DELTA,
-                {"text": "hello"},
-            )
-            yield ExecutionStreamEvent(
-                self.execution_id,
-                2,
-                ExecutionEventType.EXECUTION_SUCCEEDED,
-                {},
-            )
+    def watch(self) -> AsyncIterator[ExecutionTreeEvent]:
+        async def events() -> AsyncIterator[ExecutionTreeEvent]:
+            for sequence, event_type, payload in (
+                (1, ExecutionDeltaType.ASSISTANT_TEXT_DELTA, {"text": "hello"}),
+                (2, ExecutionEventType.EXECUTION_SUCCEEDED, {}),
+            ):
+                yield ExecutionTreeEvent(
+                    self.execution_id,
+                    "agent",
+                    ExecutionLineageKind.RUN,
+                    None,
+                    self.execution_id,
+                    None,
+                    0,
+                    ExecutionStreamEvent(
+                        self.execution_id,
+                        sequence,
+                        event_type,
+                        payload,
+                    ),
+                )
 
         return events()
 

--- a/tests/ai/test_runtime_persistence_evidence.py
+++ b/tests/ai/test_runtime_persistence_evidence.py
@@ -244,7 +244,10 @@ async def test_terminal_stream_allows_immediate_runtime_close(
         ) as runtime:
             execution = await runtime.agent("default").start("hello")
             terminal_events = []
-            async for event in execution.stream():
+            async for item in execution.watch():
+                if item.depth != 0:
+                    continue
+                event = item.event
                 if event.event_type in {
                     ExecutionEventType.EXECUTION_SUCCEEDED,
                     ExecutionEventType.EXECUTION_FAILED,

--- a/tests/ai/test_runtime_watch_api.py
+++ b/tests/ai/test_runtime_watch_api.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from datetime import datetime, timezone
+
+import pytest
+
+from linktools.ai.core import (
+    ExecutionEventType,
+    ExecutionLineageKind,
+    Principal,
+    TaskStatus,
+)
+from linktools.ai.runtime import Execution, TaskGraphRun, TaskGraphRunEvent
+from linktools.ai.runtime.service_api import (
+    ExecutionStreamEvent,
+    ExecutionTreeEvent,
+)
+from linktools.ai.task import TaskEvent, TaskEventType
+
+
+class _ExecutionService:
+    def stream_tree(
+        self,
+        execution_id: str,
+        *,
+        principal: Principal,
+        after_sequences=None,
+    ):
+        del principal, after_sequences
+
+        async def values():
+            yield ExecutionTreeEvent(
+                execution_id,
+                "agent",
+                ExecutionLineageKind.RUN,
+                None,
+                execution_id,
+                None,
+                0,
+                ExecutionStreamEvent(
+                    execution_id,
+                    1,
+                    ExecutionEventType.EXECUTION_SUCCEEDED,
+                    {},
+                ),
+            )
+
+        return values()
+
+
+class _TaskService:
+    async def snapshot_graph(self, graph_id: str, *, principal: Principal):
+        del principal
+
+        class Snapshot:
+            node_states = ()
+
+        assert graph_id == "graph"
+        return Snapshot()
+
+    def stream_graph_events(
+        self,
+        graph_id: str,
+        *,
+        principal: Principal,
+        after_sequence: int = 0,
+    ):
+        del principal
+
+        async def values():
+            now = datetime.now(timezone.utc)
+            yield TaskEvent(
+                1,
+                graph_id,
+                after_sequence + 1,
+                TaskEventType.GRAPH_ADMITTED,
+                now,
+                TaskStatus.PENDING,
+            )
+            yield TaskEvent(
+                1,
+                graph_id,
+                after_sequence + 2,
+                TaskEventType.NODE_CHANGED,
+                now,
+                TaskStatus.RUNNING,
+                TaskStatus.READY,
+                "node",
+                "worker",
+                1,
+                "execution",
+            )
+            yield TaskEvent(
+                1,
+                graph_id,
+                after_sequence + 3,
+                TaskEventType.GRAPH_CHANGED,
+                now,
+                TaskStatus.SUCCEEDED,
+                TaskStatus.RUNNING,
+            )
+
+        return values()
+
+
+class _Runtime:
+    def __init__(self) -> None:
+        self.execution = _ExecutionService()
+        self.task = _TaskService()
+
+
+@pytest.mark.asyncio
+async def test_execution_watch_projects_complete_execution_tree() -> None:
+    runtime = _Runtime()
+    execution = Execution(
+        runtime,
+        "execution",
+        "binding",
+        Principal("owner", "tenant"),
+    )
+    values = [item async for item in execution.watch()]
+    assert len(values) == 1
+    assert values[0].execution_id == "execution"
+
+
+@pytest.mark.asyncio
+async def test_task_graph_run_watch_merges_task_and_execution_events() -> None:
+    run = TaskGraphRun(_Runtime(), "graph", Principal("owner", "tenant"))
+    values = [item async for item in run.watch()]
+    assert all(isinstance(item, TaskGraphRunEvent) for item in values)
+    assert [type(item.event) for item in values].count(TaskEvent) == 3
+    execution = [
+        item for item in values if isinstance(item.event, ExecutionTreeEvent)
+    ]
+    assert len(execution) == 1
+    assert execution[0].node_id == "node"
+    assert execution[0].event.execution_id == "execution"
+
+
+def test_task_run_event_rejects_execution_without_node() -> None:
+    event = ExecutionTreeEvent(
+        "execution",
+        "agent",
+        ExecutionLineageKind.RUN,
+        None,
+        "execution",
+        None,
+        0,
+        ExecutionStreamEvent(
+            "execution",
+            1,
+            ExecutionEventType.EXECUTION_SUCCEEDED,
+            {},
+        ),
+    )
+    with pytest.raises(ValueError):
+        TaskGraphRunEvent("graph", None, event)

--- a/tests/ai/test_session_admission_conformance.py
+++ b/tests/ai/test_session_admission_conformance.py
@@ -351,7 +351,7 @@ async def test_rejected_admission_terminalizes_pending_start() -> None:
             )
         )
         with pytest.raises(AIError) as error:
-            await service.run_for_session(
+            await service.start_for_session(
                 "agent",
                 "b" * 64,
                 "session",

--- a/tests/ai/test_task_context_durability.py
+++ b/tests/ai/test_task_context_durability.py
@@ -131,7 +131,7 @@ async def test_task_service_replay_rejects_correlation_drift() -> None:
         )
 
         with pytest.raises(AIError) as raised:
-            await service.run_graph(
+            await service.start_graph(
                 _request(graph, correlation={"trace_id": "trace-b"})
             )
 

--- a/tests/ai/test_task_mixed_node_reliability.py
+++ b/tests/ai/test_task_mixed_node_reliability.py
@@ -179,7 +179,7 @@ async def test_runtime_executes_custom_agent_custom_graph_and_persists_each_resu
         last = handler.node("custom-last", dependencies=("agent",))
         graph = TaskGraph("mixed-graph", (first, agent, last))
 
-        result = await runtime.run_graph_and_wait(
+        result = await runtime.run_graph(
             graph,
             idempotency_key="mixed-graph-run-0001",
             timeout_seconds=10,
@@ -311,12 +311,12 @@ async def test_runtime_shutdown_leaves_running_custom_task_recoverable(
         state=state,
         capabilities=(application,),
     ) as runtime:
-        await runtime.run_graph(
+        await runtime.start_graph(
             graph,
             idempotency_key="shutdown-graph-run-0001",
         )
         await asyncio.wait_for(entered.wait(), 1)
-        snapshot = await runtime.task.inspect_graph_state(
+        snapshot = await runtime.task.snapshot_graph(
             graph.graph_id,
             principal=runtime.default_principal,
         )

--- a/tests/ai/test_task_sqlite_cas_convergence.py
+++ b/tests/ai/test_task_sqlite_cas_convergence.py
@@ -151,7 +151,7 @@ async def test_sqlite_public_runtime_task_graph_repeated_concurrency_is_stable(
                     agent.task("b", "run b", dependencies=("a",)),
                 ),
             )
-            result = await runtime.run_graph_and_wait(
+            result = await runtime.run_graph(
                 graph,
                 idempotency_key=f"submit:serial:{index}",
                 limits=TaskGraphLimits(max_concurrency=1),
@@ -176,7 +176,7 @@ async def test_sqlite_public_runtime_task_graph_repeated_concurrency_is_stable(
                     ),
                 ),
             )
-            result = await runtime.run_graph_and_wait(
+            result = await runtime.run_graph(
                 graph,
                 idempotency_key=f"submit:parallel:{index}",
                 limits=TaskGraphLimits(max_concurrency=3),
@@ -232,7 +232,7 @@ async def test_sqlite_public_runtime_task_failure_blocks_dependency(
                 agent.task("dependent", "dependent", dependencies=("fail",)),
             ),
         )
-        result = await runtime.run_graph_and_wait(
+        result = await runtime.run_graph(
             graph,
             idempotency_key="submit:failure",
             limits=TaskGraphLimits(max_concurrency=1),
@@ -288,7 +288,7 @@ async def test_sqlite_public_runtime_task_wait_timeout_and_cancel(
         agent = runtime.agent("default")
         graph = TaskGraph("timeout", (agent.task("blocked", "blocked"),))
         with pytest.raises(AIError) as raised:
-            await runtime.run_graph_and_wait(
+            await runtime.run_graph(
                 graph,
                 idempotency_key="submit:timeout",
                 limits=TaskGraphLimits(max_concurrency=1),


### PR DESCRIPTION
## Summary
- make `Execution.watch()` the single high-level live observation API for root Agent + direct Subagents
- add runtime-bound `TaskGraphRun` with `watch()`, `wait()`, `inspect()`, `snapshot()`, and `cancel()`
- align TaskGraph runtime actions: `start_graph()` returns `TaskGraphRun`, while `run_graph()` waits for terminal `TaskGraphResult`
- align Execution service actions: `start()` returns `ExecutionHandle`, while `run()` waits for terminal `ExecutionResult`
- rename `inspect_graph_state()` to `snapshot_graph()` and remove high-level `run_graph_and_wait()` / `Execution.stream()` / `Execution.stream_tree()` ambiguity
- keep low-level `stream_*` APIs for durable/raw event ownership

## Observation model
- `Execution.watch()` projects the existing execution tree; it does not create a second durable event log
- `TaskGraphRun.watch()` multiplexes durable `TaskEvent` records with each Node's `ExecutionTreeEvent`
- TaskGraph sequence ownership remains `TaskEvent.sequence`
- Execution sequence ownership remains per-execution `durable_sequence`
- no global observation sequence, new persistence owner, table, or schema change

## Cursor model
- Graph resume uses `after_graph_sequence`
- each Node Execution tree resumes with its existing per-execution sequence mapping
- reconnect can recover already-bound Node executions from the graph snapshot without inventing Graph→Execution state

## Validation
- source tree was validated with `python manage.py check linktools-ai`
- architecture gate passed
- ruff passed
- 1475 tests passed
- clean delivery branch is one commit ahead of master and contains no staging workflow/scripts
