### PR TITLE
fix(ai): align execution stream event contract

### DIFF
--- a/linktools-ai/src/linktools/ai/acp.py
+++ b/linktools-ai/src/linktools/ai/acp.py
@@ -20,6 +20,7 @@ except ModuleNotFoundError:
 from .core import (
     ExecutionDeltaType,
     ExecutionEventType,
+    ExecutionStatus,
     JsonValue,
     Principal,
     validate_memory_scope,
@@ -138,7 +139,13 @@ class ACPAgent:
                 update = _acp_update(schema, event.event_type, event.payload)
                 if update is not None:
                     await self._connection.session_update(session_id, update)
-        return schema.PromptResponse(stopReason="end_turn")
+        result = await execution.wait()
+        stop_reason = (
+            "cancelled"
+            if result.status is ExecutionStatus.CANCELLED
+            else "end_turn"
+        )
+        return schema.PromptResponse(stopReason=stop_reason)
 
     async def cancel(self, session_id: str, **kwargs: JsonValue) -> None:
         loaded = await self._runtime.session.load(session_id, principal=self._principal)

--- a/linktools-ai/src/linktools/ai/acp.py
+++ b/linktools-ai/src/linktools/ai/acp.py
@@ -20,7 +20,6 @@ except ModuleNotFoundError:
 from .core import (
     ExecutionDeltaType,
     ExecutionEventType,
-    ExecutionStatus,
     JsonValue,
     Principal,
     validate_memory_scope,
@@ -131,20 +130,17 @@ class ACPAgent:
             session_id=session_id,
             memory_scope=self._memory_scope,
         )
+        stop_reason = "end_turn"
         async for item in execution.watch():
             if item.depth != 0:
                 continue
             event = item.event
+            if event.event_type == ExecutionEventType.EXECUTION_CANCELLED.value:
+                stop_reason = "cancelled"
             if self._connection is not None:
                 update = _acp_update(schema, event.event_type, event.payload)
                 if update is not None:
                     await self._connection.session_update(session_id, update)
-        result = await execution.wait()
-        stop_reason = (
-            "cancelled"
-            if result.status is ExecutionStatus.CANCELLED
-            else "end_turn"
-        )
         return schema.PromptResponse(stopReason=stop_reason)
 
     async def cancel(self, session_id: str, **kwargs: JsonValue) -> None:

--- a/linktools-ai/src/linktools/ai/acp.py
+++ b/linktools-ai/src/linktools/ai/acp.py
@@ -194,18 +194,18 @@ def _require_acp() -> "tuple[ModuleType, ModuleType]":
 
 def _acp_update(
     schema: ModuleType,
-    event_type: "ExecutionEventType | ExecutionDeltaType",
+    event_type: str,
     payload: JsonValue,
 ) -> "JsonValue | None":
     if not isinstance(payload, dict):
         return None
-    if event_type is ExecutionDeltaType.ASSISTANT_TEXT_DELTA:
+    if event_type == ExecutionDeltaType.ASSISTANT_TEXT_DELTA.value:
         return schema.AgentMessageChunk(content=schema.TextContentBlock(type="text", text=str(payload.get("text", ""))), sessionUpdate="agent_message_chunk")
-    if event_type is ExecutionDeltaType.ASSISTANT_THINKING_DELTA:
+    if event_type == ExecutionDeltaType.ASSISTANT_THINKING_DELTA.value:
         return schema.AgentThoughtChunk(content=schema.TextContentBlock(type="text", text=str(payload.get("text", ""))), sessionUpdate="agent_thought_chunk")
-    if event_type is ExecutionEventType.TOOL_CALL_STARTED:
+    if event_type == ExecutionEventType.TOOL_CALL_STARTED.value:
         return schema.ToolCallStart(toolCallId=str(payload.get("call_id", "")), title=str(payload.get("tool_name", "tool")), kind="execute", status="in_progress", sessionUpdate="tool_call")
-    if event_type is ExecutionEventType.TOOL_CALL_FINISHED:
+    if event_type == ExecutionEventType.TOOL_CALL_FINISHED.value:
         return schema.ToolCallProgress(toolCallId=str(payload.get("call_id", "")), kind="execute", status="completed" if payload.get("status") == "SUCCEEDED" else "failed", sessionUpdate="tool_call_update")
     return None
 

--- a/linktools-ai/src/linktools/commands/ai/run.py
+++ b/linktools-ai/src/linktools/commands/ai/run.py
@@ -160,9 +160,16 @@ async def _emit_result(
             raise
         payload = _result_payload(result)
         print(json.dumps(payload, ensure_ascii=False, sort_keys=True))
-        _require_success(result)
+        if result.status is not ExecutionStatus.SUCCEEDED:
+            raise CommandError(
+                "execution failed: "
+                f"execution_id={result.execution_id} status={result.status.value} "
+                f"error_code={result.error_code} "
+                f"safe_error_details={dict(result.safe_error_details)}"
+            )
         return 0
 
+    succeeded = False
     execution = await agent.start(
         prompt,
         session_id=session_id,
@@ -170,6 +177,10 @@ async def _emit_result(
         planning=planning,
         thinking=thinking,
     )
+    execution_id = execution.execution_id
+    terminal_status = "UNKNOWN"
+    terminal_error_code: object = None
+    terminal_safe_details: object = {}
     try:
         async for item in execution.watch():
             if item.depth != 0:
@@ -187,25 +198,29 @@ async def _emit_result(
                 _write_stderr("[tool] " + _payload_text(event.payload))
             elif event_type == ExecutionEventType.TOOL_CALL_FINISHED.value:
                 _write_stderr("[tool] finished " + _payload_text(event.payload))
-        result = await execution.wait()
+            elif event_type == ExecutionEventType.EXECUTION_SUCCEEDED.value:
+                succeeded = True
+                terminal_status = ExecutionStatus.SUCCEEDED.value
+            elif event_type in {
+                ExecutionEventType.EXECUTION_FAILED.value,
+                ExecutionEventType.EXECUTION_CANCELLED.value,
+            }:
+                terminal_status = event_type.removeprefix("EXECUTION_")
+                if isinstance(event.payload, dict):
+                    terminal_error_code = event.payload.get("error_code")
+                    terminal_safe_details = event.payload.get("safe_error_details", {})
     except asyncio.CancelledError:
         await _cancel_interrupted_execution(execution)
         raise
     sys.stdout.write("\n")
     sys.stdout.flush()
-    _require_success(result)
+    if not succeeded:
+        raise CommandError(
+            "execution failed: "
+            f"execution_id={execution_id} status={terminal_status} "
+            f"error_code={terminal_error_code} safe_error_details={terminal_safe_details}"
+        )
     return 0
-
-
-def _require_success(result: ExecutionResult) -> None:
-    if result.status is ExecutionStatus.SUCCEEDED:
-        return
-    raise CommandError(
-        "execution failed: "
-        f"execution_id={result.execution_id} status={result.status.value} "
-        f"error_code={result.error_code} "
-        f"safe_error_details={dict(result.safe_error_details)}"
-    )
 
 
 async def _cancel_interrupted_execution(execution: "Execution[object]") -> None:

--- a/linktools-ai/src/linktools/commands/ai/run.py
+++ b/linktools-ai/src/linktools/commands/ai/run.py
@@ -186,25 +186,26 @@ async def _emit_result(
             if item.depth != 0:
                 continue
             event = item.event
-            if event.event_type is ExecutionDeltaType.ASSISTANT_TEXT_DELTA:
+            event_type = event.event_type
+            if event_type == ExecutionDeltaType.ASSISTANT_TEXT_DELTA.value:
                 text = event.payload.get("text") if isinstance(event.payload, dict) else None
                 if isinstance(text, str):
                     sys.stdout.write(text)
                     sys.stdout.flush()
-            elif event.event_type is ExecutionDeltaType.ASSISTANT_THINKING_DELTA:
+            elif event_type == ExecutionDeltaType.ASSISTANT_THINKING_DELTA.value:
                 _write_stderr("[thinking] " + _payload_text(event.payload))
-            elif event.event_type is ExecutionEventType.TOOL_CALL_STARTED:
+            elif event_type == ExecutionEventType.TOOL_CALL_STARTED.value:
                 _write_stderr("[tool] " + _payload_text(event.payload))
-            elif event.event_type is ExecutionEventType.TOOL_CALL_FINISHED:
+            elif event_type == ExecutionEventType.TOOL_CALL_FINISHED.value:
                 _write_stderr("[tool] finished " + _payload_text(event.payload))
-            elif event.event_type is ExecutionEventType.EXECUTION_SUCCEEDED:
+            elif event_type == ExecutionEventType.EXECUTION_SUCCEEDED.value:
                 succeeded = True
                 terminal_status = ExecutionStatus.SUCCEEDED.value
-            elif event.event_type in {
-                ExecutionEventType.EXECUTION_FAILED,
-                ExecutionEventType.EXECUTION_CANCELLED,
+            elif event_type in {
+                ExecutionEventType.EXECUTION_FAILED.value,
+                ExecutionEventType.EXECUTION_CANCELLED.value,
             }:
-                terminal_status = event.event_type.value.removeprefix("EXECUTION_")
+                terminal_status = event_type.removeprefix("EXECUTION_")
                 if isinstance(event.payload, dict):
                     terminal_error_code = event.payload.get("error_code")
                     terminal_safe_details = event.payload.get("safe_error_details", {})

--- a/linktools-ai/src/linktools/commands/ai/run.py
+++ b/linktools-ai/src/linktools/commands/ai/run.py
@@ -160,16 +160,9 @@ async def _emit_result(
             raise
         payload = _result_payload(result)
         print(json.dumps(payload, ensure_ascii=False, sort_keys=True))
-        if result.status is not ExecutionStatus.SUCCEEDED:
-            raise CommandError(
-                "execution failed: "
-                f"execution_id={result.execution_id} status={result.status.value} "
-                f"error_code={result.error_code} "
-                f"safe_error_details={dict(result.safe_error_details)}"
-            )
+        _require_success(result)
         return 0
 
-    succeeded = False
     execution = await agent.start(
         prompt,
         session_id=session_id,
@@ -177,10 +170,6 @@ async def _emit_result(
         planning=planning,
         thinking=thinking,
     )
-    execution_id = execution.execution_id
-    terminal_status = "UNKNOWN"
-    terminal_error_code: object = None
-    terminal_safe_details: object = {}
     try:
         async for item in execution.watch():
             if item.depth != 0:
@@ -198,29 +187,25 @@ async def _emit_result(
                 _write_stderr("[tool] " + _payload_text(event.payload))
             elif event_type == ExecutionEventType.TOOL_CALL_FINISHED.value:
                 _write_stderr("[tool] finished " + _payload_text(event.payload))
-            elif event_type == ExecutionEventType.EXECUTION_SUCCEEDED.value:
-                succeeded = True
-                terminal_status = ExecutionStatus.SUCCEEDED.value
-            elif event_type in {
-                ExecutionEventType.EXECUTION_FAILED.value,
-                ExecutionEventType.EXECUTION_CANCELLED.value,
-            }:
-                terminal_status = event_type.removeprefix("EXECUTION_")
-                if isinstance(event.payload, dict):
-                    terminal_error_code = event.payload.get("error_code")
-                    terminal_safe_details = event.payload.get("safe_error_details", {})
+        result = await execution.wait()
     except asyncio.CancelledError:
         await _cancel_interrupted_execution(execution)
         raise
     sys.stdout.write("\n")
     sys.stdout.flush()
-    if not succeeded:
-        raise CommandError(
-            "execution failed: "
-            f"execution_id={execution_id} status={terminal_status} "
-            f"error_code={terminal_error_code} safe_error_details={terminal_safe_details}"
-        )
+    _require_success(result)
     return 0
+
+
+def _require_success(result: ExecutionResult) -> None:
+    if result.status is ExecutionStatus.SUCCEEDED:
+        return
+    raise CommandError(
+        "execution failed: "
+        f"execution_id={result.execution_id} status={result.status.value} "
+        f"error_code={result.error_code} "
+        f"safe_error_details={dict(result.safe_error_details)}"
+    )
 
 
 async def _cancel_interrupted_execution(execution: "Execution[object]") -> None:

--- a/tests/ai/test_error_contract_matrix.py
+++ b/tests/ai/test_error_contract_matrix.py
@@ -372,8 +372,12 @@ class _StreamingExecution:
     def watch(self) -> AsyncIterator[ExecutionTreeEvent]:
         async def events() -> AsyncIterator[ExecutionTreeEvent]:
             for sequence, event_type, payload in (
-                (1, ExecutionDeltaType.ASSISTANT_TEXT_DELTA, {"text": "hello"}),
-                (2, ExecutionEventType.EXECUTION_SUCCEEDED, {}),
+                (
+                    1,
+                    ExecutionDeltaType.ASSISTANT_TEXT_DELTA.value,
+                    {"text": "hello"},
+                ),
+                (2, ExecutionEventType.EXECUTION_SUCCEEDED.value, {}),
             ):
                 yield ExecutionTreeEvent(
                     self.execution_id,
@@ -392,6 +396,15 @@ class _StreamingExecution:
                 )
 
         return events()
+
+    async def wait(self) -> ExecutionResult:
+        return ExecutionResult(
+            self.execution_id,
+            ExecutionStatus.SUCCEEDED,
+            {"text": "hello"},
+            "a" * 64,
+            UsageMetrics(),
+        )
 
 
 class _StreamingAgent:

--- a/tests/ai/test_runtime_watch_api.py
+++ b/tests/ai/test_runtime_watch_api.py
@@ -42,7 +42,7 @@ class _ExecutionService:
                 ExecutionStreamEvent(
                     execution_id,
                     1,
-                    ExecutionEventType.EXECUTION_SUCCEEDED,
+                    ExecutionEventType.EXECUTION_SUCCEEDED.value,
                     {},
                 ),
             )
@@ -132,6 +132,7 @@ async def test_execution_watch_projects_complete_execution_tree() -> None:
     values = [item async for item in execution.watch()]
     assert len(values) == 1
     assert values[0].execution_id == "execution"
+    assert values[0].event.event_type == ExecutionEventType.EXECUTION_SUCCEEDED.value
 
 
 @pytest.mark.asyncio
@@ -151,6 +152,10 @@ async def test_task_graph_run_watch_merges_task_and_execution_events() -> None:
     assert len(execution) == 1
     assert execution[0].node_id == "node"
     assert execution[0].event.execution_id == "execution"
+    assert (
+        execution[0].event.event.event_type
+        == ExecutionEventType.EXECUTION_SUCCEEDED.value
+    )
 
 
 def test_runtime_does_not_expose_stream_tree() -> None:
@@ -169,7 +174,7 @@ def test_task_run_event_rejects_execution_without_node() -> None:
         ExecutionStreamEvent(
             "execution",
             1,
-            ExecutionEventType.EXECUTION_SUCCEEDED,
+            ExecutionEventType.EXECUTION_SUCCEEDED.value,
             {},
         ),
     )

--- a/tests/ai/test_stream_event_contract.py
+++ b/tests/ai/test_stream_event_contract.py
@@ -176,23 +176,23 @@ async def test_cli_stream_reads_string_terminal_failure(
 class _ACPSchema:
     @staticmethod
     def TextContentBlock(**kwargs: object) -> dict[str, object]:
-        return {"kind": "content", **kwargs}
+        return {"schema_type": "content", **kwargs}
 
     @staticmethod
     def AgentMessageChunk(**kwargs: object) -> dict[str, object]:
-        return {"kind": "message", **kwargs}
+        return {"schema_type": "message", **kwargs}
 
     @staticmethod
     def AgentThoughtChunk(**kwargs: object) -> dict[str, object]:
-        return {"kind": "thought", **kwargs}
+        return {"schema_type": "thought", **kwargs}
 
     @staticmethod
     def ToolCallStart(**kwargs: object) -> dict[str, object]:
-        return {"kind": "tool-start", **kwargs}
+        return {"schema_type": "tool-start", **kwargs}
 
     @staticmethod
     def ToolCallProgress(**kwargs: object) -> dict[str, object]:
-        return {"kind": "tool-progress", **kwargs}
+        return {"schema_type": "tool-progress", **kwargs}
 
     @staticmethod
     def PromptResponse(**kwargs: object) -> dict[str, object]:
@@ -236,7 +236,7 @@ def test_acp_maps_string_stream_event_types(
     )
 
     assert isinstance(update, dict)
-    assert update["kind"] == expected_kind
+    assert update["schema_type"] == expected_kind
 
 
 def test_acp_ignores_unknown_additive_stream_event() -> None:

--- a/tests/ai/test_stream_event_contract.py
+++ b/tests/ai/test_stream_event_contract.py
@@ -3,16 +3,25 @@
 """Execution stream consumers must honor the public string event contract."""
 
 from collections.abc import AsyncIterator
+from types import SimpleNamespace
 
 import pytest
 
-from linktools.ai.acp import _acp_update
+from linktools.ai.acp import ACPAgent, _acp_update
 from linktools.ai.core import (
     ExecutionDeltaType,
     ExecutionEventType,
     ExecutionLineageKind,
+    ExecutionStatus,
+    Principal,
+    UsageMetrics,
 )
-from linktools.ai.runtime import ExecutionStreamEvent, ExecutionTreeEvent
+from linktools.ai.errors import ErrorCode
+from linktools.ai.runtime import (
+    ExecutionResult,
+    ExecutionStreamEvent,
+    ExecutionTreeEvent,
+)
 from linktools.cli import CommandError
 from linktools.commands.ai.run import _emit_result
 
@@ -192,6 +201,10 @@ class _ACPSchema:
     def ToolCallProgress(**kwargs: object) -> dict[str, object]:
         return {"kind": "tool-progress", **kwargs}
 
+    @staticmethod
+    def PromptResponse(**kwargs: object) -> dict[str, object]:
+        return kwargs
+
 
 @pytest.mark.parametrize(
     ("event_type", "payload", "expected_kind"),
@@ -239,3 +252,108 @@ def test_acp_ignores_unknown_additive_stream_event() -> None:
         "FUTURE_EXECUTION_EVENT",
         {},
     ) is None
+
+
+class _ACPExecution:
+    execution_id = "execution"
+
+    def __init__(self, result: ExecutionResult, event_type: str) -> None:
+        self._result = result
+        self._event_type = event_type
+
+    def watch(self) -> AsyncIterator[ExecutionTreeEvent]:
+        async def values() -> AsyncIterator[ExecutionTreeEvent]:
+            yield _tree_event(self._event_type, {}, sequence=1)
+
+        return values()
+
+    async def wait(self) -> ExecutionResult:
+        return self._result
+
+
+class _ACPAgentRuntime:
+    def __init__(self, execution: _ACPExecution) -> None:
+        self._execution = execution
+        self.session = SimpleNamespace(get=self._get_session)
+
+    async def _get_session(self, session_id: str, *, principal: Principal) -> object:
+        del session_id, principal
+        return SimpleNamespace(agent_id="agent")
+
+    def agent(self, agent_id: str) -> object:
+        assert agent_id == "agent"
+        execution = self._execution
+
+        class BoundAgent:
+            async def start(
+                self,
+                prompt: str,
+                *,
+                principal: Principal,
+                session_id: str,
+                memory_scope: str,
+            ) -> _ACPExecution:
+                del prompt, principal, session_id, memory_scope
+                return execution
+
+        return BoundAgent()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("status", "event_type", "expected_stop_reason"),
+    (
+        (
+            ExecutionStatus.SUCCEEDED,
+            ExecutionEventType.EXECUTION_SUCCEEDED.value,
+            "end_turn",
+        ),
+        (
+            ExecutionStatus.CANCELLED,
+            ExecutionEventType.EXECUTION_CANCELLED.value,
+            "cancelled",
+        ),
+    ),
+)
+async def test_acp_prompt_uses_authoritative_terminal_stop_reason(
+    monkeypatch: pytest.MonkeyPatch,
+    status: ExecutionStatus,
+    event_type: str,
+    expected_stop_reason: str,
+) -> None:
+    if status is ExecutionStatus.SUCCEEDED:
+        result = ExecutionResult(
+            "execution",
+            status,
+            {"text": "done"},
+            "a" * 64,
+            UsageMetrics(),
+        )
+    else:
+        result = ExecutionResult(
+            "execution",
+            status,
+            None,
+            None,
+            UsageMetrics(),
+            ErrorCode.EXECUTION_CANCELLED.value,
+            {},
+        )
+    runtime = _ACPAgentRuntime(_ACPExecution(result, event_type))
+    agent = ACPAgent(
+        runtime,  # type: ignore[arg-type]
+        principal=Principal("principal", "tenant", "service"),
+        memory_scope="memory",
+    )
+    agent._initialized = True
+    monkeypatch.setattr(
+        "linktools.ai.acp._require_acp",
+        lambda: (SimpleNamespace(), _ACPSchema),
+    )
+
+    response = await agent.prompt(
+        "session",
+        [SimpleNamespace(text="prompt")],  # type: ignore[list-item]
+    )
+
+    assert response["stopReason"] == expected_stop_reason

--- a/tests/ai/test_stream_event_contract.py
+++ b/tests/ai/test_stream_event_contract.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Execution stream consumers must honor the public string event contract."""
+
+from collections.abc import AsyncIterator
+
+import pytest
+
+from linktools.ai.acp import _acp_update
+from linktools.ai.core import (
+    ExecutionDeltaType,
+    ExecutionEventType,
+    ExecutionLineageKind,
+)
+from linktools.ai.runtime import ExecutionStreamEvent, ExecutionTreeEvent
+from linktools.cli import CommandError
+from linktools.commands.ai.run import _emit_result
+
+
+def _tree_event(
+    event_type: str,
+    payload: object,
+    *,
+    sequence: "int | None" = None,
+) -> ExecutionTreeEvent:
+    return ExecutionTreeEvent(
+        "execution",
+        "agent",
+        ExecutionLineageKind.RUN,
+        None,
+        "execution",
+        None,
+        0,
+        ExecutionStreamEvent(
+            "execution",
+            sequence,
+            event_type,
+            payload,  # type: ignore[arg-type]
+        ),
+    )
+
+
+class _StreamingExecution:
+    execution_id = "execution"
+
+    def __init__(self, events: tuple[ExecutionTreeEvent, ...]) -> None:
+        self._events = events
+
+    def watch(self) -> AsyncIterator[ExecutionTreeEvent]:
+        async def values() -> AsyncIterator[ExecutionTreeEvent]:
+            for event in self._events:
+                yield event
+
+        return values()
+
+
+class _StreamingAgent:
+    def __init__(self, events: tuple[ExecutionTreeEvent, ...]) -> None:
+        self._events = events
+
+    async def start(
+        self,
+        prompt: str,
+        *,
+        session_id: str,
+        memory_scope: str,
+        planning: bool,
+        thinking: bool,
+    ) -> _StreamingExecution:
+        del prompt, session_id, memory_scope, planning, thinking
+        return _StreamingExecution(self._events)
+
+
+class _StreamingRuntime:
+    def __init__(self, events: tuple[ExecutionTreeEvent, ...]) -> None:
+        self._events = events
+
+    def agent(self) -> _StreamingAgent:
+        return _StreamingAgent(self._events)
+
+
+@pytest.mark.asyncio
+async def test_cli_stream_consumes_string_event_types(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    events = (
+        _tree_event(
+            ExecutionDeltaType.ASSISTANT_TEXT_DELTA.value,
+            {"text": "hello"},
+        ),
+        _tree_event(
+            ExecutionDeltaType.ASSISTANT_THINKING_DELTA.value,
+            {"text": "reason"},
+        ),
+        _tree_event(
+            ExecutionEventType.TOOL_CALL_STARTED.value,
+            {"tool_name": "read_file"},
+            sequence=1,
+        ),
+        _tree_event(
+            ExecutionEventType.TOOL_CALL_FINISHED.value,
+            {"tool_name": "read_file", "status": "SUCCEEDED"},
+            sequence=2,
+        ),
+        _tree_event(
+            ExecutionEventType.EXECUTION_SUCCEEDED.value,
+            {},
+            sequence=3,
+        ),
+    )
+
+    result = await _emit_result(
+        _StreamingRuntime(events),  # type: ignore[arg-type]
+        "prompt",
+        "session",
+        "memory",
+        False,
+        False,
+        False,
+    )
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert captured.out == "hello\n"
+    assert "[thinking] reason" in captured.err
+    assert "[tool] read_file" in captured.err
+    assert "[tool] finished read_file" in captured.err
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("event_type", "payload", "expected_status"),
+    (
+        (
+            ExecutionEventType.EXECUTION_FAILED.value,
+            {
+                "error_code": "MODEL_API_ERROR",
+                "safe_error_details": {"provider": "test"},
+            },
+            "FAILED",
+        ),
+        (
+            ExecutionEventType.EXECUTION_CANCELLED.value,
+            {
+                "error_code": "EXECUTION_CANCELLED",
+                "safe_error_details": {},
+            },
+            "CANCELLED",
+        ),
+    ),
+)
+async def test_cli_stream_reads_string_terminal_failure(
+    event_type: str,
+    payload: dict[str, object],
+    expected_status: str,
+) -> None:
+    runtime = _StreamingRuntime((_tree_event(event_type, payload, sequence=1),))
+
+    with pytest.raises(CommandError) as raised:
+        await _emit_result(
+            runtime,  # type: ignore[arg-type]
+            "prompt",
+            "session",
+            "memory",
+            False,
+            False,
+            False,
+        )
+
+    assert f"status={expected_status}" in str(raised.value)
+    assert str(payload["error_code"]) in str(raised.value)
+
+
+class _ACPSchema:
+    @staticmethod
+    def TextContentBlock(**kwargs: object) -> dict[str, object]:
+        return {"kind": "content", **kwargs}
+
+    @staticmethod
+    def AgentMessageChunk(**kwargs: object) -> dict[str, object]:
+        return {"kind": "message", **kwargs}
+
+    @staticmethod
+    def AgentThoughtChunk(**kwargs: object) -> dict[str, object]:
+        return {"kind": "thought", **kwargs}
+
+    @staticmethod
+    def ToolCallStart(**kwargs: object) -> dict[str, object]:
+        return {"kind": "tool-start", **kwargs}
+
+    @staticmethod
+    def ToolCallProgress(**kwargs: object) -> dict[str, object]:
+        return {"kind": "tool-progress", **kwargs}
+
+
+@pytest.mark.parametrize(
+    ("event_type", "payload", "expected_kind"),
+    (
+        (
+            ExecutionDeltaType.ASSISTANT_TEXT_DELTA.value,
+            {"text": "hello"},
+            "message",
+        ),
+        (
+            ExecutionDeltaType.ASSISTANT_THINKING_DELTA.value,
+            {"text": "reason"},
+            "thought",
+        ),
+        (
+            ExecutionEventType.TOOL_CALL_STARTED.value,
+            {"call_id": "call", "tool_name": "read_file"},
+            "tool-start",
+        ),
+        (
+            ExecutionEventType.TOOL_CALL_FINISHED.value,
+            {"call_id": "call", "status": "SUCCEEDED"},
+            "tool-progress",
+        ),
+    ),
+)
+def test_acp_maps_string_stream_event_types(
+    event_type: str,
+    payload: dict[str, object],
+    expected_kind: str,
+) -> None:
+    update = _acp_update(
+        _ACPSchema,  # type: ignore[arg-type]
+        event_type,
+        payload,  # type: ignore[arg-type]
+    )
+
+    assert isinstance(update, dict)
+    assert update["kind"] == expected_kind
+
+
+def test_acp_ignores_unknown_additive_stream_event() -> None:
+    assert _acp_update(
+        _ACPSchema,  # type: ignore[arg-type]
+        "FUTURE_EXECUTION_EVENT",
+        {},
+    ) is None

--- a/tests/ai/test_stream_event_contract.py
+++ b/tests/ai/test_stream_event_contract.py
@@ -49,11 +49,50 @@ def _tree_event(
     )
 
 
+def _succeeded_result() -> ExecutionResult:
+    return ExecutionResult(
+        "execution",
+        ExecutionStatus.SUCCEEDED,
+        {"text": "done"},
+        "a" * 64,
+        UsageMetrics(),
+    )
+
+
+def _failed_result() -> ExecutionResult:
+    return ExecutionResult(
+        "execution",
+        ExecutionStatus.FAILED,
+        None,
+        None,
+        UsageMetrics(),
+        ErrorCode.MODEL_API_ERROR.value,
+        {"provider": "test"},
+    )
+
+
+def _cancelled_result() -> ExecutionResult:
+    return ExecutionResult(
+        "execution",
+        ExecutionStatus.CANCELLED,
+        None,
+        None,
+        UsageMetrics(),
+        ErrorCode.EXECUTION_CANCELLED.value,
+        {},
+    )
+
+
 class _StreamingExecution:
     execution_id = "execution"
 
-    def __init__(self, events: tuple[ExecutionTreeEvent, ...]) -> None:
+    def __init__(
+        self,
+        events: tuple[ExecutionTreeEvent, ...],
+        result: ExecutionResult,
+    ) -> None:
         self._events = events
+        self._result = result
 
     def watch(self) -> AsyncIterator[ExecutionTreeEvent]:
         async def values() -> AsyncIterator[ExecutionTreeEvent]:
@@ -62,10 +101,18 @@ class _StreamingExecution:
 
         return values()
 
+    async def wait(self) -> ExecutionResult:
+        return self._result
+
 
 class _StreamingAgent:
-    def __init__(self, events: tuple[ExecutionTreeEvent, ...]) -> None:
+    def __init__(
+        self,
+        events: tuple[ExecutionTreeEvent, ...],
+        result: ExecutionResult,
+    ) -> None:
         self._events = events
+        self._result = result
 
     async def start(
         self,
@@ -77,15 +124,20 @@ class _StreamingAgent:
         thinking: bool,
     ) -> _StreamingExecution:
         del prompt, session_id, memory_scope, planning, thinking
-        return _StreamingExecution(self._events)
+        return _StreamingExecution(self._events, self._result)
 
 
 class _StreamingRuntime:
-    def __init__(self, events: tuple[ExecutionTreeEvent, ...]) -> None:
+    def __init__(
+        self,
+        events: tuple[ExecutionTreeEvent, ...],
+        result: ExecutionResult,
+    ) -> None:
         self._events = events
+        self._result = result
 
     def agent(self) -> _StreamingAgent:
-        return _StreamingAgent(self._events)
+        return _StreamingAgent(self._events, self._result)
 
 
 @pytest.mark.asyncio
@@ -119,7 +171,7 @@ async def test_cli_stream_consumes_string_event_types(
     )
 
     result = await _emit_result(
-        _StreamingRuntime(events),  # type: ignore[arg-type]
+        _StreamingRuntime(events, _succeeded_result()),  # type: ignore[arg-type]
         "prompt",
         "session",
         "memory",
@@ -138,32 +190,32 @@ async def test_cli_stream_consumes_string_event_types(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("event_type", "payload", "expected_status"),
+    ("event_type", "terminal", "expected_status"),
     (
         (
             ExecutionEventType.EXECUTION_FAILED.value,
-            {
-                "error_code": "MODEL_API_ERROR",
-                "safe_error_details": {"provider": "test"},
-            },
+            _failed_result,
             "FAILED",
         ),
         (
             ExecutionEventType.EXECUTION_CANCELLED.value,
-            {
-                "error_code": "EXECUTION_CANCELLED",
-                "safe_error_details": {},
-            },
+            _cancelled_result,
             "CANCELLED",
         ),
     ),
 )
-async def test_cli_stream_reads_string_terminal_failure(
+async def test_cli_stream_uses_terminal_result_as_authoritative_truth(
     event_type: str,
-    payload: dict[str, object],
+    terminal: object,
     expected_status: str,
 ) -> None:
-    runtime = _StreamingRuntime((_tree_event(event_type, payload, sequence=1),))
+    result_factory = terminal
+    assert callable(result_factory)
+    result = result_factory()
+    runtime = _StreamingRuntime(
+        (_tree_event(event_type, {}, sequence=1),),
+        result,
+    )
 
     with pytest.raises(CommandError) as raised:
         await _emit_result(
@@ -177,7 +229,7 @@ async def test_cli_stream_reads_string_terminal_failure(
         )
 
     assert f"status={expected_status}" in str(raised.value)
-    assert str(payload["error_code"]) in str(raised.value)
+    assert str(result.error_code) in str(raised.value)
 
 
 class _ACPSchema:
@@ -301,15 +353,15 @@ class _ACPAgentRuntime:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("status", "event_type", "expected_stop_reason"),
+    ("result", "event_type", "expected_stop_reason"),
     (
         (
-            ExecutionStatus.SUCCEEDED,
+            _succeeded_result(),
             ExecutionEventType.EXECUTION_SUCCEEDED.value,
             "end_turn",
         ),
         (
-            ExecutionStatus.CANCELLED,
+            _cancelled_result(),
             ExecutionEventType.EXECUTION_CANCELLED.value,
             "cancelled",
         ),
@@ -317,28 +369,10 @@ class _ACPAgentRuntime:
 )
 async def test_acp_prompt_uses_authoritative_terminal_stop_reason(
     monkeypatch: pytest.MonkeyPatch,
-    status: ExecutionStatus,
+    result: ExecutionResult,
     event_type: str,
     expected_stop_reason: str,
 ) -> None:
-    if status is ExecutionStatus.SUCCEEDED:
-        result = ExecutionResult(
-            "execution",
-            status,
-            {"text": "done"},
-            "a" * 64,
-            UsageMetrics(),
-        )
-    else:
-        result = ExecutionResult(
-            "execution",
-            status,
-            None,
-            None,
-            UsageMetrics(),
-            ErrorCode.EXECUTION_CANCELLED.value,
-            {},
-        )
     runtime = _ACPAgentRuntime(_ACPExecution(result, event_type))
     agent = ACPAgent(
         runtime,  # type: ignore[arg-type]

--- a/tests/ai/test_stream_event_contract.py
+++ b/tests/ai/test_stream_event_contract.py
@@ -12,16 +12,9 @@ from linktools.ai.core import (
     ExecutionDeltaType,
     ExecutionEventType,
     ExecutionLineageKind,
-    ExecutionStatus,
     Principal,
-    UsageMetrics,
 )
-from linktools.ai.errors import ErrorCode
-from linktools.ai.runtime import (
-    ExecutionResult,
-    ExecutionStreamEvent,
-    ExecutionTreeEvent,
-)
+from linktools.ai.runtime import ExecutionStreamEvent, ExecutionTreeEvent
 from linktools.cli import CommandError
 from linktools.commands.ai.run import _emit_result
 
@@ -49,50 +42,11 @@ def _tree_event(
     )
 
 
-def _succeeded_result() -> ExecutionResult:
-    return ExecutionResult(
-        "execution",
-        ExecutionStatus.SUCCEEDED,
-        {"text": "done"},
-        "a" * 64,
-        UsageMetrics(),
-    )
-
-
-def _failed_result() -> ExecutionResult:
-    return ExecutionResult(
-        "execution",
-        ExecutionStatus.FAILED,
-        None,
-        None,
-        UsageMetrics(),
-        ErrorCode.MODEL_API_ERROR.value,
-        {"provider": "test"},
-    )
-
-
-def _cancelled_result() -> ExecutionResult:
-    return ExecutionResult(
-        "execution",
-        ExecutionStatus.CANCELLED,
-        None,
-        None,
-        UsageMetrics(),
-        ErrorCode.EXECUTION_CANCELLED.value,
-        {},
-    )
-
-
 class _StreamingExecution:
     execution_id = "execution"
 
-    def __init__(
-        self,
-        events: tuple[ExecutionTreeEvent, ...],
-        result: ExecutionResult,
-    ) -> None:
+    def __init__(self, events: tuple[ExecutionTreeEvent, ...]) -> None:
         self._events = events
-        self._result = result
 
     def watch(self) -> AsyncIterator[ExecutionTreeEvent]:
         async def values() -> AsyncIterator[ExecutionTreeEvent]:
@@ -101,18 +55,10 @@ class _StreamingExecution:
 
         return values()
 
-    async def wait(self) -> ExecutionResult:
-        return self._result
-
 
 class _StreamingAgent:
-    def __init__(
-        self,
-        events: tuple[ExecutionTreeEvent, ...],
-        result: ExecutionResult,
-    ) -> None:
+    def __init__(self, events: tuple[ExecutionTreeEvent, ...]) -> None:
         self._events = events
-        self._result = result
 
     async def start(
         self,
@@ -124,20 +70,15 @@ class _StreamingAgent:
         thinking: bool,
     ) -> _StreamingExecution:
         del prompt, session_id, memory_scope, planning, thinking
-        return _StreamingExecution(self._events, self._result)
+        return _StreamingExecution(self._events)
 
 
 class _StreamingRuntime:
-    def __init__(
-        self,
-        events: tuple[ExecutionTreeEvent, ...],
-        result: ExecutionResult,
-    ) -> None:
+    def __init__(self, events: tuple[ExecutionTreeEvent, ...]) -> None:
         self._events = events
-        self._result = result
 
     def agent(self) -> _StreamingAgent:
-        return _StreamingAgent(self._events, self._result)
+        return _StreamingAgent(self._events)
 
 
 @pytest.mark.asyncio
@@ -171,7 +112,7 @@ async def test_cli_stream_consumes_string_event_types(
     )
 
     result = await _emit_result(
-        _StreamingRuntime(events, _succeeded_result()),  # type: ignore[arg-type]
+        _StreamingRuntime(events),  # type: ignore[arg-type]
         "prompt",
         "session",
         "memory",
@@ -190,32 +131,32 @@ async def test_cli_stream_consumes_string_event_types(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("event_type", "terminal", "expected_status"),
+    ("event_type", "payload", "expected_status"),
     (
         (
             ExecutionEventType.EXECUTION_FAILED.value,
-            _failed_result,
+            {
+                "error_code": "MODEL_API_ERROR",
+                "safe_error_details": {"provider": "test"},
+            },
             "FAILED",
         ),
         (
             ExecutionEventType.EXECUTION_CANCELLED.value,
-            _cancelled_result,
+            {
+                "error_code": "EXECUTION_CANCELLED",
+                "safe_error_details": {},
+            },
             "CANCELLED",
         ),
     ),
 )
-async def test_cli_stream_uses_terminal_result_as_authoritative_truth(
+async def test_cli_stream_reads_string_terminal_failure(
     event_type: str,
-    terminal: object,
+    payload: dict[str, object],
     expected_status: str,
 ) -> None:
-    result_factory = terminal
-    assert callable(result_factory)
-    result = result_factory()
-    runtime = _StreamingRuntime(
-        (_tree_event(event_type, {}, sequence=1),),
-        result,
-    )
+    runtime = _StreamingRuntime((_tree_event(event_type, payload, sequence=1),))
 
     with pytest.raises(CommandError) as raised:
         await _emit_result(
@@ -229,7 +170,7 @@ async def test_cli_stream_uses_terminal_result_as_authoritative_truth(
         )
 
     assert f"status={expected_status}" in str(raised.value)
-    assert str(result.error_code) in str(raised.value)
+    assert str(payload["error_code"]) in str(raised.value)
 
 
 class _ACPSchema:
@@ -309,8 +250,7 @@ def test_acp_ignores_unknown_additive_stream_event() -> None:
 class _ACPExecution:
     execution_id = "execution"
 
-    def __init__(self, result: ExecutionResult, event_type: str) -> None:
-        self._result = result
+    def __init__(self, event_type: str) -> None:
         self._event_type = event_type
 
     def watch(self) -> AsyncIterator[ExecutionTreeEvent]:
@@ -318,9 +258,6 @@ class _ACPExecution:
             yield _tree_event(self._event_type, {}, sequence=1)
 
         return values()
-
-    async def wait(self) -> ExecutionResult:
-        return self._result
 
 
 class _ACPAgentRuntime:
@@ -353,29 +290,19 @@ class _ACPAgentRuntime:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("result", "event_type", "expected_stop_reason"),
+    ("event_type", "expected_stop_reason"),
     (
-        (
-            _succeeded_result(),
-            ExecutionEventType.EXECUTION_SUCCEEDED.value,
-            "end_turn",
-        ),
-        (
-            _cancelled_result(),
-            ExecutionEventType.EXECUTION_CANCELLED.value,
-            "cancelled",
-        ),
+        (ExecutionEventType.EXECUTION_SUCCEEDED.value, "end_turn"),
+        (ExecutionEventType.EXECUTION_CANCELLED.value, "cancelled"),
     ),
 )
-async def test_acp_prompt_uses_authoritative_terminal_stop_reason(
+async def test_acp_prompt_uses_string_terminal_stop_reason(
     monkeypatch: pytest.MonkeyPatch,
-    result: ExecutionResult,
     event_type: str,
     expected_stop_reason: str,
 ) -> None:
-    runtime = _ACPAgentRuntime(_ACPExecution(result, event_type))
     agent = ACPAgent(
-        runtime,  # type: ignore[arg-type]
+        _ACPAgentRuntime(_ACPExecution(event_type)),  # type: ignore[arg-type]
         principal=Principal("principal", "tenant", "service"),
         memory_scope="memory",
     )

--- a/tests/ai/test_subagent_execution_tree.py
+++ b/tests/ai/test_subagent_execution_tree.py
@@ -155,7 +155,7 @@ class _EventStreamer:
             yield ExecutionStreamEvent(
                 execution_id,
                 sequence,
-                ExecutionEventType.EXECUTION_SUCCEEDED,
+                ExecutionEventType.EXECUTION_SUCCEEDED.value,
                 {},
             )
 
@@ -193,7 +193,7 @@ def test_execution_tree_event_rejects_nested_depth() -> None:
     event = ExecutionStreamEvent(
         "child",
         1,
-        ExecutionEventType.EXECUTION_SUCCEEDED,
+        ExecutionEventType.EXECUTION_SUCCEEDED.value,
         {},
     )
     with pytest.raises(ValueError):
@@ -271,7 +271,7 @@ async def test_tree_stream_keeps_at_most_one_prefetched_event_per_execution() ->
                     yield ExecutionStreamEvent(
                         execution_id,
                         after_sequence + offset,
-                        ExecutionEventType.EXECUTION_STARTED,
+                        ExecutionEventType.EXECUTION_STARTED.value,
                         {},
                     )
 
@@ -315,7 +315,7 @@ async def test_tree_stream_does_not_close_terminal_source_before_delivery() -> N
                     yield ExecutionStreamEvent(
                         execution_id,
                         after_sequence + 1,
-                        ExecutionEventType.EXECUTION_SUCCEEDED,
+                        ExecutionEventType.EXECUTION_SUCCEEDED.value,
                         {},
                     )
                 finally:
@@ -336,7 +336,7 @@ async def test_tree_stream_does_not_close_terminal_source_before_delivery() -> N
 
     event = await anext(stream)
 
-    assert event.event.event_type is ExecutionEventType.EXECUTION_SUCCEEDED
+    assert event.event.event_type == ExecutionEventType.EXECUTION_SUCCEEDED.value
     assert events.closed is False
 
     await stream.aclose()
@@ -376,7 +376,7 @@ async def test_tree_stream_adds_dynamic_direct_child_once() -> None:
                 yield ExecutionStreamEvent(
                     execution_id,
                     after_sequence + 1,
-                    ExecutionEventType.EXECUTION_SUCCEEDED,
+                    ExecutionEventType.EXECUTION_SUCCEEDED.value,
                     {},
                 )
 


### PR DESCRIPTION
Fix the execution-stream type boundary exposed by real `ai-run` output.

Changes:
- keep `ExecutionStreamEvent.event_type` as the public string transport contract and consume it as strings in CLI/ACP
- fix CLI success/failed/cancelled terminal recognition without adding another terminal query
- make ACP return `cancelled` when the root stream terminates with cancellation; existing success/failure behavior remains unchanged
- align watch/tree test fixtures with real string event values
- cover success, failed, cancelled, delta, tool and unknown additive stream event strings

The audit found no equivalent issue in Task/Execution status domains because those APIs are explicitly typed as enums. No new abstraction, durable state/schema change, or additional steady-state I/O is introduced.