### PR TITLE
feat(ai): make file inputs transient

### DIFF
--- a/linktools-ai/README.md
+++ b/linktools-ai/README.md
@@ -248,7 +248,9 @@ result = await agent.run(
 )
 ```
 
-The Sandbox canonicalizes each logical path before reading it. The first model request receives the files as `BinaryContent`; each distinct logical file is read at most once, and the captured bytes are recovered from Runtime state rather than the Workspace path. `Agent.task()` remains a generic TaskGraph API and does not accept `files`; delegated subagents use the same `files=` execution input.
+The Sandbox canonicalizes and deduplicates logical paths before reading them. The initial model request receives each file as `BinaryContent` together with its canonical Workspace path, and the captured bytes are recovered from Runtime state rather than reread from the Workspace during retry or recovery. After a complete model response consumes that binary input, Runtime keeps only lightweight file/path context in the active model context, so later agent-loop requests, Session turns, and forks do not repeatedly resend the bytes. The raw transcript remains lossless.
+
+If an Agent needs to inspect a Workspace file again, select `attach_files` in `allow_tools`. `attach_files(paths=[...])` is a normal `filesystem.read` Workspace tool: it applies the existing Sandbox, path, approval, and repository-instruction boundaries, reads the current Workspace contents, and sends those files only to the next model request. A later complete model response consumes them under the same transient rule. `Agent.task()` remains a generic TaskGraph API and does not accept `files`; delegated subagents use the same explicit `files=` execution input.
 
 ## 7. Runtime state
 

--- a/linktools-ai/src/linktools/ai/capability/__init__.py
+++ b/linktools-ai/src/linktools/ai/capability/__init__.py
@@ -36,6 +36,7 @@ from ._workspace import (
     workspace_capabilities,
     workspace_tool_class,
     workspace_tool_contributions,
+    workspace_tool_path_fields_from_metadata,
 )
 
 __all__ = [
@@ -69,4 +70,5 @@ __all__ = [
     "workspace_capabilities",
     "workspace_tool_class",
     "workspace_tool_contributions",
+    "workspace_tool_path_fields_from_metadata",
 ]

--- a/linktools-ai/src/linktools/ai/capability/_workspace.py
+++ b/linktools-ai/src/linktools/ai/capability/_workspace.py
@@ -467,7 +467,7 @@ class _WorkspaceToolSurface:
             command_id: The ID returned by start_command.
 
         Returns:
-            Status and recent output.
+            Status and recent output of the background command.
         """
         return await self._call(self._require_session().check_command(command_id))
 

--- a/linktools-ai/src/linktools/ai/capability/_workspace.py
+++ b/linktools-ai/src/linktools/ai/capability/_workspace.py
@@ -4,7 +4,6 @@
 
 import asyncio
 import hashlib
-import json
 import mimetypes
 from collections.abc import Awaitable, Mapping, Sequence
 from pathlib import Path
@@ -258,13 +257,10 @@ class _WorkspaceToolSurface:
                     "sha256": hashlib.sha256(body).hexdigest(),
                 }
             )
-            content.extend(
-                (
-                    f"Workspace file path: {json.dumps(path)}",
-                    BinaryContent(
-                        data=body,
-                        media_type=media_type,
-                    ),
+            content.append(
+                BinaryContent(
+                    data=body,
+                    media_type=media_type,
                 )
             )
         return ToolReturn(

--- a/linktools-ai/src/linktools/ai/capability/_workspace.py
+++ b/linktools-ai/src/linktools/ai/capability/_workspace.py
@@ -264,7 +264,6 @@ class _WorkspaceToolSurface:
                     BinaryContent(
                         data=body,
                         media_type=media_type,
-                        identifier=Path(path).name,
                     ),
                 )
             )

--- a/linktools-ai/src/linktools/ai/capability/_workspace.py
+++ b/linktools-ai/src/linktools/ai/capability/_workspace.py
@@ -3,14 +3,16 @@
 """Adapt one opened workspace session to Pydantic AI tools."""
 
 import asyncio
+import mimetypes
 from collections.abc import Awaitable, Mapping, Sequence
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, TypeVar, cast
 
 from linktools.core import environ
 from pydantic_ai import Tool
 from pydantic_ai.capabilities import AbstractCapability
 from pydantic_ai.exceptions import ModelRetry
+from pydantic_ai.messages import BinaryContent, ToolReturn, UserContent
 from pydantic_ai.toolsets import FunctionToolset
 
 from ..errors import AIError, ErrorCode
@@ -19,6 +21,7 @@ from ..workspace import (
     Sandbox,
     SandboxSession,
     Workspace,
+    WorkspacePolicy,
     normalize_workspace_path,
 )
 from ._context import AgentContext
@@ -28,7 +31,10 @@ from ._group import (
     contribution_semantic_contract,
 )
 
+_ResultT = TypeVar("_ResultT")
+
 _BASE_WORKSPACE_FILESYSTEM_TOOL_NAMES = (
+    "attach_files",
     "create_directory",
     "edit_file",
     "file_info",
@@ -39,6 +45,7 @@ _BASE_WORKSPACE_FILESYSTEM_TOOL_NAMES = (
     "write_file",
 )
 _BASE_WORKSPACE_FILESYSTEM_READ_TOOL_NAMES = (
+    "attach_files",
     "file_info",
     "find_files",
     "list_directory",
@@ -179,8 +186,14 @@ def workspace_tool_path_metadata(fields: Sequence[str]) -> dict[str, object]:
 
 
 class _WorkspaceToolSurface:
-    def __init__(self, session: SandboxSession | None) -> None:
+    def __init__(
+        self,
+        session: SandboxSession | None,
+        policy: WorkspacePolicy,
+    ) -> None:
         self._session = session
+        self._policy = policy
+        self._mime = mimetypes.MimeTypes(filenames=())
 
     def _require_session(self) -> SandboxSession:
         if self._session is None:
@@ -188,13 +201,74 @@ class _WorkspaceToolSurface:
         return self._session
 
     @staticmethod
-    async def _call(operation: Awaitable[str]) -> str:
+    async def _call(operation: Awaitable[_ResultT]) -> _ResultT:
         try:
             return await operation
         except AIError as error:
             if error.code not in _MODEL_CORRECTABLE_ERRORS:
                 raise
             raise ModelRetry(_MODEL_ERROR_MESSAGES[error.code]) from error
+
+    async def attach_files(self, paths: list[str]) -> ToolReturn:
+        """Attach Workspace files to the next model request.
+
+        Args:
+            paths: File paths relative to the root directory.
+
+        Returns:
+            Lightweight file metadata plus the file content for the next model request.
+        """
+        return await self._call(self._attach_files(paths))
+
+    async def _attach_files(self, paths: list[str]) -> ToolReturn:
+        if not paths:
+            raise AIError(ErrorCode.REQUEST_FIELD_INVALID)
+        unique_paths = tuple(dict.fromkeys(paths))
+        if len(unique_paths) > self._policy.max_binary_input_parts:
+            raise AIError(ErrorCode.REQUEST_FIELD_INVALID)
+
+        session = self._require_session()
+        total_bytes = 0
+        metadata: list[dict[str, object]] = []
+        content: list[UserContent] = []
+        for path in unique_paths:
+            media_type, _ = self._mime.guess_type(path, strict=False)
+            if not media_type:
+                raise AIError(
+                    ErrorCode.REQUEST_FIELD_INVALID,
+                    safe_details={
+                        "field": "paths",
+                        "reason": "media_type_unknown",
+                    },
+                )
+            remaining = self._policy.max_binary_input_bytes - total_bytes
+            if remaining < 0:
+                raise AIError(ErrorCode.REQUEST_FIELD_INVALID)
+            body = await session.read_bytes(path, max_bytes=remaining)
+            total_bytes += len(body)
+            if total_bytes > self._policy.max_binary_input_bytes:
+                raise AIError(ErrorCode.REQUEST_FIELD_INVALID)
+            metadata.append(
+                {
+                    "path": path,
+                    "media_type": media_type,
+                    "size": len(body),
+                }
+            )
+            content.extend(
+                (
+                    f"Workspace file: {path}",
+                    BinaryContent(
+                        data=body,
+                        media_type=media_type,
+                        identifier=Path(path).name,
+                    ),
+                )
+            )
+        return ToolReturn(
+            return_value={"files": metadata},
+            content=content,
+        )
 
     async def read_file(
         self,
@@ -412,9 +486,10 @@ class _WorkspaceSandboxToolset(FunctionToolset[AgentContext[object]]):
         self,
         selected_tool_names: tuple[str, ...],
         session: SandboxSession | None,
+        policy: WorkspacePolicy,
     ) -> None:
         super().__init__(id=_WORKSPACE_SANDBOX_CAPABILITY_ID)
-        surface = _WorkspaceToolSurface(session)
+        surface = _WorkspaceToolSurface(session, policy)
         for name in selected_tool_names:
             self.add_tool(_workspace_tool(surface, name))
 
@@ -424,21 +499,26 @@ class _WorkspaceCapability(AbstractCapability[AgentContext[object]]):
         self,
         selected_tool_names: tuple[str, ...],
         session: SandboxSession | None,
+        policy: WorkspacePolicy,
     ) -> None:
         self.id = _WORKSPACE_SANDBOX_CAPABILITY_ID
         self._selected_tool_names = selected_tool_names
         self._session = session
+        self._policy = policy
 
     def get_toolset(self) -> _WorkspaceSandboxToolset:
-        return _WorkspaceSandboxToolset(self._selected_tool_names, self._session)
+        return _WorkspaceSandboxToolset(
+            self._selected_tool_names,
+            self._session,
+            self._policy,
+        )
 
 
 def workspace_tool_contributions(
     workspace: Workspace,
 ) -> tuple[CapabilityContribution[object], ...]:
     """Return the stable workspace tool definitions used by the compiler."""
-    del workspace
-    surface = _WorkspaceToolSurface(None)
+    surface = _WorkspaceToolSurface(None, workspace.policy)
     result: list[CapabilityContribution[object]] = []
     for name in _WORKSPACE_TOOL_NAMES:
         tool = _workspace_tool(surface, name)
@@ -461,7 +541,6 @@ def workspace_capabilities(
     session: SandboxSession | None = None,
 ) -> tuple[AbstractCapability[AgentContext[object]], ...]:
     """Adapt selected tools to a caller-owned, already-opened session."""
-    del workspace
     selected = frozenset(selected_tool_names)
     unknown = selected.difference(_WORKSPACE_TOOL_NAMES)
     if unknown:
@@ -476,7 +555,7 @@ def workspace_capabilities(
         ordered,
         session is not None,
     )
-    return (_WorkspaceCapability(ordered, session),)
+    return (_WorkspaceCapability(ordered, session, workspace.policy),)
 
 
 def workspace_tool_class(tool: Tool[Any]) -> str | None:
@@ -501,7 +580,8 @@ def _workspace_tool(surface: _WorkspaceToolSurface, name: str) -> Tool[Any]:
     )
     metadata: dict[str, object] = {_WORKSPACE_METADATA_KEY: tool_class}
     if tool_class in {"filesystem.read", "filesystem.write"}:
-        metadata.update(workspace_tool_path_metadata(("path",)))
+        fields = ("paths",) if name == "attach_files" else ("path",)
+        metadata.update(workspace_tool_path_metadata(fields))
     return Tool(
         cast(Any, getattr(surface, name)),
         takes_ctx=False,

--- a/linktools-ai/src/linktools/ai/capability/_workspace.py
+++ b/linktools-ai/src/linktools/ai/capability/_workspace.py
@@ -3,6 +3,8 @@
 """Adapt one opened workspace session to Pydantic AI tools."""
 
 import asyncio
+import hashlib
+import json
 import mimetypes
 from collections.abc import Awaitable, Mapping, Sequence
 from pathlib import Path
@@ -253,11 +255,12 @@ class _WorkspaceToolSurface:
                     "path": path,
                     "media_type": media_type,
                     "size": len(body),
+                    "sha256": hashlib.sha256(body).hexdigest(),
                 }
             )
             content.extend(
                 (
-                    f"Workspace file: {path}",
+                    f"Workspace file path: {json.dumps(path)}",
                     BinaryContent(
                         data=body,
                         media_type=media_type,
@@ -465,7 +468,7 @@ class _WorkspaceToolSurface:
             command_id: The ID returned by start_command.
 
         Returns:
-            Status and recent output of the background command.
+            Status and recent output.
         """
         return await self._call(self._require_session().check_command(command_id))
 

--- a/linktools-ai/src/linktools/ai/runtime/_agent_executor.py
+++ b/linktools-ai/src/linktools/ai/runtime/_agent_executor.py
@@ -75,6 +75,7 @@ from ..capability import (
     SKILL_TOOL_NAMES,
     SkillSourceRegistry,
     SubagentDelegate,
+    WORKSPACE_FILESYSTEM_READ_TOOL_NAMES,
     WORKSPACE_FILESYSTEM_TOOL_NAMES,
     WORKSPACE_SHELL_TOOL_NAMES,
     workspace_capabilities,
@@ -811,17 +812,7 @@ async def _materialize_agent(
         context_target_tokens=scope.context_target_tokens,
         workspace_read_available=(
             scope.sandbox_session is not None
-            and any(
-                name
-                in {
-                    "file_info",
-                    "find_files",
-                    "list_directory",
-                    "read_file",
-                    "search_files",
-                }
-                for name in workspace_names
-            )
+            and any(name in WORKSPACE_FILESYSTEM_READ_TOOL_NAMES for name in workspace_names)
         ),
         parent_step_run_id=scope.parent_step_run_id,
         plan_store_resolver=scope.plan_store_resolver,
@@ -901,13 +892,7 @@ def _workspace_descriptors(
         if name in WORKSPACE_FILESYSTEM_TOOL_NAMES:
             tool_class = (
                 "filesystem.read"
-                if name in {
-                    "file_info",
-                    "find_files",
-                    "list_directory",
-                    "read_file",
-                    "search_files",
-                }
+                if name in WORKSPACE_FILESYSTEM_READ_TOOL_NAMES
                 else "filesystem.write"
             )
             effect = "none" if tool_class == "filesystem.read" else "non_replay_safe"
@@ -972,13 +957,7 @@ def _plan_mode_prepare(
                     selected.append(tool_def)
                 continue
             if tool_def.name in WORKSPACE_FILESYSTEM_TOOL_NAMES:
-                if tool_def.name in {
-                    "file_info",
-                    "find_files",
-                    "list_directory",
-                    "read_file",
-                    "search_files",
-                }:
+                if tool_def.name in WORKSPACE_FILESYSTEM_READ_TOOL_NAMES:
                     selected.append(tool_def)
                 continue
             if tool_def.name == "check_command":

--- a/linktools-ai/src/linktools/ai/runtime/_compaction.py
+++ b/linktools-ai/src/linktools/ai/runtime/_compaction.py
@@ -10,7 +10,7 @@ from collections.abc import Sequence
 from dataclasses import replace
 from typing import Any, Protocol
 
-from pydantic_ai.capabilities import AbstractCapability
+from pydantic_ai.capabilities import AbstractCapability, WrapModelRequestHandler
 from pydantic_ai.messages import ModelMessage, ModelResponse, ToolCallPart
 from pydantic_ai.models import Model, ModelRequestContext, ModelRequestParameters
 from pydantic_ai.models.wrapper import WrapperModel
@@ -147,7 +147,7 @@ class _ObservedCompactionModel(WrapperModel):
 
 
 class RuntimeCompaction(AbstractCapability[None]):
-    """Adapt Harness compaction to Runtime context projection ownership."""
+    """Project the provider context without rewriting the raw run transcript."""
 
     def __init__(
         self,
@@ -179,29 +179,32 @@ class RuntimeCompaction(AbstractCapability[None]):
             )
         )
 
-    async def before_model_request(
+    async def wrap_model_request(
         self,
         ctx: PydanticRunContext[Any],
+        *,
         request_context: ModelRequestContext,
-    ) -> ModelRequestContext:
+        handler: WrapModelRequestHandler,
+    ) -> ModelResponse:
         source = tuple(request_context.messages)
+        projected_context = request_context
         binary_projected = project_transient_binary_content(source)
         if binary_projected != source:
-            request_context = replace(
-                request_context,
+            projected_context = replace(
+                projected_context,
                 messages=list(binary_projected),
             )
-        _validate_pending_binary_content(ctx, request_context.messages)
+        _validate_pending_binary_content(ctx, projected_context.messages)
         if self._target_tokens is None:
-            request_context = await self._deduplicate.before_model_request(
+            projected_context = await self._deduplicate.before_model_request(
                 ctx,
-                request_context,
+                projected_context,
             )
         else:
             summary_model: Model | None = None
             if self._journal is not None and self._observer is not None:
                 summary_model = _ObservedCompactionModel(
-                    request_context.model,
+                    projected_context.model,
                     ctx=ctx,
                     journal=self._journal,
                     observer=self._observer,
@@ -222,17 +225,17 @@ class RuntimeCompaction(AbstractCapability[None]):
                 ),
                 target_tokens=self._target_tokens,
             )
-            request_context = await tiered.before_model_request(
+            projected_context = await tiered.before_model_request(
                 ctx,
-                request_context,
+                projected_context,
             )
-        projected = tuple(request_context.messages)
+        projected = tuple(projected_context.messages)
         if self._projection_sink is not None:
             self._projection_sink(
                 source,
                 None if projected == source else projected,
             )
-        return request_context
+        return await handler(projected_context)
 
 
 def _validate_pending_binary_content(

--- a/linktools-ai/src/linktools/ai/runtime/_compaction.py
+++ b/linktools-ai/src/linktools/ai/runtime/_compaction.py
@@ -187,13 +187,11 @@ class RuntimeCompaction(AbstractCapability[None]):
         handler: WrapModelRequestHandler,
     ) -> ModelResponse:
         source = tuple(request_context.messages)
-        projected_context = request_context
         binary_projected = project_transient_binary_content(source)
-        if binary_projected != source:
-            projected_context = replace(
-                projected_context,
-                messages=list(binary_projected),
-            )
+        projected_context = replace(
+            request_context,
+            messages=list(binary_projected),
+        )
         _validate_pending_binary_content(ctx, projected_context.messages)
         if self._target_tokens is None:
             projected_context = await self._deduplicate.before_model_request(

--- a/linktools-ai/src/linktools/ai/runtime/_compaction.py
+++ b/linktools-ai/src/linktools/ai/runtime/_compaction.py
@@ -191,6 +191,7 @@ class RuntimeCompaction(AbstractCapability[None]):
                 request_context,
                 messages=list(binary_projected),
             )
+        _validate_pending_binary_content(ctx, request_context.messages)
         if self._target_tokens is None:
             request_context = await self._deduplicate.before_model_request(
                 ctx,
@@ -226,7 +227,6 @@ class RuntimeCompaction(AbstractCapability[None]):
                 request_context,
             )
         projected = tuple(request_context.messages)
-        _validate_pending_binary_content(ctx, projected)
         if self._projection_sink is not None:
             self._projection_sink(
                 source,

--- a/linktools-ai/src/linktools/ai/runtime/_compaction.py
+++ b/linktools-ai/src/linktools/ai/runtime/_compaction.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import asyncio
 import json
 from collections.abc import Sequence
+from dataclasses import replace
 from typing import Any, Protocol
 
 from pydantic_ai.capabilities import AbstractCapability
@@ -22,9 +23,11 @@ from pydantic_ai_harness.compaction import (
     TieredCompaction,
 )
 
+from ..capability import AgentContext
 from ..errors import AIError, ErrorCode
 from ..workspace import normalize_workspace_path
 from ._journal import ModelRequestFact, ModelRequestJournal
+from ._message import binary_content_usage, project_transient_binary_content
 
 _KEEP_COMPLETED_PAIRS = 3
 _SUMMARY_TAIL_MESSAGES = 20
@@ -182,6 +185,12 @@ class RuntimeCompaction(AbstractCapability[None]):
         request_context: ModelRequestContext,
     ) -> ModelRequestContext:
         source = tuple(request_context.messages)
+        binary_projected = project_transient_binary_content(source)
+        if binary_projected != source:
+            request_context = replace(
+                request_context,
+                messages=list(binary_projected),
+            )
         if self._target_tokens is None:
             request_context = await self._deduplicate.before_model_request(
                 ctx,
@@ -217,12 +226,29 @@ class RuntimeCompaction(AbstractCapability[None]):
                 request_context,
             )
         projected = tuple(request_context.messages)
+        _validate_pending_binary_content(ctx, projected)
         if self._projection_sink is not None:
             self._projection_sink(
                 source,
                 None if projected == source else projected,
             )
         return request_context
+
+
+def _validate_pending_binary_content(
+    ctx: PydanticRunContext[Any],
+    messages: Sequence[ModelMessage],
+) -> None:
+    deps = ctx.deps
+    if not isinstance(deps, AgentContext):
+        return
+    count, total_bytes = binary_content_usage(messages)
+    policy = deps.workspace.policy
+    if (
+        count > policy.max_binary_input_parts
+        or total_bytes > policy.max_binary_input_bytes
+    ):
+        raise AIError(ErrorCode.REQUEST_FIELD_INVALID)
 
 
 def _workspace_file_key(call: ToolCallPart) -> str | None:

--- a/linktools-ai/src/linktools/ai/runtime/_harness.py
+++ b/linktools-ai/src/linktools/ai/runtime/_harness.py
@@ -22,6 +22,7 @@ from pydantic_ai_harness.step_persistence import (
 )
 
 from ..errors import AIError, ErrorCode
+from ._message import project_transient_binary_content
 from ._plan import PlanItem, RuntimePlanStore
 from .state._step_contracts import (
     ContinuableSnapshot,
@@ -357,16 +358,25 @@ class HarnessStepStoreAdapter:
         self,
         messages: Sequence[ModelMessage],
     ) -> list[ModelMessage] | None:
+        message_values = tuple(messages)
         source = self._projection_source
         projected = self._projection_messages
-        if projected is None:
-            return None
-        message_values = tuple(messages)
-        if _message_prefix(message_values, projected):
-            return list(message_values)
-        if source is None or not _message_prefix(message_values, source):
-            return None
-        return [*projected, *message_values[len(source) :]]
+        context_values = message_values
+        has_projection = False
+        if projected is not None:
+            if _message_prefix(message_values, projected):
+                has_projection = True
+            elif source is not None and _message_prefix(message_values, source):
+                context_values = (
+                    *projected,
+                    *message_values[len(source) :],
+                )
+                has_projection = True
+        binary_projected = project_transient_binary_content(context_values)
+        if binary_projected != context_values:
+            context_values = binary_projected
+            has_projection = True
+        return list(context_values) if has_projection else None
 
 
 def _harness_run(record: RunRecord) -> HarnessRunRecord:

--- a/linktools-ai/src/linktools/ai/runtime/_input.py
+++ b/linktools-ai/src/linktools/ai/runtime/_input.py
@@ -163,7 +163,7 @@ class ExecutionInputMaterializer:
         canonical_files: Sequence[str],
     ) -> CanonicalUserInput:
         canonical = validate_user_input(value)
-        files = tuple(dict.fromkeys(_require_canonical_files(canonical_files)))
+        files = _require_canonical_files(canonical_files)
         direct_binary = _binary_parts(canonical)
         if len(direct_binary) > self._policy.max_binary_input_parts:
             raise AIError(ErrorCode.REQUEST_FIELD_INVALID)
@@ -187,7 +187,7 @@ class ExecutionInputMaterializer:
                 raise AIError(ErrorCode.REQUEST_FIELD_INVALID)
             additions.extend(
                 (
-                    f"Workspace file: {path}",
+                    f"Workspace file path: {json.dumps(path)}",
                     BinaryContent(
                         data=body,
                         media_type=media_type,
@@ -201,8 +201,7 @@ class ExecutionInputMaterializer:
             materialized = (*canonical, *additions)
         validate_user_content(materialized)
         _logger.info(
-            "execution input materialized: files=%s distinct_files=%s binary_bytes=%s",
-            len(files),
+            "execution input materialized: files=%s binary_bytes=%s",
             len(files),
             total_bytes,
         )

--- a/linktools-ai/src/linktools/ai/runtime/_input.py
+++ b/linktools-ai/src/linktools/ai/runtime/_input.py
@@ -9,7 +9,6 @@ import json
 import mimetypes
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-from pathlib import Path
 from typing import TYPE_CHECKING, TypeAlias, cast
 
 from linktools.core import environ
@@ -191,7 +190,6 @@ class ExecutionInputMaterializer:
                     BinaryContent(
                         data=body,
                         media_type=media_type,
-                        identifier=Path(path).name,
                     ),
                 )
             )

--- a/linktools-ai/src/linktools/ai/runtime/_input.py
+++ b/linktools-ai/src/linktools/ai/runtime/_input.py
@@ -130,6 +130,7 @@ class ExecutionInputMaterializer:
     async def canonicalize_files(self, files: Sequence[str]) -> tuple[str, ...]:
         raw_files = _require_files(files)
         result: list[str] = []
+        seen: set[str] = set()
         for path in raw_files:
             try:
                 canonical = normalize_workspace_path(
@@ -142,6 +143,9 @@ class ExecutionInputMaterializer:
                     ErrorCode.REQUEST_FIELD_INVALID,
                     safe_details={"field": "files", "reason": "path_invalid"},
                 ) from error
+            if canonical in seen:
+                continue
+            seen.add(canonical)
             result.append(canonical)
         return tuple(result)
 
@@ -159,7 +163,7 @@ class ExecutionInputMaterializer:
         canonical_files: Sequence[str],
     ) -> CanonicalUserInput:
         canonical = validate_user_input(value)
-        files = _require_canonical_files(canonical_files)
+        files = tuple(dict.fromkeys(_require_canonical_files(canonical_files)))
         direct_binary = _binary_parts(canonical)
         if len(direct_binary) > self._policy.max_binary_input_parts:
             raise AIError(ErrorCode.REQUEST_FIELD_INVALID)
@@ -171,23 +175,26 @@ class ExecutionInputMaterializer:
         if not files:
             return canonical
 
-        bodies: dict[str, BinaryContent] = {}
+        additions: list[UserContent] = []
         for path in files:
-            if path not in bodies:
-                media_type = self._media_type(path)
-                remaining = self._policy.max_binary_input_bytes - total_bytes
-                if remaining < 0:
-                    raise AIError(ErrorCode.REQUEST_FIELD_INVALID)
-                body = await self._access.read_bytes(path, max_bytes=remaining)
-                total_bytes += len(body)
-                if total_bytes > self._policy.max_binary_input_bytes:
-                    raise AIError(ErrorCode.REQUEST_FIELD_INVALID)
-                bodies[path] = BinaryContent(
-                    data=body,
-                    media_type=media_type,
-                    identifier=Path(path).name,
+            media_type = self._media_type(path)
+            remaining = self._policy.max_binary_input_bytes - total_bytes
+            if remaining < 0:
+                raise AIError(ErrorCode.REQUEST_FIELD_INVALID)
+            body = await self._access.read_bytes(path, max_bytes=remaining)
+            total_bytes += len(body)
+            if total_bytes > self._policy.max_binary_input_bytes:
+                raise AIError(ErrorCode.REQUEST_FIELD_INVALID)
+            additions.extend(
+                (
+                    f"Workspace file: {path}",
+                    BinaryContent(
+                        data=body,
+                        media_type=media_type,
+                        identifier=Path(path).name,
+                    ),
                 )
-        additions = tuple(bodies[path] for path in files)
+            )
         if isinstance(canonical, str):
             materialized: CanonicalUserInput = (canonical, *additions)
         else:
@@ -196,7 +203,7 @@ class ExecutionInputMaterializer:
         _logger.info(
             "execution input materialized: files=%s distinct_files=%s binary_bytes=%s",
             len(files),
-            len(bodies),
+            len(files),
             total_bytes,
         )
         return materialized

--- a/linktools-ai/src/linktools/ai/runtime/_message.py
+++ b/linktools-ai/src/linktools/ai/runtime/_message.py
@@ -20,6 +20,8 @@ from pydantic_ai.messages import (
 from ..core import JsonValue, canonical_json_bytes
 from ..errors import AIError, ErrorCode
 
+_CONSUMED_BINARY_MARKER = "[binary content already consumed]"
+
 
 def _json_value(value: object, *, reading: bool) -> JsonValue:
     if value is None or isinstance(value, (bool, int, str)):
@@ -47,13 +49,6 @@ def _json_value(value: object, *, reading: bool) -> JsonValue:
     if reading:
         raise AIError(ErrorCode.STORAGE_INTEGRITY_ERROR)
     raise TypeError("model message persistence contains a non-JSON value")
-
-
-def _consumed_binary_marker(value: BinaryContent) -> str:
-    details = [value.media_type]
-    if value.identifier:
-        details.append(f"identifier={value.identifier}")
-    return f"[binary content already consumed: {', '.join(details)}]"
 
 
 def project_transient_binary_content(
@@ -85,7 +80,7 @@ def project_transient_binary_content(
             part_changed = False
             for item in part.content:
                 if isinstance(item, BinaryContent):
-                    content.append(_consumed_binary_marker(item))
+                    content.append(_CONSUMED_BINARY_MARKER)
                     part_changed = True
                 else:
                     content.append(item)

--- a/linktools-ai/src/linktools/ai/runtime/_message.py
+++ b/linktools-ai/src/linktools/ai/runtime/_message.py
@@ -1,14 +1,21 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-"""Canonical persistence conversion for Pydantic AI ModelMessage values."""
+"""Canonical persistence conversion and active model-context projection."""
 
 import json
 import math
 from collections.abc import Sequence
+from dataclasses import replace
 from typing import cast
 
 from pydantic_ai import ModelMessagesTypeAdapter
-from pydantic_ai.messages import ModelMessage
+from pydantic_ai.messages import (
+    BinaryContent,
+    ModelMessage,
+    ModelRequest,
+    ModelResponse,
+    UserPromptPart,
+)
 
 from ..core import JsonValue, canonical_json_bytes
 from ..errors import AIError, ErrorCode
@@ -42,6 +49,80 @@ def _json_value(value: object, *, reading: bool) -> JsonValue:
     raise TypeError("model message persistence contains a non-JSON value")
 
 
+def _consumed_binary_marker(value: BinaryContent) -> str:
+    details = [value.media_type]
+    if value.identifier:
+        details.append(f"identifier={value.identifier}")
+    return f"[binary content already consumed: {', '.join(details)}]"
+
+
+def project_transient_binary_content(
+    messages: Sequence[ModelMessage],
+) -> tuple[ModelMessage, ...]:
+    """Remove binary bodies already consumed by a complete model response."""
+    values = tuple(messages)
+    seen_complete_response = False
+    changed = False
+    projected_reversed: list[ModelMessage] = []
+
+    for message in reversed(values):
+        if isinstance(message, ModelResponse):
+            if message.state == "complete":
+                seen_complete_response = True
+            projected_reversed.append(message)
+            continue
+        if not seen_complete_response or not isinstance(message, ModelRequest):
+            projected_reversed.append(message)
+            continue
+
+        message_changed = False
+        parts = []
+        for part in message.parts:
+            if not isinstance(part, UserPromptPart) or isinstance(part.content, str):
+                parts.append(part)
+                continue
+            content = []
+            part_changed = False
+            for item in part.content:
+                if isinstance(item, BinaryContent):
+                    content.append(_consumed_binary_marker(item))
+                    part_changed = True
+                else:
+                    content.append(item)
+            if part_changed:
+                parts.append(replace(part, content=content))
+                message_changed = True
+            else:
+                parts.append(part)
+        if message_changed:
+            projected_reversed.append(replace(message, parts=parts))
+            changed = True
+        else:
+            projected_reversed.append(message)
+
+    if not changed:
+        return values
+    projected_reversed.reverse()
+    return tuple(projected_reversed)
+
+
+def binary_content_usage(messages: Sequence[ModelMessage]) -> tuple[int, int]:
+    """Return BinaryContent part count and bytes in user-prompt content."""
+    count = 0
+    total_bytes = 0
+    for message in messages:
+        if not isinstance(message, ModelRequest):
+            continue
+        for part in message.parts:
+            if not isinstance(part, UserPromptPart) or isinstance(part.content, str):
+                continue
+            for item in part.content:
+                if isinstance(item, BinaryContent):
+                    count += 1
+                    total_bytes += len(item.data)
+    return count, total_bytes
+
+
 def encode_model_messages(messages: Sequence[ModelMessage]) -> bytes:
     value = ModelMessagesTypeAdapter.dump_python(
         list(messages),
@@ -65,4 +146,9 @@ def decode_model_messages(raw: bytes) -> tuple[ModelMessage, ...]:
     return tuple(messages)
 
 
-__all__ = ["decode_model_messages", "encode_model_messages"]
+__all__ = [
+    "binary_content_usage",
+    "decode_model_messages",
+    "encode_model_messages",
+    "project_transient_binary_content",
+]

--- a/linktools-ai/src/linktools/ai/runtime/_tool_boundary.py
+++ b/linktools-ai/src/linktools/ai/runtime/_tool_boundary.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Mapping, Sequence
 from contextlib import AsyncExitStack
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from typing import Any, Literal, Protocol
 
 from pydantic import ValidationError
@@ -24,14 +24,12 @@ from pydantic_ai.messages import ToolCallPart
 from pydantic_ai.tools import RunContext as PydanticRunContext, ToolDefinition
 from pydantic_ai.toolsets import AbstractToolset, ToolsetTool
 
-from ..capability import AgentContext
+from ..capability import AgentContext, workspace_tool_path_fields_from_metadata
 from ..core import canonical_sha256, normalize_json_value
 from ..errors import AIError, ErrorCode
 from ..workspace import SandboxSession, WorkspaceToolPermissionPolicy
 from ._tool import ToolOperationBridge
 from ._tool_metrics import _ToolMetricContext
-
-_WORKSPACE_PATH_FIELDS_KEY = "linktools.ai.workspace_path_fields"
 
 
 class RepositoryInstructionBoundary(Protocol):
@@ -189,15 +187,13 @@ class RuntimeToolBoundaryToolset(AbstractToolset[AgentContext[object]]):
         descriptor = self._descriptors.get(name, self._default_descriptor)
         if descriptor is None or tool.toolset is not self:
             raise AIError(ErrorCode.CAPABILITY_RESOLUTION_INVALID)
+        path_fields = descriptor.workspace_path_fields
         if descriptor.tool_class.startswith("filesystem"):
-            path_fields = (tool.tool_def.metadata or {}).get(_WORKSPACE_PATH_FIELDS_KEY)
-            if isinstance(path_fields, (list, tuple)):
-                descriptor = replace(
-                    descriptor,
-                    workspace_path_fields=tuple(path_fields),
-                )
+            path_fields = workspace_tool_path_fields_from_metadata(tool.tool_def.metadata)
+            if not path_fields:
+                raise AIError(ErrorCode.CAPABILITY_RESOLUTION_INVALID)
         raw_toolset, raw_tool = await self._raw_tool(name, ctx)
-        final_args = await self._canonicalize_args(tool_args, descriptor)
+        final_args = await self._canonicalize_args(tool_args, path_fields)
         call_id = ctx.tool_call_id
         if not isinstance(call_id, str) or not call_id:
             raise AIError(ErrorCode.RUNTIME_DEPENDENCY_NOT_READY)
@@ -207,7 +203,7 @@ class RuntimeToolBoundaryToolset(AbstractToolset[AgentContext[object]]):
                 tool_name=name,
                 tool_call_id=call_id,
                 arguments=final_args,
-                path_fields=descriptor.workspace_path_fields,
+                path_fields=path_fields,
             )
         await self._authorize(
             name,
@@ -364,15 +360,15 @@ class RuntimeToolBoundaryToolset(AbstractToolset[AgentContext[object]]):
     async def _canonicalize_args(
         self,
         args: dict[str, Any],
-        descriptor: ManagedToolDescriptor,
+        path_fields: tuple[str, ...],
     ) -> dict[str, Any]:
-        if not descriptor.workspace_path_fields:
+        if not path_fields:
             return dict(args)
         session = self._sandbox_session
         if session is None:
             raise AIError(ErrorCode.SANDBOX_SESSION_CLOSED)
         result = dict(args)
-        for field in descriptor.workspace_path_fields:
+        for field in path_fields:
             if field not in result:
                 continue
             value = result[field]

--- a/linktools-ai/src/linktools/ai/runtime/_tool_boundary.py
+++ b/linktools-ai/src/linktools/ai/runtime/_tool_boundary.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Mapping, Sequence
 from contextlib import AsyncExitStack
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any, Literal, Protocol
 
 from pydantic import ValidationError
@@ -30,6 +30,8 @@ from ..errors import AIError, ErrorCode
 from ..workspace import SandboxSession, WorkspaceToolPermissionPolicy
 from ._tool import ToolOperationBridge
 from ._tool_metrics import _ToolMetricContext
+
+_WORKSPACE_PATH_FIELDS_KEY = "linktools.ai.workspace_path_fields"
 
 
 class RepositoryInstructionBoundary(Protocol):
@@ -187,6 +189,13 @@ class RuntimeToolBoundaryToolset(AbstractToolset[AgentContext[object]]):
         descriptor = self._descriptors.get(name, self._default_descriptor)
         if descriptor is None or tool.toolset is not self:
             raise AIError(ErrorCode.CAPABILITY_RESOLUTION_INVALID)
+        if descriptor.tool_class.startswith("filesystem"):
+            path_fields = (tool.tool_def.metadata or {}).get(_WORKSPACE_PATH_FIELDS_KEY)
+            if isinstance(path_fields, (list, tuple)):
+                descriptor = replace(
+                    descriptor,
+                    workspace_path_fields=tuple(path_fields),
+                )
         raw_toolset, raw_tool = await self._raw_tool(name, ctx)
         final_args = await self._canonicalize_args(tool_args, descriptor)
         call_id = ctx.tool_call_id

--- a/linktools-ai/src/linktools/ai/runtime/_tool_boundary.py
+++ b/linktools-ai/src/linktools/ai/runtime/_tool_boundary.py
@@ -189,9 +189,11 @@ class RuntimeToolBoundaryToolset(AbstractToolset[AgentContext[object]]):
             raise AIError(ErrorCode.CAPABILITY_RESOLUTION_INVALID)
         path_fields = descriptor.workspace_path_fields
         if descriptor.tool_class.startswith("filesystem"):
-            path_fields = workspace_tool_path_fields_from_metadata(tool.tool_def.metadata)
-            if not path_fields:
-                raise AIError(ErrorCode.CAPABILITY_RESOLUTION_INVALID)
+            declared_fields = workspace_tool_path_fields_from_metadata(
+                tool.tool_def.metadata
+            )
+            if declared_fields:
+                path_fields = declared_fields
         raw_toolset, raw_tool = await self._raw_tool(name, ctx)
         final_args = await self._canonicalize_args(tool_args, path_fields)
         call_id = ctx.tool_call_id

--- a/tests/ai/fixtures/persistence/workspace_tool_semantics_v1.json
+++ b/tests/ai/fixtures/persistence/workspace_tool_semantics_v1.json
@@ -1,4 +1,10 @@
 {
+  "attach_files": {
+    "description": "<summary>Attach Workspace files to the next model request.</summary>\n<returns>\n<description>Lightweight file metadata plus the file content for the next model request.</description>\n</returns>",
+    "metadata": {"linktools.ai.workspace_tool_class": "filesystem.read", "linktools.ai.workspace_path_fields": ["paths"]},
+    "parameters": {"additionalProperties": false, "properties": {"paths": {"description": "File paths relative to the root directory.", "items": {"type": "string"}, "type": "array"}}, "required": ["paths"], "type": "object"},
+    "return_schema": {}, "strict": null, "version": 1
+  },
   "check_command": {
     "description": "<summary>Check the status and recent output of a background command.</summary>\n<returns>\n<description>Status and recent output of the background command.</description>\n</returns>",
     "metadata": {"linktools.ai.workspace_tool_class": "shell"},

--- a/tests/ai/test_attach_files_tool.py
+++ b/tests/ai/test_attach_files_tool.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Workspace attach_files tool contracts."""
+
+from pathlib import Path
+
+import pytest
+from pydantic_ai.exceptions import ModelRetry
+from pydantic_ai.messages import BinaryContent, ToolReturn
+from pydantic_ai.models.test import TestModel
+from pydantic_ai.tools import RunContext
+from pydantic_ai.usage import RunUsage
+
+from linktools.ai.capability import workspace_capabilities, workspace_tool_contributions
+from linktools.ai.errors import AIError, ErrorCode
+from linktools.ai.runtime._tool_boundary import (
+    ManagedToolDescriptor,
+    RuntimeToolBoundaryToolset,
+)
+from linktools.ai.workspace import Workspace
+
+
+class _AttachmentSession:
+    def __init__(self, values: dict[str, bytes]) -> None:
+        self.values = values
+        self.canonicalized: list[str] = []
+        self.reads: list[str] = []
+
+    async def canonicalize_path(self, path: str) -> str:
+        self.canonicalized.append(path)
+        return path
+
+    async def read_bytes(self, path: str, *, max_bytes: int | None = None) -> bytes:
+        self.reads.append(path)
+        try:
+            value = self.values[path]
+        except KeyError as error:
+            raise AIError(ErrorCode.STORAGE_NOT_FOUND) from error
+        if max_bytes is not None and len(value) > max_bytes:
+            raise AIError(ErrorCode.REQUEST_FIELD_INVALID)
+        return value
+
+    async def close(self) -> None:
+        return None
+
+
+class _RepositoryBoundary:
+    def __init__(self) -> None:
+        self.path_fields: tuple[str, ...] | None = None
+
+    def render(self) -> str:
+        return ""
+
+    async def check(
+        self,
+        *,
+        tool_name: str,
+        tool_call_id: str,
+        arguments: dict[str, object],
+        path_fields: tuple[str, ...],
+    ) -> None:
+        del tool_name, tool_call_id, arguments
+        self.path_fields = path_fields
+
+
+def _context() -> RunContext[None]:
+    return RunContext(
+        deps=None,
+        model=TestModel(),
+        usage=RunUsage(),
+        run_id="run",
+        tool_call_id="call",
+    )
+
+
+async def _boundary(
+    workspace: Workspace,
+    session: _AttachmentSession,
+    repository: _RepositoryBoundary | None = None,
+) -> tuple[RuntimeToolBoundaryToolset, object]:
+    capability = workspace_capabilities(
+        workspace,
+        ("attach_files",),
+        session=session,  # type: ignore[arg-type]
+    )[0]
+    boundary = RuntimeToolBoundaryToolset(
+        (capability.get_toolset(),),
+        {
+            "attach_files": ManagedToolDescriptor(
+                effect_owner="none",
+                effect="none",
+                tool_class="filesystem.read",
+                workspace_path_fields=("path",),
+            )
+        },
+        id="workspace-boundary",
+        workspace_policy=workspace.policy.tool_permissions,
+        sandbox_session=session,  # type: ignore[arg-type]
+        repository_boundary=repository,
+    )
+    tools = await boundary.get_tools(_context())  # type: ignore[arg-type]
+    return boundary, tools["attach_files"]
+
+
+def test_attach_files_declares_multi_path_workspace_metadata(tmp_path: Path) -> None:
+    contributions = workspace_tool_contributions(
+        Workspace.load(tmp_path, workspace_id="workspace")
+    )
+    tool = next(item.value for item in contributions if item.id == "attach_files")
+
+    assert tool.tool_def.metadata == {  # type: ignore[attr-defined]
+        "linktools.ai.workspace_tool_class": "filesystem.read",
+        "linktools.ai.workspace_path_fields": ["paths"],
+    }
+
+
+@pytest.mark.asyncio
+async def test_attach_files_uses_boundary_paths_and_deduplicates_reads(tmp_path: Path) -> None:
+    workspace = Workspace.load(tmp_path, workspace_id="workspace")
+    session = _AttachmentSession({"evidence.png": b"png"})
+    repository = _RepositoryBoundary()
+    boundary, tool = await _boundary(workspace, session, repository)
+    context = _context()
+
+    result = await boundary.call_tool(  # type: ignore[arg-type]
+        "attach_files",
+        {"paths": ["evidence.png", "evidence.png"]},
+        context,
+        tool,
+    )
+
+    assert isinstance(result, ToolReturn)
+    assert result.return_value == {
+        "files": [
+            {
+                "path": "evidence.png",
+                "media_type": "image/png",
+                "size": 3,
+            }
+        ]
+    }
+    assert result.content is not None
+    assert "Workspace file: evidence.png" in result.content
+    assert sum(isinstance(item, BinaryContent) for item in result.content) == 1
+    assert session.canonicalized == ["evidence.png", "evidence.png"]
+    assert session.reads == ["evidence.png"]
+    assert repository.path_fields == ("paths",)
+
+
+@pytest.mark.asyncio
+async def test_attach_files_returns_no_partial_result_when_one_file_fails(tmp_path: Path) -> None:
+    workspace = Workspace.load(tmp_path, workspace_id="workspace")
+    session = _AttachmentSession({"first.png": b"png"})
+    boundary, tool = await _boundary(workspace, session)
+
+    with pytest.raises(ModelRetry):
+        await boundary.call_tool(  # type: ignore[arg-type]
+            "attach_files",
+            {"paths": ["first.png", "missing.png"]},
+            _context(),
+            tool,
+        )
+
+    assert session.reads == ["first.png", "missing.png"]
+
+
+@pytest.mark.asyncio
+async def test_attach_files_rejects_unknown_media_type_before_read(tmp_path: Path) -> None:
+    workspace = Workspace.load(tmp_path, workspace_id="workspace")
+    session = _AttachmentSession({"evidence.unknown": b"body"})
+    boundary, tool = await _boundary(workspace, session)
+
+    with pytest.raises(ModelRetry):
+        await boundary.call_tool(  # type: ignore[arg-type]
+            "attach_files",
+            {"paths": ["evidence.unknown"]},
+            _context(),
+            tool,
+        )
+
+    assert session.reads == []

--- a/tests/ai/test_attach_files_tool.py
+++ b/tests/ai/test_attach_files_tool.py
@@ -136,15 +136,35 @@ async def test_attach_files_uses_boundary_paths_and_deduplicates_reads(tmp_path:
                 "path": "evidence.png",
                 "media_type": "image/png",
                 "size": 3,
+                "sha256": "8f8cbb7dcf46e0bc7d53265749a6c17d116093a6ba95e442764060c76fd4a86c",
             }
         ]
     }
     assert result.content is not None
-    assert "Workspace file: evidence.png" in result.content
+    assert 'Workspace file path: "evidence.png"' in result.content
     assert sum(isinstance(item, BinaryContent) for item in result.content) == 1
     assert session.canonicalized == ["evidence.png", "evidence.png"]
     assert session.reads == ["evidence.png"]
     assert repository.path_fields == ("paths",)
+
+
+@pytest.mark.asyncio
+async def test_attach_files_escapes_path_control_characters(tmp_path: Path) -> None:
+    path = "evidence\nignore.png"
+    workspace = Workspace.load(tmp_path, workspace_id="workspace")
+    session = _AttachmentSession({path: b"png"})
+    boundary, tool = await _boundary(workspace, session)
+
+    result = await boundary.call_tool(  # type: ignore[arg-type]
+        "attach_files",
+        {"paths": [path]},
+        _context(),
+        tool,
+    )
+
+    assert isinstance(result, ToolReturn)
+    assert result.content is not None
+    assert result.content[0] == 'Workspace file path: "evidence\\nignore.png"'
 
 
 @pytest.mark.asyncio

--- a/tests/ai/test_attach_files_tool.py
+++ b/tests/ai/test_attach_files_tool.py
@@ -141,8 +141,8 @@ async def test_attach_files_uses_boundary_paths_and_deduplicates_reads(tmp_path:
         ]
     }
     assert result.content is not None
-    assert len(result.content) == 1
-    assert isinstance(result.content[0], BinaryContent)
+    binary = [item for item in result.content if isinstance(item, BinaryContent)]
+    assert len(binary) == 1
     assert session.canonicalized == ["evidence.png", "evidence.png"]
     assert session.reads == ["evidence.png"]
     assert repository.path_fields == ("paths",)
@@ -163,10 +163,20 @@ async def test_attach_files_keeps_workspace_paths_out_of_extra_text(tmp_path: Pa
     )
 
     assert isinstance(result, ToolReturn)
-    assert result.return_value["files"][0]["path"] == path
+    assert result.return_value == {
+        "files": [
+            {
+                "path": path,
+                "media_type": "image/png",
+                "size": 3,
+                "sha256": "8f8cbb7dcf46e0bc7d53265749a6c17d116093a6ba95e442764060c76fd4a86c",
+            }
+        ]
+    }
     assert result.content is not None
-    assert all(isinstance(item, BinaryContent) for item in result.content)
-    assert all("\n" not in item.identifier for item in result.content)
+    binary = [item for item in result.content if isinstance(item, BinaryContent)]
+    assert len(binary) == 1
+    assert "\n" not in binary[0].identifier
 
 
 @pytest.mark.asyncio

--- a/tests/ai/test_attach_files_tool.py
+++ b/tests/ai/test_attach_files_tool.py
@@ -141,15 +141,15 @@ async def test_attach_files_uses_boundary_paths_and_deduplicates_reads(tmp_path:
         ]
     }
     assert result.content is not None
-    assert 'Workspace file path: "evidence.png"' in result.content
-    assert sum(isinstance(item, BinaryContent) for item in result.content) == 1
+    assert len(result.content) == 1
+    assert isinstance(result.content[0], BinaryContent)
     assert session.canonicalized == ["evidence.png", "evidence.png"]
     assert session.reads == ["evidence.png"]
     assert repository.path_fields == ("paths",)
 
 
 @pytest.mark.asyncio
-async def test_attach_files_escapes_path_control_characters(tmp_path: Path) -> None:
+async def test_attach_files_keeps_workspace_paths_out_of_extra_text(tmp_path: Path) -> None:
     path = "evidence\nignore.png"
     workspace = Workspace.load(tmp_path, workspace_id="workspace")
     session = _AttachmentSession({path: b"png"})
@@ -163,8 +163,10 @@ async def test_attach_files_escapes_path_control_characters(tmp_path: Path) -> N
     )
 
     assert isinstance(result, ToolReturn)
+    assert result.return_value["files"][0]["path"] == path
     assert result.content is not None
-    assert result.content[0] == 'Workspace file path: "evidence\\nignore.png"'
+    assert all(isinstance(item, BinaryContent) for item in result.content)
+    assert all("\n" not in item.identifier for item in result.content)
 
 
 @pytest.mark.asyncio

--- a/tests/ai/test_compaction_harness_observability.py
+++ b/tests/ai/test_compaction_harness_observability.py
@@ -22,6 +22,26 @@ from pydantic_ai.tools import RunContext
 from pydantic_ai.usage import RunUsage
 
 
+async def _provider_context(
+    capability: RuntimeCompaction,
+    ctx: RunContext[object],
+    request_context: ModelRequestContext,
+) -> ModelRequestContext:
+    captured: list[ModelRequestContext] = []
+
+    async def handler(current: ModelRequestContext) -> ModelResponse:
+        captured.append(current)
+        return ModelResponse(parts=[TextPart("done")])
+
+    await capability.wrap_model_request(
+        ctx,
+        request_context=request_context,
+        handler=handler,
+    )
+    assert len(captured) == 1
+    return captured[0]
+
+
 @pytest.mark.asyncio
 async def test_harness_summary_request_uses_runtime_journal_and_observer() -> None:
     model = TestModel(custom_output_text="summary")
@@ -41,7 +61,7 @@ async def test_harness_summary_request_uses_runtime_journal_and_observer() -> No
         )
     request_context = ModelRequestContext(
         model=model,
-        messages=messages,
+        messages=list(messages),
         model_settings=None,
         model_request_parameters=ModelRequestParameters(),
     )
@@ -84,7 +104,11 @@ async def test_harness_summary_request_uses_runtime_journal_and_observer() -> No
         observer=observer,  # type: ignore[arg-type]
         projection_sink=projection_sink,
     )
-    await capability.before_model_request(ctx, request_context)
+    provider_context = await _provider_context(
+        capability,
+        ctx,  # type: ignore[arg-type]
+        request_context,
+    )
 
     assert [phase for phase, _, _ in observed] == ["started", "completed"]
     assert all(fact.purpose == "compaction" for _, fact, _ in observed)
@@ -92,7 +116,8 @@ async def test_harness_summary_request_uses_runtime_journal_and_observer() -> No
     assert projections
     assert projections[-1][0] == tuple(messages)
     assert projections[-1][1] is not None
-    assert len(request_context.messages) < len(messages)
+    assert len(provider_context.messages) < len(messages)
+    assert request_context.messages == messages
     with pytest.raises(RuntimeError, match="missing"):
         journal.current(observed[-1][1].request_sequence)
 
@@ -190,11 +215,16 @@ async def test_compaction_target_does_not_rewrite_history_below_threshold() -> N
         model_request_parameters=ModelRequestParameters(),
     )
 
-    await RuntimeCompaction(
-        1_000_000,
-        workspace_read_available=True,
-    ).before_model_request(ctx, request_context)
+    provider_context = await _provider_context(
+        RuntimeCompaction(
+            1_000_000,
+            workspace_read_available=True,
+        ),
+        ctx,  # type: ignore[arg-type]
+        request_context,
+    )
 
+    assert provider_context.messages == messages
     assert request_context.messages == messages
 
 
@@ -215,10 +245,15 @@ async def test_compaction_without_target_still_deduplicates_file_reads() -> None
         model_request_parameters=ModelRequestParameters(),
     )
 
-    await RuntimeCompaction(
-        None,
-        workspace_read_available=True,
-    ).before_model_request(ctx, request_context)
+    provider_context = await _provider_context(
+        RuntimeCompaction(
+            None,
+            workspace_read_available=True,
+        ),
+        ctx,  # type: ignore[arg-type]
+        request_context,
+    )
 
-    assert request_context.messages != messages
-    assert "[superseded file read]" in str(request_context.messages)
+    assert provider_context.messages != messages
+    assert "[superseded file read]" in str(provider_context.messages)
+    assert request_context.messages == messages

--- a/tests/ai/test_transient_binary_context.py
+++ b/tests/ai/test_transient_binary_context.py
@@ -63,8 +63,9 @@ def test_consumed_binary_is_removed_without_mutating_raw_transcript() -> None:
     assert isinstance(projected_request, ModelRequest)
     content = projected_request.parts[0].content  # type: ignore[attr-defined]
     assert "Workspace file: a.png" in content
-    assert any(
-        isinstance(item, str) and "binary content already consumed" in item
+    assert "[binary content already consumed]" in content
+    assert not any(
+        isinstance(item, str) and "identifier=" in item
         for item in content
     )
 

--- a/tests/ai/test_transient_binary_context.py
+++ b/tests/ai/test_transient_binary_context.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Transient BinaryContent projection contracts."""
+
+import pytest
+from pydantic_ai.messages import (
+    BinaryContent,
+    ModelMessage,
+    ModelRequest,
+    ModelResponse,
+    TextPart,
+    UserPromptPart,
+)
+
+from linktools.ai.runtime._harness import HarnessStepStoreAdapter
+from linktools.ai.runtime._message import (
+    binary_content_usage,
+    project_transient_binary_content,
+)
+from linktools.ai.runtime.state._step_contracts import (
+    ContinuableSnapshot,
+    RunRecord,
+)
+from linktools.ai.runtime.state._steps import StagingStepStore
+
+
+def _request(name: str, body: bytes) -> ModelRequest:
+    return ModelRequest(
+        parts=[
+            UserPromptPart(
+                content=[
+                    f"Workspace file: {name}",
+                    BinaryContent(body, media_type="image/png", identifier=name),
+                ]
+            )
+        ]
+    )
+
+
+def test_pending_binary_is_kept_until_complete_model_response() -> None:
+    request = _request("a.png", b"image")
+    interrupted = ModelResponse(parts=[TextPart("partial")], state="interrupted")
+
+    pending = project_transient_binary_content((request,))
+    interrupted_projection = project_transient_binary_content((request, interrupted))
+
+    assert pending == (request,)
+    assert interrupted_projection == (request, interrupted)
+    assert binary_content_usage(pending) == (1, 5)
+
+
+def test_consumed_binary_is_removed_without_mutating_raw_transcript() -> None:
+    request = _request("a.png", b"image")
+    response = ModelResponse(parts=[TextPart("done")])
+    raw: tuple[ModelMessage, ...] = (request, response)
+
+    projected = project_transient_binary_content(raw)
+
+    assert projected != raw
+    assert binary_content_usage(projected) == (0, 0)
+    assert binary_content_usage(raw) == (1, 5)
+    projected_request = projected[0]
+    assert isinstance(projected_request, ModelRequest)
+    content = projected_request.parts[0].content  # type: ignore[attr-defined]
+    assert "Workspace file: a.png" in content
+    assert any(
+        isinstance(item, str) and "binary content already consumed" in item
+        for item in content
+    )
+
+
+def test_only_binary_after_latest_complete_response_remains_pending() -> None:
+    first = _request("old.png", b"old")
+    response = ModelResponse(parts=[TextPart("done")])
+    second = _request("new.png", b"new")
+
+    projected = project_transient_binary_content((first, response, second))
+
+    assert binary_content_usage(projected) == (1, 3)
+    assert binary_content_usage((first, response, second)) == (2, 6)
+
+
+def test_snapshot_context_projects_consumed_binary_even_without_compaction() -> None:
+    adapter = HarnessStepStoreAdapter(object(), execution_id="execution")  # type: ignore[arg-type]
+    request = _request("a.png", b"image")
+    response = ModelResponse(parts=[TextPart("done")])
+    raw = [request, response]
+
+    context = adapter.snapshot_context_messages(raw)
+
+    assert context is not None
+    assert binary_content_usage(context) == (0, 0)
+    assert binary_content_usage(raw) == (1, 5)
+
+
+def test_snapshot_context_composes_compaction_with_pending_binary() -> None:
+    adapter = HarnessStepStoreAdapter(object(), execution_id="execution")  # type: ignore[arg-type]
+    consumed_request = _request("old.png", b"old")
+    consumed_response = ModelResponse(parts=[TextPart("done")])
+    source = (consumed_request, consumed_response)
+    summary = ModelRequest(parts=[UserPromptPart(content="summary")])
+    adapter.remember_context_projection(source, (summary,))
+    pending = _request("new.png", b"new")
+
+    context = adapter.snapshot_context_messages((*source, pending))
+
+    assert context is not None
+    assert context[0] == summary
+    assert context[-1] == pending
+    assert binary_content_usage(context) == (1, 3)
+
+
+@pytest.mark.asyncio
+async def test_snapshot_recovery_keeps_pending_and_drops_consumed_binary() -> None:
+    store = StagingStepStore()
+    await store.initialize()
+    await store.register_run(RunRecord("pending"))
+    await store.register_run(RunRecord("consumed"))
+    adapter = HarnessStepStoreAdapter(store, execution_id=None)
+    pending_request = _request("pending.png", b"pending")
+    consumed_request = _request("consumed.png", b"consumed")
+    consumed_response = ModelResponse(parts=[TextPart("done")])
+
+    await store.save_snapshot(
+        ContinuableSnapshot(
+            run_id="pending",
+            step_index=1,
+            messages=[pending_request],
+            context_messages=adapter.snapshot_context_messages([pending_request]),
+        )
+    )
+    consumed_raw = [consumed_request, consumed_response]
+    await store.save_snapshot(
+        ContinuableSnapshot(
+            run_id="consumed",
+            step_index=1,
+            messages=consumed_raw,
+            context_messages=adapter.snapshot_context_messages(consumed_raw),
+        )
+    )
+
+    pending = await store.load_loaded_model_context(owner_id="pending")
+    consumed = await store.load_loaded_model_context(owner_id="consumed")
+
+    assert binary_content_usage(pending.model_messages()) == (1, 7)
+    assert binary_content_usage(consumed.model_messages()) == (0, 0)

--- a/tests/ai/test_transient_binary_limits.py
+++ b/tests/ai/test_transient_binary_limits.py
@@ -10,6 +10,7 @@ from pydantic_ai.models import ModelRequestContext, ModelRequestParameters
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.tools import RunContext
 from pydantic_ai.usage import RunUsage
+from pydantic_ai_harness.compaction import TieredCompaction
 
 from linktools.ai.capability import AgentContext
 from linktools.ai.core import Principal
@@ -18,8 +19,7 @@ from linktools.ai.runtime._compaction import RuntimeCompaction
 from linktools.ai.workspace import Workspace, WorkspacePolicy
 
 
-@pytest.mark.asyncio
-async def test_pending_binary_limit_applies_to_combined_model_context() -> None:
+def _contexts() -> tuple[RunContext[AgentContext[None]], ModelRequestContext]:
     workspace = Workspace(
         root=Path("."),
         config={},
@@ -34,14 +34,15 @@ async def test_pending_binary_limit_applies_to_combined_model_context() -> None:
         execution_id="execution",
         session_metadata={},
     )
+    model = TestModel()
     context = RunContext(
         deps=deps,
-        model=TestModel(),
+        model=model,
         usage=RunUsage(),
         run_id="run",
     )
     request_context = ModelRequestContext(
-        model=TestModel(),
+        model=model,
         messages=[
             ModelRequest(
                 parts=[
@@ -57,8 +58,31 @@ async def test_pending_binary_limit_applies_to_combined_model_context() -> None:
         model_settings=None,
         model_request_parameters=ModelRequestParameters(),
     )
+    return context, request_context
+
+
+@pytest.mark.asyncio
+async def test_pending_binary_limit_applies_to_combined_model_context() -> None:
+    context, request_context = _contexts()
 
     with pytest.raises(AIError) as raised:
         await RuntimeCompaction(None).before_model_request(context, request_context)
+
+    assert raised.value.code is ErrorCode.REQUEST_FIELD_INVALID
+
+
+@pytest.mark.asyncio
+async def test_pending_binary_limit_fails_before_compaction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context, request_context = _contexts()
+
+    async def unexpected_compaction(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("compaction must not run for an invalid model request")
+
+    monkeypatch.setattr(TieredCompaction, "before_model_request", unexpected_compaction)
+
+    with pytest.raises(AIError) as raised:
+        await RuntimeCompaction(1).before_model_request(context, request_context)
 
     assert raised.value.code is ErrorCode.REQUEST_FIELD_INVALID

--- a/tests/ai/test_transient_binary_limits.py
+++ b/tests/ai/test_transient_binary_limits.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Aggregate transient BinaryContent request limits."""
+
+from pathlib import Path
+
+import pytest
+from pydantic_ai.messages import BinaryContent, ModelRequest, UserPromptPart
+from pydantic_ai.models import ModelRequestContext, ModelRequestParameters
+from pydantic_ai.models.test import TestModel
+from pydantic_ai.tools import RunContext
+from pydantic_ai.usage import RunUsage
+
+from linktools.ai.capability import AgentContext
+from linktools.ai.core import Principal
+from linktools.ai.errors import AIError, ErrorCode
+from linktools.ai.runtime._compaction import RuntimeCompaction
+from linktools.ai.workspace import Workspace, WorkspacePolicy
+
+
+@pytest.mark.asyncio
+async def test_pending_binary_limit_applies_to_combined_model_context() -> None:
+    workspace = Workspace(
+        root=Path("."),
+        config={},
+        workspace_id="workspace",
+        policy=WorkspacePolicy(max_binary_input_parts=1),
+    )
+    deps = AgentContext(
+        app=None,
+        principal=Principal("user", "tenant", "local_trusted"),
+        workspace=workspace,
+        session_id=None,
+        execution_id="execution",
+        session_metadata={},
+    )
+    context = RunContext(
+        deps=deps,
+        model=TestModel(),
+        usage=RunUsage(),
+        run_id="run",
+    )
+    request_context = ModelRequestContext(
+        model=TestModel(),
+        messages=[
+            ModelRequest(
+                parts=[
+                    UserPromptPart(
+                        content=[
+                            BinaryContent(b"a", media_type="image/png"),
+                            BinaryContent(b"b", media_type="image/png"),
+                        ]
+                    )
+                ]
+            )
+        ],
+        model_settings=None,
+        model_request_parameters=ModelRequestParameters(),
+    )
+
+    with pytest.raises(AIError) as raised:
+        await RuntimeCompaction(None).before_model_request(context, request_context)
+
+    assert raised.value.code is ErrorCode.REQUEST_FIELD_INVALID

--- a/tests/ai/test_transient_binary_limits.py
+++ b/tests/ai/test_transient_binary_limits.py
@@ -5,7 +5,7 @@
 from pathlib import Path
 
 import pytest
-from pydantic_ai.messages import BinaryContent, ModelRequest, UserPromptPart
+from pydantic_ai.messages import BinaryContent, ModelRequest, ModelResponse, UserPromptPart
 from pydantic_ai.models import ModelRequestContext, ModelRequestParameters
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.tools import RunContext
@@ -61,12 +61,20 @@ def _contexts() -> tuple[RunContext[AgentContext[None]], ModelRequestContext]:
     return context, request_context
 
 
+async def _unexpected_handler(_request_context: ModelRequestContext) -> ModelResponse:
+    raise AssertionError("provider handler must not run for an invalid model request")
+
+
 @pytest.mark.asyncio
 async def test_pending_binary_limit_applies_to_combined_model_context() -> None:
     context, request_context = _contexts()
 
     with pytest.raises(AIError) as raised:
-        await RuntimeCompaction(None).before_model_request(context, request_context)
+        await RuntimeCompaction(None).wrap_model_request(
+            context,
+            request_context=request_context,
+            handler=_unexpected_handler,
+        )
 
     assert raised.value.code is ErrorCode.REQUEST_FIELD_INVALID
 
@@ -83,6 +91,10 @@ async def test_pending_binary_limit_fails_before_compaction(
     monkeypatch.setattr(TieredCompaction, "before_model_request", unexpected_compaction)
 
     with pytest.raises(AIError) as raised:
-        await RuntimeCompaction(1).before_model_request(context, request_context)
+        await RuntimeCompaction(1).wrap_model_request(
+            context,
+            request_context=request_context,
+            handler=_unexpected_handler,
+        )
 
     assert raised.value.code is ErrorCode.REQUEST_FIELD_INVALID

--- a/tests/ai/test_transient_files_agent_loop.py
+++ b/tests/ai/test_transient_files_agent_loop.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""End-to-end transient file behavior across a Pydantic agent loop."""
+
+from pathlib import Path
+
+import pytest
+from pydantic_ai import Agent as PydanticAgent
+from pydantic_ai.messages import ModelMessage, ModelResponse, TextPart, ToolCallPart
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+
+from linktools.ai.capability import AgentContext, workspace_capabilities
+from linktools.ai.core import Principal
+from linktools.ai.runtime._compaction import RuntimeCompaction
+from linktools.ai.runtime._message import binary_content_usage
+from linktools.ai.workspace import Workspace
+
+
+class _Session:
+    async def canonicalize_path(self, path: str) -> str:
+        return path
+
+    async def read_bytes(self, path: str, *, max_bytes: int | None = None) -> bytes:
+        assert path == "evidence.png"
+        value = b"png"
+        assert max_bytes is None or len(value) <= max_bytes
+        return value
+
+    async def read_file(
+        self,
+        path: str,
+        *,
+        offset: int = 0,
+        limit: int | None = None,
+    ) -> str:
+        assert path == "note.txt"
+        assert offset == 0
+        assert limit is None
+        return "note"
+
+    async def close(self) -> None:
+        return None
+
+
+@pytest.mark.asyncio
+async def test_attach_files_is_visible_for_one_model_request_only(tmp_path: Path) -> None:
+    workspace = Workspace.load(tmp_path, workspace_id="workspace")
+    session = _Session()
+    toolset = workspace_capabilities(
+        workspace,
+        ("attach_files", "read_file"),
+        session=session,  # type: ignore[arg-type]
+    )[0].get_toolset()
+    observed_binary: list[tuple[int, int]] = []
+
+    def model_function(
+        messages: list[ModelMessage],
+        _info: AgentInfo,
+    ) -> ModelResponse:
+        observed_binary.append(binary_content_usage(messages))
+        if len(observed_binary) == 1:
+            return ModelResponse(
+                parts=[
+                    ToolCallPart(
+                        "attach_files",
+                        {"paths": ["evidence.png"]},
+                        "attach-call",
+                    )
+                ]
+            )
+        if len(observed_binary) == 2:
+            return ModelResponse(
+                parts=[
+                    ToolCallPart(
+                        "read_file",
+                        {"path": "note.txt"},
+                        "read-call",
+                    )
+                ]
+            )
+        return ModelResponse(parts=[TextPart("done")])
+
+    deps = AgentContext(
+        app=None,
+        principal=Principal("user", "tenant", "local_trusted"),
+        workspace=workspace,
+        session_id=None,
+        execution_id="execution",
+        session_metadata={},
+    )
+    agent = PydanticAgent(
+        FunctionModel(model_function),
+        deps_type=AgentContext,
+        toolsets=(toolset,),
+    )
+
+    result = await agent.run(
+        "inspect evidence",
+        deps=deps,
+        capabilities=(RuntimeCompaction(None),),
+    )
+
+    assert result.output == "done"
+    assert observed_binary == [(0, 0), (1, 3), (0, 0)]
+    assert binary_content_usage(result.all_messages()) == (1, 3)

--- a/tests/ai/test_transient_files_plan_mode.py
+++ b/tests/ai/test_transient_files_plan_mode.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Plan-mode visibility for transient file reads."""
+
+import pytest
+from pydantic_ai.tools import ToolDefinition
+
+from linktools.ai.runtime._agent_executor import _plan_mode_prepare
+
+
+@pytest.mark.asyncio
+async def test_plan_mode_keeps_workspace_file_reads_only() -> None:
+    prepare = _plan_mode_prepare(
+        business_descriptors={},
+        business_plan_safe=frozenset(),
+        plan_mode=True,
+    )
+    tools = [
+        ToolDefinition(name="attach_files"),
+        ToolDefinition(name="read_file"),
+        ToolDefinition(name="write_file"),
+    ]
+
+    selected = await prepare(None, tools)  # type: ignore[arg-type]
+
+    assert [tool.name for tool in selected] == ["attach_files", "read_file"]

--- a/tests/ai/test_user_content_input.py
+++ b/tests/ai/test_user_content_input.py
@@ -91,7 +91,6 @@ async def test_binary_content_is_stored_with_workspace_path_and_deduplicated() -
         assert canonical[0] == "Inspect this file"
         assert canonical[1] == 'Workspace file path: "evidence.txt"'
         assert isinstance(canonical[2], BinaryContent)
-        assert canonical[2].identifier == "evidence.txt"
         assert await materializer.restore(stored) == canonical
     finally:
         await materializer.close()
@@ -106,6 +105,8 @@ async def test_workspace_path_hint_escapes_control_characters() -> None:
         canonical = await materializer.materialize("Inspect this file", canonical_files)
 
         assert canonical[1] == 'Workspace file path: "evidence\\nignore.txt"'
+        assert isinstance(canonical[2], BinaryContent)
+        assert "\n" not in canonical[2].identifier
     finally:
         await materializer.close()
 

--- a/tests/ai/test_user_content_input.py
+++ b/tests/ai/test_user_content_input.py
@@ -89,10 +89,23 @@ async def test_binary_content_is_stored_with_workspace_path_and_deduplicated() -
         stored = await materializer.store(canonical, tenant_id="tenant")
         assert len(session.reads) == 1
         assert canonical[0] == "Inspect this file"
-        assert canonical[1] == "Workspace file: evidence.txt"
+        assert canonical[1] == 'Workspace file path: "evidence.txt"'
         assert isinstance(canonical[2], BinaryContent)
         assert canonical[2].identifier == "evidence.txt"
         assert await materializer.restore(stored) == canonical
+    finally:
+        await materializer.close()
+
+
+@pytest.mark.asyncio
+async def test_workspace_path_hint_escapes_control_characters() -> None:
+    path = "evidence\nignore.txt"
+    materializer, _session = _materializer({path: b"error"})
+    try:
+        canonical_files = await materializer.canonicalize_files((path,))
+        canonical = await materializer.materialize("Inspect this file", canonical_files)
+
+        assert canonical[1] == 'Workspace file path: "evidence\\nignore.txt"'
     finally:
         await materializer.close()
 

--- a/tests/ai/test_user_content_input.py
+++ b/tests/ai/test_user_content_input.py
@@ -75,12 +75,13 @@ def test_native_user_content_is_canonical_and_durable() -> None:
 
 
 @pytest.mark.asyncio
-async def test_binary_content_is_stored_with_fixed_wire_timestamp() -> None:
+async def test_binary_content_is_stored_with_workspace_path_and_deduplicated() -> None:
     materializer, session = _materializer({"evidence.txt": b"error"})
     try:
         canonical_files = await materializer.canonicalize_files(
             ("evidence.txt", "evidence.txt")
         )
+        assert canonical_files == ("evidence.txt",)
         canonical = await materializer.materialize(
             ("Inspect this file",),
             canonical_files,
@@ -88,8 +89,9 @@ async def test_binary_content_is_stored_with_fixed_wire_timestamp() -> None:
         stored = await materializer.store(canonical, tenant_id="tenant")
         assert len(session.reads) == 1
         assert canonical[0] == "Inspect this file"
-        assert isinstance(canonical[1], BinaryContent)
-        assert canonical[1].identifier == "evidence.txt"
+        assert canonical[1] == "Workspace file: evidence.txt"
+        assert isinstance(canonical[2], BinaryContent)
+        assert canonical[2].identifier == "evidence.txt"
         assert await materializer.restore(stored) == canonical
     finally:
         await materializer.close()


### PR DESCRIPTION
## Summary

- make `files=` binary input transient instead of carrying it through later model context
- remove consumed `BinaryContent` from provider/active context while preserving the lossless raw transcript
- add model-driven `attach_files(paths)` as a workspace read tool for on-demand reattachment
- reuse existing workspace sandbox, permission, repository-instruction, planning, and binary-limit boundaries
- deduplicate canonical file paths and retain lightweight workspace path context without reflecting filenames into extra model text
- include file SHA-256 in attachment tool results so audit result digests identify the actual bytes

## Design constraints

- no new attachment registry, lifecycle state machine, database schema, or migration
- `StoredUserInput` remains the execution-input durable owner
- URL/uploaded-file reference semantics remain unchanged
- provider-context projection must not rewrite Pydantic AI raw message history

## Tests

Added focused coverage for transient binary projection, recovery/snapshot behavior, compaction composition, aggregate binary limits, `attach_files`, path metadata, plan-mode visibility, and a real Pydantic agent loop proving that an attached binary is visible for exactly one model response cycle while remaining present in the raw transcript.

GitHub Actions `Python checks` passes on the current head for Python latest, Python 3.10, and the Python 3.6 static compatibility scan.