### PR TITLE
refactor(ai): converge tool semantics and runtime contracts

### DIFF
--- a/linktools-ai/README.md
+++ b/linktools-ai/README.md
@@ -98,6 +98,13 @@ async with Runtime.open(
 
 Generic capabilities are trusted host-Python extensions. LinkTools preserves their native hooks and does not sandbox or deny their file, network, or process access; only LinkTools-owned workspace, opaque-effect, and deferred-resolution boundaries provide those controls.
 
+LinkTools-owned Tool declarations carry their runtime semantics in
+`ToolDefinition.metadata`. `CapabilityGroup.tool()` writes the registered
+`effect`, `plan_safe`, and `tool_class=business` values there; Workspace and
+MCP owners declare their own effect, class, path, and context semantics. Plan
+filtering, sandbox selection, leaf effect handling, and compaction consume
+these declarations instead of inferring behavior from Tool names.
+
 `CapabilityGroup.agent()` creates an `AgentSpec`; declarations themselves use the single v1 wire contract and do not expose a per-declaration revision field.
 
 ## 3. Workspace declarations
@@ -239,6 +246,13 @@ User prompt transport is also durable: plain text uses the `text` codec, while s
 
 URL and uploaded-file content remains an external reference: Runtime persists its declared metadata and does not implicitly download it. Inline binary content and workspace file inputs are frozen as bytes before execution reservation when their durable contract requires it. Model transport retries use `max_retries=2` with a fixed `retry_delay=1.0`; tool correction defaults to `tool_retries=10000`, and output correction defaults to `output_retries=3`.
 
+OpenAI model declarations accept explicit `vision=True` or `vision=False`
+(`False` by default). The value is part of the model semantic fingerprint. A
+model with `vision=False` rejects recognizable image content at the final
+request boundary before provider calls or transport retries; PDF, text, and
+other non-image attachments continue through the existing provider contract.
+LinkTools does not infer image support from model names, endpoints, or probes.
+
 Execution file input uses the same durable boundary:
 
 ```python
@@ -251,6 +265,46 @@ result = await agent.run(
 The Sandbox canonicalizes and deduplicates logical paths before reading them. The initial model request receives each file as `BinaryContent` together with its canonical Workspace path, and the captured bytes are recovered from Runtime state rather than reread from the Workspace during retry or recovery. After a complete model response consumes that binary input, Runtime keeps only lightweight file/path context in the active model context, so later agent-loop requests, Session turns, and forks do not repeatedly resend the bytes. The raw transcript remains lossless.
 
 If an Agent needs to inspect a Workspace file again, select `attach_files` in `allow_tools`. `attach_files(paths=[...])` is a normal `filesystem.read` Workspace tool: it applies the existing Sandbox, path, approval, and repository-instruction boundaries, reads the current Workspace contents, and sends those files only to the next model request. A later complete model response consumes them under the same transient rule. `Agent.task()` remains a generic TaskGraph API and does not accept `files`; delegated subagents use the same explicit `files=` execution input.
+
+### Runtime context and execution queries
+
+`Runtime.open()` is the stable Runtime construction entry point. Use
+`RuntimeContext` to provide the application object, tenant, correlation, and
+low-cardinality metric dimensions for the Runtime lifetime:
+
+```python
+from linktools.ai.runtime import RuntimeContext
+
+context = RuntimeContext(app, tenant_id="tenant-a")
+async with Runtime.open(workspace, models=models, context=context) as runtime:
+    ...
+```
+
+Execution metadata is available through the authorized public query surface:
+
+```python
+from linktools.ai.runtime import ListExecutionRequest
+
+page = await runtime.execution.list(
+    ListExecutionRequest(
+        principal=runtime.default_principal,
+        session_id="chat-1",
+        agent_id="audit",
+    )
+)
+```
+
+`RuntimeHistory.open()` provides the same read-only execution metadata and
+history projections without loading a ModelRegistry or compiling Agents.
+`RuntimeHistory.inspect_execution()` and `list_executions()` use the same
+authorization and filters as `Runtime.execution`. Execution list cursors are
+HMAC-protected, ordered weak-consistency continuations: they do not provide a
+cross-page MVCC snapshot, and a caller needing a closed set should query after
+the target set is stable or restart from the first page.
+
+Downstream code must not scan `ExecutionRecord`, codec data, `StateStore`, or
+private repositories directly. No durable schema or data migration is part of
+this Runtime query surface.
 
 ## 7. Runtime state
 
@@ -338,6 +392,6 @@ from linktools.ai import (
 )
 ```
 
-Package-specific public contracts remain available from their owning packages, for example `linktools.ai.asset`, `linktools.ai.model`, `linktools.ai.spec`, and `linktools.ai.runtime`. `ErrorDiagnostics` is available from `linktools.ai.runtime`.
+Package-specific public contracts remain available from their owning packages, for example `linktools.ai.asset`, `linktools.ai.model`, `linktools.ai.spec`, and `linktools.ai.runtime`. `ErrorDiagnostics` is available from `linktools.ai.errors`.
 
 Private modules prefixed with `_` are implementation details. Downstream applications should not import Runtime execution infrastructure, state repository internals, or private compiler helpers directly.

--- a/linktools-ai/src/linktools/ai/agent/_compiler.py
+++ b/linktools-ai/src/linktools/ai/agent/_compiler.py
@@ -11,14 +11,19 @@ from pydantic import BaseModel
 from ..capability import (
     CapabilityContribution,
     SkillDefinition,
-    mcp_selector_server,
     mcp_server_namespace,
     mcp_server_selector,
 )
 from ..core import canonical_sha256
 from ..errors import AIError, ErrorCode
 from ..model import ModelBinding, ModelResolver
-from ..spec import AgentSpec, AgentSpecCodec, MCPServerSpecCodec, SubagentRef
+from ..spec import (
+    AgentSpec,
+    AgentSpecCodec,
+    MCPServerSpecCodec,
+    SubagentRef,
+    parse_mcp_tool_selector,
+)
 from ._binding import AgentBinding, AgentBindingSnapshot, SemanticPin
 from ._definition import AgentDefinition
 from ._output import bind_output, restore_output
@@ -257,7 +262,7 @@ class AgentCompiler:
         ordinary_policy: list[str] = []
         mcp_policy: list[str] = []
         for selector in spec.allow_tools:
-            parsed = mcp_selector_server(selector)
+            parsed = parse_mcp_tool_selector(selector)
             if parsed is None:
                 ordinary_policy.append(selector)
                 if selector in tools:
@@ -332,12 +337,16 @@ class AgentCompiler:
                 ),
             )
         ordinary = tuple(
-            sorted(selector for selector in spec.allow_tools if not selector.startswith("mcp__"))
+            sorted(
+                selector
+                for selector in spec.allow_tools
+                if parse_mcp_tool_selector(selector) is None
+            )
         )
         allowed_namespaces = {mcp_server_namespace(item.id) for item in selected_mcp}
         mcp_policy = []
         for selector in spec.allow_tools:
-            parsed = mcp_selector_server(selector)
+            parsed = parse_mcp_tool_selector(selector)
             if parsed is None:
                 continue
             if parsed[0] not in allowed_namespaces:

--- a/linktools-ai/src/linktools/ai/capability/__init__.py
+++ b/linktools-ai/src/linktools/ai/capability/__init__.py
@@ -9,14 +9,8 @@ from ._group import (
     CapabilityLoadContext,
     CapabilityLoadEntry,
     CapabilityLoader,
-    PLAN_SAFE_METADATA_KEY,
 )
-from ._mcp import (
-    mcp_selector_server,
-    mcp_server_namespace,
-    mcp_server_selector,
-)
-from ._names import SKILL_TOOL_NAMES, SUBAGENT_TOOL_NAMES
+from ._mcp import mcp_server_namespace, mcp_server_selector
 from ._skill import LinkToolsSkills, SkillDefinition
 from ._skill_source import (
     AssetSkillResourceSource,
@@ -29,15 +23,26 @@ from ._skill_source import (
 )
 from ._subagent import LinkToolsSubagents, SubagentDelegate
 from ._task import TaskExpander, TaskExpansionContext
+from ._tool_semantic import (
+    TOOL_CLASS_METADATA_KEY,
+    TOOL_COMPACTION_KEEP_RESULT_METADATA_KEY,
+    TOOL_CONTEXT_DEDUPE_METADATA_KEY,
+    TOOL_EFFECT_METADATA_KEY,
+    TOOL_PATH_FIELDS_METADATA_KEY,
+    TOOL_PLAN_SAFE_METADATA_KEY,
+    tool_class_from_metadata,
+    tool_compaction_keep_result_from_metadata,
+    tool_context_dedupe_from_metadata,
+    tool_effect_from_metadata,
+    tool_path_fields_from_metadata,
+    tool_plan_safe_from_metadata,
+    tool_semantic_metadata,
+    validate_tool_semantic_metadata,
+)
 from ._workspace import (
-    WORKSPACE_FILESYSTEM_READ_TOOL_NAMES,
-    WORKSPACE_FILESYSTEM_TOOL_NAMES,
-    WORKSPACE_SHELL_TOOL_NAMES,
     WorkspaceAccess,
     workspace_capabilities,
-    workspace_tool_class,
     workspace_tool_contributions,
-    workspace_tool_path_fields_from_metadata,
 )
 
 __all__ = [
@@ -51,27 +56,32 @@ __all__ = [
     "LinkToolsSkills",
     "LinkToolsSubagents",
     "LocalSkillResourceSource",
-    "PLAN_SAFE_METADATA_KEY",
+    "TOOL_CLASS_METADATA_KEY",
+    "TOOL_COMPACTION_KEEP_RESULT_METADATA_KEY",
+    "TOOL_CONTEXT_DEDUPE_METADATA_KEY",
+    "TOOL_EFFECT_METADATA_KEY",
+    "TOOL_PATH_FIELDS_METADATA_KEY",
+    "TOOL_PLAN_SAFE_METADATA_KEY",
     "SkillDefinition",
     "SkillLocation",
     "SkillResourceSource",
     "SkillResourceView",
     "SkillSourceRef",
     "SkillSourceRegistry",
-    "SKILL_TOOL_NAMES",
-    "SUBAGENT_TOOL_NAMES",
     "SubagentDelegate",
     "TaskExpander",
     "TaskExpansionContext",
-    "WORKSPACE_FILESYSTEM_READ_TOOL_NAMES",
-    "WORKSPACE_FILESYSTEM_TOOL_NAMES",
-    "WORKSPACE_SHELL_TOOL_NAMES",
     "WorkspaceAccess",
-    "mcp_selector_server",
     "mcp_server_namespace",
     "mcp_server_selector",
     "workspace_capabilities",
-    "workspace_tool_class",
     "workspace_tool_contributions",
-    "workspace_tool_path_fields_from_metadata",
+    "tool_class_from_metadata",
+    "tool_compaction_keep_result_from_metadata",
+    "tool_context_dedupe_from_metadata",
+    "tool_effect_from_metadata",
+    "tool_path_fields_from_metadata",
+    "tool_plan_safe_from_metadata",
+    "tool_semantic_metadata",
+    "validate_tool_semantic_metadata",
 ]

--- a/linktools-ai/src/linktools/ai/capability/_group.py
+++ b/linktools-ai/src/linktools/ai/capability/_group.py
@@ -685,7 +685,11 @@ def contribution_semantic_contract(
         raise AIError(ErrorCode.CAPABILITY_RESOLUTION_INVALID)
     if kind == "tool" and isinstance(value, Tool):
         definition = value.tool_def
-        validate_tool_semantic_metadata(definition.metadata)
+        validate_tool_semantic_metadata(
+            definition.metadata,
+            require_effect=True,
+            require_tool_class=True,
+        )
         contract: dict[str, JsonValue] = {
             "version": 1,
             "description": definition.description,

--- a/linktools-ai/src/linktools/ai/capability/_group.py
+++ b/linktools-ai/src/linktools/ai/capability/_group.py
@@ -27,16 +27,19 @@ from ..spec import (
     SkillMarkdownSpecCodec,
     SkillSpecCodec,
     ThinkingValue,
+    parse_mcp_tool_selector,
 )
 from ..task import TaskExpanderRef, TaskNodeHandler
 from ._context import AgentContext
-from ._names import SKILL_TOOL_NAMES, SUBAGENT_TOOL_NAMES
 from ._skill import SkillDefinition
 from ._skill_source import AssetSkillResourceSource, SkillResourceSource, SkillSourceRef
 from ._task import TaskExpander
+from ._tool_semantic import (
+    tool_semantic_metadata,
+    validate_tool_semantic_metadata,
+)
 
 AppT = TypeVar("AppT")
-PLAN_SAFE_METADATA_KEY = "linktools.ai.plan_safe"
 
 
 ContributionKind = Literal[
@@ -56,17 +59,6 @@ ContributionSemanticValue: TypeAlias = (
     | AbstractCapability
     | TaskNodeHandler[object]
     | TaskExpander
-)
-_RESERVED_TOOL_NAMES = frozenset(
-    {
-        *SKILL_TOOL_NAMES,
-        *SUBAGENT_TOOL_NAMES,
-        "write_plan",
-        "delete_memory",
-        "read_memory",
-        "search_memory",
-        "write_memory",
-    }
 )
 _TOOL_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_.-]{0,127}$")
 _TASK_TYPE = re.compile(r"^[A-Za-z][A-Za-z0-9_.-]{0,127}$")
@@ -154,14 +146,15 @@ class CapabilityContribution(Generic[AppT]):
         identity: str,
         value: "Tool[AgentContext[AppT]] | AbstractCapability[AgentContext[AppT]]",
         *,
-        revision: int = 1,
+        revision: "int | None" = None,
         semantic_id: "str | None" = None,
         semantic_config: "Mapping[str, JsonValue] | None" = None,
     ) -> "CapabilityContribution[AppT]":
         """Create an opaque Python Tool or Capability from its public semantic inputs."""
         if kind not in {"tool", "capability"}:
             raise AIError(ErrorCode.CAPABILITY_RESOLUTION_INVALID)
-        _validate_revision(revision)
+        if revision is not None:
+            _validate_revision(revision)
         contract = contribution_semantic_contract(
             kind,
             identity,
@@ -355,13 +348,18 @@ class CapabilityGroup(Generic[AppT]):
         tool_name = name or function.__name__
         _validate_business_tool_name(tool_name)
         adapted = _adapt_tool(function, name=tool_name)
+        adapted.metadata = tool_semantic_metadata(
+            effect=effect,
+            plan_safe=plan_safe,
+            tool_class="business",
+            base=adapted.metadata,
+        )
         self._contributions.append(
             CapabilityContribution.from_opaque(
                 "tool",
                 tool_name,
                 adapted,
                 revision=revision,
-                semantic_config={"effect": effect, "plan_safe": plan_safe},
             )
         )
         return adapted
@@ -513,10 +511,11 @@ class CapabilityGroup(Generic[AppT]):
                 if any(not isinstance(item, CapabilityContribution) for item in loaded):
                     raise AIError(ErrorCode.CAPABILITY_RESOLUTION_INVALID)
                 contributions.extend(loaded)
-        _validate_unique(contributions)
-        generic = [item for item in contributions if item.kind == "capability"]
+        frozen = tuple(_freeze_contribution(item) for item in contributions)
+        _validate_unique(frozen)
+        generic = [item for item in frozen if item.kind == "capability"]
         declarations = sorted(
-            (item for item in contributions if item.kind != "capability"),
+            (item for item in frozen if item.kind != "capability"),
             key=lambda item: (item.kind, item.id, item.fingerprint),
         )
         return tuple((*declarations, *generic))
@@ -631,6 +630,20 @@ def _declaration_contribution(
     )
 
 
+def _freeze_contribution(
+    value: CapabilityContribution[AppT],
+) -> CapabilityContribution[AppT]:
+    if isinstance(value, _SemanticContribution):
+        return value
+    return _SemanticContribution(
+        value.kind,
+        value.id,
+        value.fingerprint,
+        value.value,
+        value.semantic_contract,
+    )
+
+
 def _adapt_tool(function: Callable[..., object], *, name: str) -> Tool:
     if not callable(function):
         raise TypeError("tool function must be callable")
@@ -668,10 +681,11 @@ def contribution_semantic_contract(
     semantic_id: "str | None" = None,
     semantic_config: "Mapping[str, JsonValue] | None" = None,
 ) -> "dict[str, JsonValue]":
-    if semantic_config is not None and kind not in {"tool", "capability"}:
+    if semantic_config is not None and kind != "capability":
         raise AIError(ErrorCode.CAPABILITY_RESOLUTION_INVALID)
     if kind == "tool" and isinstance(value, Tool):
         definition = value.tool_def
+        validate_tool_semantic_metadata(definition.metadata)
         contract: dict[str, JsonValue] = {
             "version": 1,
             "description": definition.description,
@@ -682,11 +696,6 @@ def contribution_semantic_contract(
         }
         if semantic_revision is not None:
             contract["semantic_revision"] = semantic_revision
-        if semantic_config is not None:
-            try:
-                contract.update(dict(ImmutableJsonMapping(semantic_config)))
-            except (TypeError, ValueError) as error:
-                raise AIError(ErrorCode.CAPABILITY_RESOLUTION_INVALID) from error
         return contract
     if kind == "agent" and isinstance(value, AgentSpec):
         return AgentSpecCodec().to_payload(value)
@@ -779,9 +788,10 @@ def _validate_business_tool_name(value: str) -> None:
     if (
         not isinstance(value, str)
         or _TOOL_NAME.fullmatch(value) is None
-        or value.startswith("mcp__")
-        or value in _RESERVED_TOOL_NAMES
+        or value.startswith("linktools.")
     ):
+        raise AIError(ErrorCode.CAPABILITY_RESOLUTION_INVALID)
+    if parse_mcp_tool_selector(value) is not None:
         raise AIError(ErrorCode.CAPABILITY_RESOLUTION_INVALID)
 
 
@@ -843,7 +853,6 @@ __all__ = [
     "CapabilityLoadContext",
     "CapabilityLoadEntry",
     "CapabilityLoader",
-    "PLAN_SAFE_METADATA_KEY",
     "capability_fingerprint",
     "contribution_semantic_contract",
 ]

--- a/linktools-ai/src/linktools/ai/capability/_mcp.py
+++ b/linktools-ai/src/linktools/ai/capability/_mcp.py
@@ -20,28 +20,17 @@ def mcp_server_selector(server_id: str) -> str:
 
 
 def mcp_tool_name(server_id: str, tool_name: str) -> str:
-    if not tool_name or tool_name != tool_name.strip() or "*" in tool_name:
+    if (
+        not tool_name
+        or tool_name != tool_name.strip()
+        or "*" in tool_name
+        or "__" in tool_name
+    ):
         raise AIError(ErrorCode.CAPABILITY_RESOLUTION_INVALID)
     return f"{mcp_server_selector(server_id)}__{tool_name}"
 
 
-def mcp_selector_server(selector: str) -> "tuple[str, str | None] | None":
-    """Return namespace and exact tool name for one canonical MCP selector."""
-    if not selector.startswith("mcp__"):
-        return None
-    tail = selector[5:]
-    namespace, separator, tool = tail.partition("__")
-    if not namespace:
-        raise AIError(ErrorCode.CAPABILITY_RESOLUTION_INVALID)
-    if not separator:
-        return namespace, None
-    if not tool:
-        raise AIError(ErrorCode.CAPABILITY_RESOLUTION_INVALID)
-    return namespace, None if tool == "*" else tool
-
-
 __all__ = [
-    "mcp_selector_server",
     "mcp_server_namespace",
     "mcp_server_selector",
     "mcp_tool_name",

--- a/linktools-ai/src/linktools/ai/capability/_names.py
+++ b/linktools-ai/src/linktools/ai/capability/_names.py
@@ -1,8 +1,0 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-"""Stable capability tool-name groups used by agent materialization."""
-
-SKILL_TOOL_NAMES = ("list_skills", "load_skill")
-SUBAGENT_TOOL_NAMES = ("list_subagents", "delegate_task")
-
-__all__ = ["SKILL_TOOL_NAMES", "SUBAGENT_TOOL_NAMES"]

--- a/linktools-ai/src/linktools/ai/capability/_skill.py
+++ b/linktools-ai/src/linktools/ai/capability/_skill.py
@@ -21,6 +21,7 @@ from ._skill_source import (
     SkillSourceRegistry,
     normalize_skill_resource_path,
 )
+from ._tool_semantic import tool_semantic_metadata
 
 
 @dataclass(frozen=True, slots=True)
@@ -133,14 +134,24 @@ class LinkToolsSkills(AbstractCapability[AgentContext[object]]):
     def get_toolset(self) -> FunctionToolset[AgentContext[object]]:
         toolset = FunctionToolset[AgentContext[object]](id=self.id)
 
-        @toolset.tool
+        @toolset.tool(
+            metadata=tool_semantic_metadata(
+                plan_safe=True,
+                compaction_keep_result=True,
+            )
+        )
         async def list_skills(
             _ctx: PydanticRunContext[AgentContext[object]],
         ) -> list[dict[str, str]]:
             """List skills available for this agent run."""
             return await self.list_skills()
 
-        @toolset.tool
+        @toolset.tool(
+            metadata=tool_semantic_metadata(
+                plan_safe=True,
+                compaction_keep_result=True,
+            )
+        )
         async def load_skill(
             _ctx: PydanticRunContext[AgentContext[object]],
             skill_id: str,

--- a/linktools-ai/src/linktools/ai/capability/_subagent.py
+++ b/linktools-ai/src/linktools/ai/capability/_subagent.py
@@ -15,7 +15,7 @@ from ..core import JsonValue
 from ..errors import AIError, ErrorCode
 from ..spec import SubagentRef
 from ._context import AgentContext
-from ._workspace import workspace_tool_path_metadata
+from ._tool_semantic import tool_semantic_metadata
 
 SUBAGENT_CAPABILITY_ID = "linktools.ai.subagents"
 
@@ -62,14 +62,21 @@ class LinkToolsSubagents(AbstractCapability[AgentContext[object]]):
     def get_toolset(self) -> FunctionToolset[AgentContext[object]]:
         toolset = FunctionToolset[AgentContext[object]](id=self.id)
 
-        @toolset.tool
+        @toolset.tool(
+            metadata=tool_semantic_metadata(
+                plan_safe=True,
+                compaction_keep_result=True,
+            )
+        )
         async def list_subagents(
             _ctx: PydanticRunContext[AgentContext[object]],
         ) -> list[dict[str, str]]:
             """List subagents available for this agent run."""
             return await self.list_subagents()
 
-        @toolset.tool(metadata=workspace_tool_path_metadata(("files",)))
+        @toolset.tool(
+            metadata=tool_semantic_metadata(compaction_keep_result=True)
+        )
         async def delegate_task(
             ctx: PydanticRunContext[AgentContext[object]],
             subagent_id: str,

--- a/linktools-ai/src/linktools/ai/capability/_tool_semantic.py
+++ b/linktools-ai/src/linktools/ai/capability/_tool_semantic.py
@@ -73,10 +73,11 @@ def validate_tool_semantic_metadata(
     metadata: Mapping[str, object] | None,
     *,
     require_effect: bool = False,
+    require_tool_class: bool = False,
 ) -> None:
     """Validate LinkTools Tool metadata without coercing any value."""
     if metadata is None:
-        if require_effect:
+        if require_effect or require_tool_class:
             raise AIError(ErrorCode.CAPABILITY_RESOLUTION_INVALID)
         return
     if not isinstance(metadata, Mapping):
@@ -100,6 +101,8 @@ def validate_tool_semantic_metadata(
     if tool_class is not None or TOOL_CLASS_METADATA_KEY in metadata:
         if not isinstance(tool_class, str) or tool_class not in _TOOL_CLASSES:
             raise AIError(ErrorCode.CAPABILITY_RESOLUTION_INVALID)
+    elif require_tool_class:
+        raise AIError(ErrorCode.CAPABILITY_RESOLUTION_INVALID)
 
     path_fields = metadata.get(TOOL_PATH_FIELDS_METADATA_KEY)
     if path_fields is not None or TOOL_PATH_FIELDS_METADATA_KEY in metadata:

--- a/linktools-ai/src/linktools/ai/capability/_tool_semantic.py
+++ b/linktools-ai/src/linktools/ai/capability/_tool_semantic.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Shared Tool metadata keys and strict semantic parsing."""
+
+from collections.abc import Mapping, Sequence
+from typing import Literal, cast
+
+from ..errors import AIError, ErrorCode
+
+TOOL_EFFECT_METADATA_KEY = "linktools.ai.effect"
+TOOL_PLAN_SAFE_METADATA_KEY = "linktools.ai.plan_safe"
+TOOL_CLASS_METADATA_KEY = "linktools.ai.tool_class"
+TOOL_PATH_FIELDS_METADATA_KEY = "linktools.ai.path_fields"
+TOOL_COMPACTION_KEEP_RESULT_METADATA_KEY = (
+    "linktools.ai.compaction_keep_result"
+)
+TOOL_CONTEXT_DEDUPE_METADATA_KEY = "linktools.ai.context_dedupe"
+
+ToolEffect = Literal["none", "replay_safe", "non_replay_safe"]
+ToolClass = Literal[
+    "business",
+    "filesystem.read",
+    "filesystem.write",
+    "shell",
+    "mcp",
+]
+ToolContextDedupe = Literal["workspace_file_read_v1"]
+
+_TOOL_EFFECTS = {"none", "replay_safe", "non_replay_safe"}
+_TOOL_CLASSES = {
+    "business",
+    "filesystem.read",
+    "filesystem.write",
+    "shell",
+    "mcp",
+}
+_TOOL_CONTEXT_DEDUPE = "workspace_file_read_v1"
+
+
+def tool_semantic_metadata(
+    *,
+    effect: ToolEffect | None = None,
+    plan_safe: bool | None = None,
+    tool_class: ToolClass | None = None,
+    path_fields: Sequence[str] | None = None,
+    compaction_keep_result: bool | None = None,
+    context_dedupe: ToolContextDedupe | None = None,
+    base: Mapping[str, object] | None = None,
+) -> dict[str, object]:
+    """Build Tool metadata while preserving unrelated upstream metadata."""
+    metadata = {} if base is None else dict(base)
+    if effect is not None:
+        metadata[TOOL_EFFECT_METADATA_KEY] = effect
+    if plan_safe is not None:
+        metadata[TOOL_PLAN_SAFE_METADATA_KEY] = plan_safe
+    if tool_class is not None:
+        metadata[TOOL_CLASS_METADATA_KEY] = tool_class
+    if path_fields is not None:
+        if isinstance(path_fields, (str, bytes, bytearray)):
+            raise AIError(ErrorCode.CAPABILITY_RESOLUTION_INVALID)
+        metadata[TOOL_PATH_FIELDS_METADATA_KEY] = list(path_fields)
+    if compaction_keep_result is not None:
+        metadata[TOOL_COMPACTION_KEEP_RESULT_METADATA_KEY] = (
+            compaction_keep_result
+        )
+    if context_dedupe is not None:
+        metadata[TOOL_CONTEXT_DEDUPE_METADATA_KEY] = context_dedupe
+    validate_tool_semantic_metadata(metadata)
+    return metadata
+
+
+def validate_tool_semantic_metadata(
+    metadata: Mapping[str, object] | None,
+    *,
+    require_effect: bool = False,
+) -> None:
+    """Validate LinkTools Tool metadata without coercing any value."""
+    if metadata is None:
+        if require_effect:
+            raise AIError(ErrorCode.CAPABILITY_RESOLUTION_INVALID)
+        return
+    if not isinstance(metadata, Mapping):
+        raise AIError(ErrorCode.CAPABILITY_RESOLUTION_INVALID)
+
+    effect = metadata.get(TOOL_EFFECT_METADATA_KEY)
+    if effect is not None or TOOL_EFFECT_METADATA_KEY in metadata:
+        if not isinstance(effect, str) or effect not in _TOOL_EFFECTS:
+            raise AIError(ErrorCode.CAPABILITY_RESOLUTION_INVALID)
+    elif require_effect:
+        raise AIError(ErrorCode.CAPABILITY_RESOLUTION_INVALID)
+
+    for key in (
+        TOOL_PLAN_SAFE_METADATA_KEY,
+        TOOL_COMPACTION_KEEP_RESULT_METADATA_KEY,
+    ):
+        if key in metadata and type(metadata[key]) is not bool:
+            raise AIError(ErrorCode.CAPABILITY_RESOLUTION_INVALID)
+
+    tool_class = metadata.get(TOOL_CLASS_METADATA_KEY)
+    if tool_class is not None or TOOL_CLASS_METADATA_KEY in metadata:
+        if not isinstance(tool_class, str) or tool_class not in _TOOL_CLASSES:
+            raise AIError(ErrorCode.CAPABILITY_RESOLUTION_INVALID)
+
+    path_fields = metadata.get(TOOL_PATH_FIELDS_METADATA_KEY)
+    if path_fields is not None or TOOL_PATH_FIELDS_METADATA_KEY in metadata:
+        if not isinstance(path_fields, list):
+            raise AIError(ErrorCode.CAPABILITY_RESOLUTION_INVALID)
+        if any(
+            not isinstance(field, str) or not field
+            for field in path_fields
+        ):
+            raise AIError(ErrorCode.CAPABILITY_RESOLUTION_INVALID)
+        if len(path_fields) != len(set(path_fields)):
+            raise AIError(ErrorCode.CAPABILITY_RESOLUTION_INVALID)
+
+    context_dedupe = metadata.get(TOOL_CONTEXT_DEDUPE_METADATA_KEY)
+    if context_dedupe is not None or TOOL_CONTEXT_DEDUPE_METADATA_KEY in metadata:
+        if context_dedupe != _TOOL_CONTEXT_DEDUPE:
+            raise AIError(ErrorCode.CAPABILITY_RESOLUTION_INVALID)
+
+
+def tool_effect_from_metadata(
+    metadata: Mapping[str, object] | None,
+    *,
+    require: bool = False,
+) -> ToolEffect | None:
+    validate_tool_semantic_metadata(metadata, require_effect=require)
+    value = None if metadata is None else metadata.get(TOOL_EFFECT_METADATA_KEY)
+    return cast("ToolEffect | None", value)
+
+
+def tool_plan_safe_from_metadata(metadata: Mapping[str, object] | None) -> bool:
+    validate_tool_semantic_metadata(metadata)
+    value = None if metadata is None else metadata.get(TOOL_PLAN_SAFE_METADATA_KEY)
+    return False if value is None else cast(bool, value)
+
+
+def tool_class_from_metadata(
+    metadata: Mapping[str, object] | None,
+) -> ToolClass | None:
+    validate_tool_semantic_metadata(metadata)
+    value = None if metadata is None else metadata.get(TOOL_CLASS_METADATA_KEY)
+    return cast("ToolClass | None", value)
+
+
+def tool_path_fields_from_metadata(
+    metadata: Mapping[str, object] | None,
+) -> tuple[str, ...]:
+    validate_tool_semantic_metadata(metadata)
+    value = None if metadata is None else metadata.get(TOOL_PATH_FIELDS_METADATA_KEY)
+    return () if value is None else tuple(cast(list[str], value))
+
+
+def tool_compaction_keep_result_from_metadata(
+    metadata: Mapping[str, object] | None,
+) -> bool:
+    validate_tool_semantic_metadata(metadata)
+    value = (
+        None
+        if metadata is None
+        else metadata.get(TOOL_COMPACTION_KEEP_RESULT_METADATA_KEY)
+    )
+    return False if value is None else cast(bool, value)
+
+
+def tool_context_dedupe_from_metadata(
+    metadata: Mapping[str, object] | None,
+) -> ToolContextDedupe | None:
+    validate_tool_semantic_metadata(metadata)
+    value = (
+        None
+        if metadata is None
+        else metadata.get(TOOL_CONTEXT_DEDUPE_METADATA_KEY)
+    )
+    return cast("ToolContextDedupe | None", value)
+
+
+__all__ = [
+    "TOOL_CLASS_METADATA_KEY",
+    "TOOL_COMPACTION_KEEP_RESULT_METADATA_KEY",
+    "TOOL_CONTEXT_DEDUPE_METADATA_KEY",
+    "TOOL_EFFECT_METADATA_KEY",
+    "TOOL_PATH_FIELDS_METADATA_KEY",
+    "TOOL_PLAN_SAFE_METADATA_KEY",
+    "ToolClass",
+    "ToolContextDedupe",
+    "ToolEffect",
+    "tool_class_from_metadata",
+    "tool_compaction_keep_result_from_metadata",
+    "tool_context_dedupe_from_metadata",
+    "tool_effect_from_metadata",
+    "tool_path_fields_from_metadata",
+    "tool_plan_safe_from_metadata",
+    "tool_semantic_metadata",
+    "validate_tool_semantic_metadata",
+]

--- a/linktools-ai/src/linktools/ai/capability/_workspace.py
+++ b/linktools-ai/src/linktools/ai/capability/_workspace.py
@@ -26,63 +26,82 @@ from ..workspace import (
     normalize_workspace_path,
 )
 from ._context import AgentContext
-from ._group import (
-    CapabilityContribution,
-    capability_fingerprint,
-    contribution_semantic_contract,
-)
+from ._group import CapabilityContribution
+from ._tool_semantic import tool_semantic_metadata
 
 _ResultT = TypeVar("_ResultT")
 
-_BASE_WORKSPACE_FILESYSTEM_TOOL_NAMES = (
-    "attach_files",
-    "create_directory",
-    "edit_file",
-    "file_info",
-    "find_files",
-    "list_directory",
-    "read_file",
-    "search_files",
-    "write_file",
-)
-_BASE_WORKSPACE_FILESYSTEM_READ_TOOL_NAMES = (
-    "attach_files",
-    "file_info",
-    "find_files",
-    "list_directory",
-    "read_file",
-    "search_files",
-)
-WORKSPACE_FILESYSTEM_TOOL_NAMES = (
-    *_BASE_WORKSPACE_FILESYSTEM_TOOL_NAMES,
-)
-WORKSPACE_FILESYSTEM_READ_TOOL_NAMES = (
-    *_BASE_WORKSPACE_FILESYSTEM_READ_TOOL_NAMES,
-)
-WORKSPACE_SHELL_TOOL_NAMES = (
-    "check_command",
-    "run_command",
-    "start_command",
-    "stop_command",
-)
-_WORKSPACE_TOOL_NAMES = (
-    *WORKSPACE_FILESYSTEM_TOOL_NAMES,
-    *WORKSPACE_SHELL_TOOL_NAMES,
-)
-_WORKSPACE_TOOL_CLASSES = {
-    **{
-        name: "filesystem.read"
-        for name in WORKSPACE_FILESYSTEM_READ_TOOL_NAMES
-    },
-    **{
-        name: "filesystem.write"
-        for name in WORKSPACE_FILESYSTEM_TOOL_NAMES
-        if name not in WORKSPACE_FILESYSTEM_READ_TOOL_NAMES
-    },
-    **{name: "shell" for name in WORKSPACE_SHELL_TOOL_NAMES},
+_WORKSPACE_TOOL_DECLARATIONS: dict[str, Mapping[str, object]] = {
+    "attach_files": tool_semantic_metadata(
+        effect="none",
+        plan_safe=True,
+        tool_class="filesystem.read",
+        path_fields=("paths",),
+    ),
+    "create_directory": tool_semantic_metadata(
+        effect="non_replay_safe",
+        tool_class="filesystem.write",
+        path_fields=("path",),
+    ),
+    "edit_file": tool_semantic_metadata(
+        effect="non_replay_safe",
+        tool_class="filesystem.write",
+        path_fields=("path",),
+    ),
+    "file_info": tool_semantic_metadata(
+        effect="none",
+        plan_safe=True,
+        tool_class="filesystem.read",
+        path_fields=("path",),
+    ),
+    "find_files": tool_semantic_metadata(
+        effect="none",
+        plan_safe=True,
+        tool_class="filesystem.read",
+        path_fields=("path",),
+    ),
+    "list_directory": tool_semantic_metadata(
+        effect="none",
+        plan_safe=True,
+        tool_class="filesystem.read",
+        path_fields=("path",),
+    ),
+    "read_file": tool_semantic_metadata(
+        effect="none",
+        plan_safe=True,
+        tool_class="filesystem.read",
+        path_fields=("path",),
+        context_dedupe="workspace_file_read_v1",
+    ),
+    "search_files": tool_semantic_metadata(
+        effect="none",
+        plan_safe=True,
+        tool_class="filesystem.read",
+        path_fields=("path",),
+    ),
+    "write_file": tool_semantic_metadata(
+        effect="non_replay_safe",
+        tool_class="filesystem.write",
+        path_fields=("path",),
+    ),
+    "check_command": tool_semantic_metadata(
+        effect="none",
+        plan_safe=True,
+        tool_class="shell",
+    ),
+    "run_command": tool_semantic_metadata(
+        effect="non_replay_safe",
+        tool_class="shell",
+    ),
+    "start_command": tool_semantic_metadata(
+        effect="non_replay_safe",
+        tool_class="shell",
+    ),
+    "stop_command": tool_semantic_metadata(
+        effect="non_replay_safe",
+        tool_class="shell",
+    ),
 }
-_WORKSPACE_METADATA_KEY = "linktools.ai.workspace_tool_class"
-_WORKSPACE_PATH_FIELDS_KEY = "linktools.ai.workspace_path_fields"
 _WORKSPACE_SANDBOX_CAPABILITY_ID = "workspace-sandbox"
 _MODEL_CORRECTABLE_ERRORS = {
     ErrorCode.REQUEST_FIELD_INVALID,
@@ -161,29 +180,6 @@ class WorkspaceAccess:
             self._session = None
         if session is not None:
             await session.close()
-
-
-def workspace_tool_path_fields(tool: Tool[Any]) -> tuple[str, ...]:
-    metadata = tool.tool_def.metadata or {}
-    return workspace_tool_path_fields_from_metadata(metadata)
-
-
-def workspace_tool_path_fields_from_metadata(
-    metadata: Mapping[str, object] | None,
-) -> tuple[str, ...]:
-    value = None if metadata is None else metadata.get(_WORKSPACE_PATH_FIELDS_KEY)
-    if not isinstance(value, (list, tuple)):
-        return ()
-    return tuple(item for item in value if isinstance(item, str))
-
-
-def workspace_tool_path_metadata(fields: Sequence[str]) -> dict[str, object]:
-    values = tuple(fields)
-    if not values or any(not isinstance(field, str) or not field for field in values):
-        raise ValueError("workspace path fields must be non-empty strings")
-    if len(values) != len(set(values)):
-        raise ValueError("workspace path fields must be unique")
-    return {_WORKSPACE_PATH_FIELDS_KEY: list(values)}
 
 
 class _WorkspaceToolSurface:
@@ -489,7 +485,13 @@ class _WorkspaceSandboxToolset(FunctionToolset[AgentContext[object]]):
         super().__init__(id=_WORKSPACE_SANDBOX_CAPABILITY_ID)
         surface = _WorkspaceToolSurface(session, policy)
         for name in selected_tool_names:
-            self.add_tool(_workspace_tool(surface, name))
+            self.add_tool(
+                _workspace_tool(
+                    surface,
+                    name,
+                    _WORKSPACE_TOOL_DECLARATIONS[name],
+                )
+            )
 
 
 class _WorkspaceCapability(AbstractCapability[AgentContext[object]]):
@@ -518,17 +520,9 @@ def workspace_tool_contributions(
     """Return the stable workspace tool definitions used by the compiler."""
     surface = _WorkspaceToolSurface(None, workspace.policy)
     result: list[CapabilityContribution[object]] = []
-    for name in _WORKSPACE_TOOL_NAMES:
-        tool = _workspace_tool(surface, name)
-        semantic = contribution_semantic_contract("tool", name, tool)
-        result.append(
-            CapabilityContribution(
-                "tool",
-                name,
-                capability_fingerprint("tool", name, semantic),
-                tool,
-            )
-        )
+    for name, metadata in _WORKSPACE_TOOL_DECLARATIONS.items():
+        tool = _workspace_tool(surface, name, metadata)
+        result.append(CapabilityContribution.from_opaque("tool", name, tool))
     return tuple(result)
 
 
@@ -540,14 +534,16 @@ def workspace_capabilities(
 ) -> tuple[AbstractCapability[AgentContext[object]], ...]:
     """Adapt selected tools to a caller-owned, already-opened session."""
     selected = frozenset(selected_tool_names)
-    unknown = selected.difference(_WORKSPACE_TOOL_NAMES)
+    unknown = selected.difference(_WORKSPACE_TOOL_DECLARATIONS)
     if unknown:
         raise ValueError(f"unknown workspace tools: {tuple(sorted(unknown))}")
     if not selected:
         return ()
     if session is None:
         raise AIError(ErrorCode.SANDBOX_SESSION_CLOSED)
-    ordered = tuple(name for name in _WORKSPACE_TOOL_NAMES if name in selected)
+    ordered = tuple(
+        name for name in _WORKSPACE_TOOL_DECLARATIONS if name in selected
+    )
     _logger.debug(
         "workspace capability materialized: tools=%s session_open=%s",
         ordered,
@@ -556,47 +552,21 @@ def workspace_capabilities(
     return (_WorkspaceCapability(ordered, session, workspace.policy),)
 
 
-def workspace_tool_class(tool: Tool[Any]) -> str | None:
-    if not isinstance(tool, Tool):
-        return None
-    expected = _WORKSPACE_TOOL_CLASSES.get(tool.name)
-    if expected is None:
-        return None
-    metadata = tool.tool_def.metadata or {}
-    if metadata.get(_WORKSPACE_METADATA_KEY) != expected:
-        return None
-    return expected
-
-
-def _workspace_tool(surface: _WorkspaceToolSurface, name: str) -> Tool[Any]:
-    tool_class = (
-        "filesystem.read"
-        if name in WORKSPACE_FILESYSTEM_READ_TOOL_NAMES
-        else "filesystem.write"
-        if name in WORKSPACE_FILESYSTEM_TOOL_NAMES
-        else "shell"
-    )
-    metadata: dict[str, object] = {_WORKSPACE_METADATA_KEY: tool_class}
-    if tool_class in {"filesystem.read", "filesystem.write"}:
-        fields = ("paths",) if name == "attach_files" else ("path",)
-        metadata.update(workspace_tool_path_metadata(fields))
+def _workspace_tool(
+    surface: _WorkspaceToolSurface,
+    name: str,
+    metadata: Mapping[str, object],
+) -> Tool[Any]:
     return Tool(
         cast(Any, getattr(surface, name)),
         takes_ctx=False,
         name=name,
-        metadata=metadata,
+        metadata=dict(metadata),
     )
 
 
 __all__ = [
-    "WORKSPACE_FILESYSTEM_READ_TOOL_NAMES",
-    "WORKSPACE_FILESYSTEM_TOOL_NAMES",
-    "WORKSPACE_SHELL_TOOL_NAMES",
     "WorkspaceAccess",
     "workspace_capabilities",
-    "workspace_tool_class",
-    "workspace_tool_path_fields",
-    "workspace_tool_path_fields_from_metadata",
-    "workspace_tool_path_metadata",
     "workspace_tool_contributions",
 ]

--- a/linktools-ai/src/linktools/ai/migrate/_database.py
+++ b/linktools-ai/src/linktools/ai/migrate/_database.py
@@ -11,7 +11,7 @@ from linktools.core import environ
 from ..asset import build_asset_sql_metadata
 from ..errors import AIError, ErrorCode
 from ..observe import build_metrics_sql_metadata
-from ..runtime.state import RuntimeDomain
+from ..runtime.state import RuntimeDomain, runtime_domain_uses_object_store
 from ..runtime.state.schema import build_runtime_sql_metadata
 from ..storage import build_object_sql_metadata, provision_sql
 
@@ -33,8 +33,6 @@ def build_sql_schema_metadata() -> "MetaData":
     build_object_sql_metadata(metadata=metadata)
     build_asset_sql_metadata(metadata=metadata)
     build_metrics_sql_metadata(metadata=metadata)
-    if len(metadata.tables) != 12:
-        raise RuntimeError("complete SQL schema must contain exactly 12 tables")
     return metadata
 
 
@@ -60,15 +58,8 @@ async def provision_runtime_database(
 
     metadata = MetaData()
     build_runtime_sql_metadata(selected, metadata=metadata)
-    if object_store is None and selected & frozenset(
-        {
-            RuntimeDomain.CONVERSATION,
-            RuntimeDomain.EXECUTION,
-            RuntimeDomain.MEMORY,
-            RuntimeDomain.ARTIFACT,
-            RuntimeDomain.RECOVERY,
-            RuntimeDomain.TASK,
-        }
+    if object_store is None and any(
+        runtime_domain_uses_object_store(domain) for domain in selected
     ):
         build_object_sql_metadata(metadata=metadata)
     await provision_sql(engine, metadata)

--- a/linktools-ai/src/linktools/ai/model/__init__.py
+++ b/linktools-ai/src/linktools/ai/model/__init__.py
@@ -2,18 +2,7 @@
 # -*- coding: utf-8 -*-
 """Model registry, resolver, and binding contracts."""
 
-from ._contract import (
-    LinkToolsUploadedFile,
-    ModelBinding,
-    ModelResolver,
-    declared_uploaded_file_media_type,
-)
+from ._contract import ModelBinding, ModelResolver
 from ._registry import ModelRegistry
 
-__all__ = [
-    "LinkToolsUploadedFile",
-    "ModelBinding",
-    "ModelRegistry",
-    "ModelResolver",
-    "declared_uploaded_file_media_type",
-]
+__all__ = ["ModelBinding", "ModelRegistry", "ModelResolver"]

--- a/linktools-ai/src/linktools/ai/model/__init__.py
+++ b/linktools-ai/src/linktools/ai/model/__init__.py
@@ -2,7 +2,18 @@
 # -*- coding: utf-8 -*-
 """Model registry, resolver, and binding contracts."""
 
-from ._contract import ModelBinding, ModelResolver
+from ._contract import (
+    LinkToolsUploadedFile,
+    ModelBinding,
+    ModelResolver,
+    declared_uploaded_file_media_type,
+)
 from ._registry import ModelRegistry
 
-__all__ = ["ModelBinding", "ModelRegistry", "ModelResolver"]
+__all__ = [
+    "LinkToolsUploadedFile",
+    "ModelBinding",
+    "ModelRegistry",
+    "ModelResolver",
+    "declared_uploaded_file_media_type",
+]

--- a/linktools-ai/src/linktools/ai/model/_contract.py
+++ b/linktools-ai/src/linktools/ai/model/_contract.py
@@ -3,8 +3,9 @@
 """Logical model binding and resolution contracts."""
 
 from collections.abc import Mapping
-from typing import Protocol
+from typing import Any, Literal, Protocol
 
+from pydantic_ai.messages import UploadedFile, UploadedFileProviderName
 from pydantic_ai.models import Model
 
 from ..core import JsonValue
@@ -19,6 +20,9 @@ class ModelBinding(Protocol):
 
     @property
     def model_identity(self) -> str: ...
+
+    @property
+    def vision(self) -> bool: ...
 
     @property
     def semantic_payload(self) -> Mapping[str, JsonValue]: ...
@@ -42,4 +46,44 @@ class ModelResolver(Protocol):
     ) -> ModelBinding: ...
 
 
-__all__ = ["ModelBinding", "ModelResolver"]
+class LinkToolsUploadedFile(UploadedFile):
+    """UploadedFile with LinkTools-owned media type provenance."""
+
+    declared_media_type: str | None
+
+    def __init__(
+        self,
+        file_id: str,
+        provider_name: UploadedFileProviderName,
+        *,
+        media_type: str | None = None,
+        vendor_metadata: dict[str, Any] | None = None,
+        identifier: str | None = None,
+        kind: Literal["uploaded-file"] = "uploaded-file",
+    ) -> None:
+        super().__init__(
+            file_id,
+            provider_name,
+            media_type=media_type,
+            vendor_metadata=vendor_metadata,
+            identifier=identifier,
+            kind=kind,
+        )
+        object.__setattr__(self, "declared_media_type", media_type)
+
+
+def declared_uploaded_file_media_type(value: UploadedFile) -> str | None:
+    """Return only a media type explicitly supplied to UploadedFile."""
+    if not isinstance(value, UploadedFile):
+        raise TypeError("value must be UploadedFile")
+    if not isinstance(value, LinkToolsUploadedFile):
+        return None
+    return value.declared_media_type
+
+
+__all__ = [
+    "LinkToolsUploadedFile",
+    "ModelBinding",
+    "ModelResolver",
+    "declared_uploaded_file_media_type",
+]

--- a/linktools-ai/src/linktools/ai/model/_contract.py
+++ b/linktools-ai/src/linktools/ai/model/_contract.py
@@ -3,9 +3,8 @@
 """Logical model binding and resolution contracts."""
 
 from collections.abc import Mapping
-from typing import Any, Literal, Protocol
+from typing import Protocol
 
-from pydantic_ai.messages import UploadedFile, UploadedFileProviderName
 from pydantic_ai.models import Model
 
 from ..core import JsonValue
@@ -46,44 +45,4 @@ class ModelResolver(Protocol):
     ) -> ModelBinding: ...
 
 
-class LinkToolsUploadedFile(UploadedFile):
-    """UploadedFile with LinkTools-owned media type provenance."""
-
-    declared_media_type: str | None
-
-    def __init__(
-        self,
-        file_id: str,
-        provider_name: UploadedFileProviderName,
-        *,
-        media_type: str | None = None,
-        vendor_metadata: dict[str, Any] | None = None,
-        identifier: str | None = None,
-        kind: Literal["uploaded-file"] = "uploaded-file",
-    ) -> None:
-        super().__init__(
-            file_id,
-            provider_name,
-            media_type=media_type,
-            vendor_metadata=vendor_metadata,
-            identifier=identifier,
-            kind=kind,
-        )
-        object.__setattr__(self, "declared_media_type", media_type)
-
-
-def declared_uploaded_file_media_type(value: UploadedFile) -> str | None:
-    """Return only a media type explicitly supplied to UploadedFile."""
-    if not isinstance(value, UploadedFile):
-        raise TypeError("value must be UploadedFile")
-    if not isinstance(value, LinkToolsUploadedFile):
-        return None
-    return value.declared_media_type
-
-
-__all__ = [
-    "LinkToolsUploadedFile",
-    "ModelBinding",
-    "ModelResolver",
-    "declared_uploaded_file_media_type",
-]
+__all__ = ["ModelBinding", "ModelResolver"]

--- a/linktools-ai/src/linktools/ai/model/_openai.py
+++ b/linktools-ai/src/linktools/ai/model/_openai.py
@@ -27,7 +27,6 @@ from pydantic_ai.providers.openai import OpenAIProvider
 
 from ..core import JsonValue, canonical_sha256
 from ..errors import AIError, ErrorCode
-from ._contract import declared_uploaded_file_media_type
 
 _logger = environ.get_logger("ai.model.openai")
 
@@ -266,11 +265,7 @@ def _contains_image_content(value: object) -> bool:
     if isinstance(value, ImageUrl):
         return True
     if isinstance(value, UploadedFile):
-        media_type = declared_uploaded_file_media_type(value)
-        return (
-            isinstance(media_type, str)
-            and media_type.lower().startswith("image/")
-        )
+        return value.media_type.lower().startswith("image/")
     if isinstance(value, Mapping):
         return any(_contains_image_content(item) for item in value.values())
     if isinstance(value, Sequence) and not isinstance(

--- a/linktools-ai/src/linktools/ai/model/_openai.py
+++ b/linktools-ai/src/linktools/ai/model/_openai.py
@@ -4,13 +4,14 @@
 
 import asyncio
 import math
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Mapping, Sequence
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from urllib.parse import urlsplit, urlunsplit
 
 from linktools.core import environ
 from pydantic_ai.exceptions import ModelAPIError, ModelHTTPError, UserError
+from pydantic_ai.messages import BinaryContent, ImageUrl, ModelRequest, UploadedFile
 from pydantic_ai.models import (
     Model,
     ModelMessage,
@@ -26,6 +27,7 @@ from pydantic_ai.providers.openai import OpenAIProvider
 
 from ..core import JsonValue, canonical_sha256
 from ..errors import AIError, ErrorCode
+from ._contract import declared_uploaded_file_media_type
 
 _logger = environ.get_logger("ai.model.openai")
 
@@ -34,6 +36,7 @@ _logger = environ.get_logger("ai.model.openai")
 class _OpenAIModelBinding:
     route_id: str
     model: str
+    vision: bool = False
     base_url: "str | None" = None
     api_key: "str | None" = field(default=None, repr=False, compare=False)
     timeout: "int | float | None" = None
@@ -45,6 +48,8 @@ class _OpenAIModelBinding:
         model = self.model.strip().removeprefix("openai:")
         if not self.route_id.strip() or not model:
             raise ValueError("OpenAI model binding is incomplete")
+        if type(self.vision) is not bool:
+            raise ValueError("OpenAI model vision must be bool")
         object.__setattr__(self, "model", model)
         object.__setattr__(self, "base_url", _normalize_base_url(self.base_url))
         if self.api_key is not None and not self.api_key.strip():
@@ -70,6 +75,7 @@ class _OpenAIModelBinding:
         return {
             "provider": self.provider,
             "model_identity": self.model_identity,
+            "vision": self.vision,
             "settings": settings,
         }
 
@@ -108,7 +114,12 @@ class _OpenAIModelBinding:
             self.model,
             self.api_key is not None,
         )
-        return _RetryingModel(model, self.max_retries, self.retry_delay)
+        return _RetryingModel(
+            model,
+            self.max_retries,
+            self.retry_delay,
+            vision=self.vision,
+        )
 
 
 def _validate_positive_number(name: str, value: "int | float | None") -> None:
@@ -150,10 +161,18 @@ def _validate_non_negative_number(name: str, value: "int | float") -> None:
 class _RetryingModel(WrapperModel):
     """Apply LinkTools' finite transport retry policy at the public Model boundary."""
 
-    def __init__(self, wrapped: Model, max_retries: int, retry_delay: "int | float") -> None:
+    def __init__(
+        self,
+        wrapped: Model,
+        max_retries: int,
+        retry_delay: "int | float",
+        *,
+        vision: bool,
+    ) -> None:
         super().__init__(wrapped)
         self._max_retries = max_retries
         self._retry_delay = retry_delay
+        self._vision = vision
 
     async def request(
         self,
@@ -161,6 +180,7 @@ class _RetryingModel(WrapperModel):
         model_settings: ModelSettings | None,
         model_request_parameters: ModelRequestParameters,
     ) -> ModelResponse:
+        _validate_vision_input(messages, vision=self._vision)
         attempt = 0
         while True:
             try:
@@ -188,6 +208,7 @@ class _RetryingModel(WrapperModel):
         model_request_parameters: ModelRequestParameters,
         run_context: "PydanticRunContext[object] | None" = None,
     ) -> AsyncGenerator[StreamedResponse, None]:
+        _validate_vision_input(messages, vision=self._vision)
         attempt = 0
         while True:
             entered = False
@@ -215,6 +236,49 @@ class _RetryingModel(WrapperModel):
                     attempt,
                 )
                 await asyncio.sleep(self._retry_delay)
+
+
+def _validate_vision_input(
+    messages: Sequence[object],
+    *,
+    vision: bool,
+) -> None:
+    if vision:
+        return
+    if any(
+        _contains_image_content(part.content)
+        for message in messages
+        if isinstance(message, ModelRequest)
+        for part in message.parts
+        if hasattr(part, "content")
+    ):
+        _logger.warning("OpenAI model rejected image input: vision=false")
+        raise AIError(
+            ErrorCode.REQUEST_FIELD_INVALID,
+            retryable=False,
+            safe_details={"reason": "image_input_not_supported"},
+        )
+
+
+def _contains_image_content(value: object) -> bool:
+    if isinstance(value, BinaryContent):
+        return value.media_type.lower().startswith("image/")
+    if isinstance(value, ImageUrl):
+        return True
+    if isinstance(value, UploadedFile):
+        media_type = declared_uploaded_file_media_type(value)
+        return (
+            isinstance(media_type, str)
+            and media_type.lower().startswith("image/")
+        )
+    if isinstance(value, Mapping):
+        return any(_contains_image_content(item) for item in value.values())
+    if isinstance(value, Sequence) and not isinstance(
+        value,
+        (str, bytes, bytearray),
+    ):
+        return any(_contains_image_content(item) for item in value)
+    return False
 
 
 def _retryable_model_error(error: ModelAPIError) -> bool:

--- a/linktools-ai/src/linktools/ai/model/_registry.py
+++ b/linktools-ai/src/linktools/ai/model/_registry.py
@@ -26,6 +26,7 @@ class ModelRegistry:
         cls,
         *,
         model: str,
+        vision: bool = False,
         base_url: "str | None" = None,
         api_key: "str | None" = None,
         timeout: "int | float | None" = None,
@@ -37,6 +38,7 @@ class ModelRegistry:
         registry.register_openai(
             "default",
             model=model,
+            vision=vision,
             base_url=base_url,
             api_key=api_key,
             timeout=timeout,
@@ -58,6 +60,7 @@ class ModelRegistry:
         route_id: str,
         *,
         model: str,
+        vision: bool = False,
         base_url: "str | None" = None,
         api_key: "str | None" = None,
         timeout: "int | float | None" = None,
@@ -69,6 +72,7 @@ class ModelRegistry:
             _OpenAIModelBinding(
                 route_id=route_id,
                 model=model,
+                vision=vision,
                 base_url=base_url,
                 api_key=api_key,
                 timeout=timeout,

--- a/linktools-ai/src/linktools/ai/runtime/__init__.py
+++ b/linktools-ai/src/linktools/ai/runtime/__init__.py
@@ -4,7 +4,11 @@
 
 from ..task import CancelGraphRequest, TaskEvent, TaskEventType, TaskGraphService
 from ._agent import Agent, Execution, Session
+from ._context import RuntimeContext
+from ._metrics import RuntimeMetricFlushResult, RuntimeMetricStatus
 from ._runtime_service import Runtime
+from ._runtime_history import RuntimeHistory
+from ._task import TaskGraphRun
 from .recovery import (
     ExecutionRecoveryEffect,
     ResolveToolEffectRequest,
@@ -54,6 +58,7 @@ from .service_api import (
     ExternalSupplyResult,
     ForkExecutionRequest,
     ForkSessionRequest,
+    ListExecutionRequest,
     ListSessionRequest,
     LoadedSession,
     Page,
@@ -123,6 +128,7 @@ __all__ = [
     "ExternalSupplyResult",
     "ForkExecutionRequest",
     "ForkSessionRequest",
+    "ListExecutionRequest",
     "ListSessionRequest",
     "LoadedSession",
     "Page",
@@ -131,6 +137,10 @@ __all__ = [
     "ResumeSessionRequest",
     "RetryExecutionRequest",
     "RuntimeDomain",
+    "RuntimeContext",
+    "RuntimeHistory",
+    "RuntimeMetricFlushResult",
+    "RuntimeMetricStatus",
     "RuntimeRetentionMode",
     "RuntimeState",
     "RuntimeStatePlan",
@@ -142,6 +152,7 @@ __all__ = [
     "StartEvaluationRequest",
     "TaskEvent",
     "TaskEventType",
+    "TaskGraphRun",
     "TaskGraphRunEvent",
     "TaskGraphService",
     "ToolEffectApplied",

--- a/linktools-ai/src/linktools/ai/runtime/_agent_executor.py
+++ b/linktools-ai/src/linktools/ai/runtime/_agent_executor.py
@@ -132,6 +132,7 @@ from .state._step_contracts import StepStore
 
 _logger = environ.get_logger("ai.runtime.agent_executor")
 _SECONDARY_ERROR_CODE_KEY = "secondary_error_code"
+_PLAN_SAFE_FRAMEWORK_TOOL_KINDS = frozenset({"capability-load", "tool-search"})
 
 
 @dataclass(frozen=True, slots=True)
@@ -883,7 +884,11 @@ def _frozen_tool_metadata(
     metadata = contract.get("metadata")
     if not isinstance(metadata, Mapping):
         raise AIError(ErrorCode.CAPABILITY_RESOLUTION_INVALID)
-    validate_tool_semantic_metadata(metadata, require_effect=True)
+    validate_tool_semantic_metadata(
+        metadata,
+        require_effect=True,
+        require_tool_class=True,
+    )
     return metadata
 
 
@@ -927,7 +932,10 @@ def _plan_mode_prepare(
             for tool_def in tool_defs:
                 metadata = tool_def.metadata
                 validate_tool_semantic_metadata(metadata)
-                if tool_compaction_keep_result_from_metadata(metadata):
+                if (
+                    tool_def.tool_kind in _PLAN_SAFE_FRAMEWORK_TOOL_KINDS
+                    or tool_compaction_keep_result_from_metadata(metadata)
+                ):
                     keep_result_tools.add(tool_def.name)
                 dedupe = tool_context_dedupe_from_metadata(metadata)
                 if dedupe is not None:
@@ -939,7 +947,8 @@ def _plan_mode_prepare(
         return [
             tool_def
             for tool_def in tool_defs
-            if tool_plan_safe_from_metadata(tool_def.metadata)
+            if tool_def.tool_kind in _PLAN_SAFE_FRAMEWORK_TOOL_KINDS
+            or tool_plan_safe_from_metadata(tool_def.metadata)
         ]
 
     return prepare

--- a/linktools-ai/src/linktools/ai/runtime/_agent_executor.py
+++ b/linktools-ai/src/linktools/ai/runtime/_agent_executor.py
@@ -6,12 +6,17 @@ from __future__ import annotations
 
 import asyncio
 import uuid
-from collections.abc import AsyncIterable, Awaitable, Callable, Mapping, Sequence
+from collections.abc import (
+    AsyncIterable,
+    Awaitable,
+    Callable,
+    Mapping,
+)
 from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
 from pathlib import Path
 from time import monotonic_ns
-from typing import TYPE_CHECKING, Any, Literal, Protocol, cast
+from typing import TYPE_CHECKING, Any, Protocol, cast
 
 from linktools.core import environ
 from openai import (
@@ -69,17 +74,17 @@ from pydantic_ai.usage import RunUsage, UsageLimitExceeded, UsageLimits
 from ..agent import AgentBinding, AgentDefinition, AssistantTextOutput
 from ..capability import (
     AgentContext,
+    CapabilityContribution,
     LinkToolsSkills,
     LinkToolsSubagents,
-    PLAN_SAFE_METADATA_KEY,
-    SKILL_TOOL_NAMES,
     SkillSourceRegistry,
     SubagentDelegate,
-    WORKSPACE_FILESYSTEM_READ_TOOL_NAMES,
-    WORKSPACE_FILESYSTEM_TOOL_NAMES,
-    WORKSPACE_SHELL_TOOL_NAMES,
+    tool_compaction_keep_result_from_metadata,
+    tool_class_from_metadata,
+    tool_context_dedupe_from_metadata,
+    tool_plan_safe_from_metadata,
+    validate_tool_semantic_metadata,
     workspace_capabilities,
-    workspace_tool_class,
 )
 from ..core import (
     ExecutionDeltaType,
@@ -102,10 +107,9 @@ if TYPE_CHECKING:
     from ..workspace import RepositoryInstructions
 
 from ._capabilities import (
-    SUBAGENT_TOOL_NAMES,
     compose_platform_capabilities,
-    select_runtime_tool_names,
 )
+from ._compaction import RuntimeCompactionPolicy
 from ._input import CanonicalUserInput
 from ._journal import ModelRequestJournal
 from ._mcp import materialize_mcp_servers
@@ -117,6 +121,7 @@ from ._tool_boundary import (
     ManagedToolDescriptor,
     RepositoryInstructionBoundary,
     RuntimeToolBoundaryToolset,
+    managed_tool_descriptor_from_metadata,
 )
 from ._tool_metrics import _ToolMetricContext
 from ._tool_return_codec import (
@@ -371,7 +376,10 @@ class AgentExecutor:
         selected = tuple(
             candidate.id
             for candidate in scope.binding.definition.selected_tools
-            if workspace_tool_class(cast(Tool, candidate.value)) is not None
+            if tool_class_from_metadata(
+                _frozen_tool_metadata(candidate)
+            )
+            in {"filesystem.read", "filesystem.write", "shell"}
         )
         resources, resource_keys = await _skill_sandbox_resources(
             scope.binding.definition,
@@ -417,9 +425,12 @@ class AgentExecutor:
                     raise primary_error from cleanup_cancel.__cause__
                 raise primary_error
             except AIError as cleanup_error:
-                _logger.exception(
-                    "workspace sandbox cleanup failed after agent error: step=%s",
+                _logger.warning(
+                    "workspace sandbox cleanup failed after agent error: "
+                    "step=%s code=%s exception_type=%s",
                     scope.step_run_id,
+                    cleanup_error.code.value,
+                    type(cleanup_error).__name__,
                 )
                 raise primary_error from cleanup_error
             raise
@@ -452,11 +463,7 @@ class AgentExecutor:
             execution_id=scope.context.execution_id,
             step_run_id=scope.step_run_id,
         )
-        (
-            agent,
-            capabilities,
-            runtime_tool_names,
-        ) = await _materialize_agent(
+        agent, capabilities = await _materialize_agent(
             scope,
             model=model,
             skill_sources=self._skill_sources,
@@ -480,14 +487,15 @@ class AgentExecutor:
             _event_stream_capability(cast(EventSink, scope.event_sink)),
         )
         _logger.debug(
-            "agent execution started: agent=%s definition=%s step=%s mode=%s planning=%s thinking=%s runtime_tools=%s",
+            "agent execution started: agent=%s definition=%s step=%s "
+            "mode=%s planning=%s thinking=%s selected_tools=%s",
             definition.spec.id,
             definition.digest,
             scope.step_run_id,
             scope.mode,
             scope.planning,
             scope.thinking,
-            runtime_tool_names,
+            len(definition.selected_tools),
         )
         user_prompt = scope.user_prompt
         deferred_kwargs: dict[str, object] = {}
@@ -625,82 +633,77 @@ async def _materialize_agent(
 ) -> tuple[
     PydanticAgent[AgentContext[object], object],
     tuple[AbstractCapability[AgentContext[object]], ...],
-    tuple[str, ...],
 ]:
     definition = scope.binding.definition
     business_tools: list[Tool[AgentContext[object]]] = []
     workspace_names: list[str] = []
     business_descriptors: dict[str, ManagedToolDescriptor] = {}
-    business_plan_safe: set[str] = set()
+    workspace_descriptors: dict[str, ManagedToolDescriptor] = {}
+    compaction_policy = RuntimeCompactionPolicy()
     for candidate in definition.selected_tools:
-        tool = cast("Tool[AgentContext[object]]", candidate.value)
-        tool_class = workspace_tool_class(tool)
+        source_tool = cast("Tool[AgentContext[object]]", candidate.value)
+        metadata = _frozen_tool_metadata(candidate)
+        tool = _tool_with_metadata(source_tool, metadata)
+        tool_class = tool_class_from_metadata(metadata)
         if tool_class is None:
+            raise AIError(ErrorCode.CAPABILITY_RESOLUTION_INVALID)
+        descriptor = managed_tool_descriptor_from_metadata(metadata)
+        if tool_class == "business":
             business_tools.append(tool)
-            contract = candidate.semantic_contract
-            effect = contract.get("effect", "non_replay_safe")
-            plan_safe = contract.get("plan_safe", False)
-            if effect not in {"none", "replay_safe", "non_replay_safe"}:
-                raise AIError(ErrorCode.CAPABILITY_RESOLUTION_INVALID)
-            if not isinstance(plan_safe, bool):
-                raise AIError(ErrorCode.CAPABILITY_RESOLUTION_INVALID)
-            business_descriptors[candidate.id] = ManagedToolDescriptor(
-                effect_owner=("none" if effect == "none" else "tool_operation"),
-                effect=cast(
-                    "Literal['none', 'replay_safe', 'non_replay_safe']",
-                    effect,
-                ),
-                tool_class="business",
-            )
-            if plan_safe:
-                business_plan_safe.add(candidate.id)
-        else:
+            business_descriptors[candidate.id] = descriptor
+        elif tool_class in {
+            "filesystem.read",
+            "filesystem.write",
+            "shell",
+        }:
             workspace_names.append(candidate.id)
-
-    runtime_tool_names = select_runtime_tool_names(
-        ordinary_tool_policy=definition.ordinary_tool_policy,
-        memory_scope=scope.context.memory_scope,
-        planning=scope.planning,
-        subagent_available=scope.subagent_available
-        and bool(scope.binding.snapshot.subagents),
-    )
+            workspace_descriptors[candidate.id] = descriptor
+        else:
+            raise AIError(ErrorCode.CAPABILITY_RESOLUTION_INVALID)
 
     capabilities: list[AbstractCapability[AgentContext[object]]] = []
     for candidate in definition.selected_capabilities:
         if not isinstance(candidate.value, AbstractCapability):
             raise AIError(ErrorCode.CAPABILITY_RESOLUTION_INVALID)
-        capabilities.append(
-            cast("AbstractCapability[AgentContext[object]]", candidate.value)
+        capability = cast(
+            "AbstractCapability[AgentContext[object]]",
+            candidate.value,
         )
+        capabilities.append(capability)
     if definition.skill_definitions:
-        capabilities.append(
-            LinkToolsSkills(
-                definition.skill_definitions,
-                skill_sources,
-                resource_paths=scope.skill_resource_paths,
-                preloaded_skill_ids=definition.spec.preload_skills,
-                max_preloaded_bytes=(
-                    scope.context.workspace.policy.max_preloaded_skill_bytes
-                ),
-            )
+        skill_capability = LinkToolsSkills(
+            definition.skill_definitions,
+            skill_sources,
+            resource_paths=scope.skill_resource_paths,
+            preloaded_skill_ids=definition.spec.preload_skills,
+            max_preloaded_bytes=(
+                scope.context.workspace.policy.max_preloaded_skill_bytes
+            ),
         )
-    if any(name in SUBAGENT_TOOL_NAMES for name in runtime_tool_names):
+        capabilities.append(skill_capability)
+    if scope.subagent_available and scope.binding.snapshot.subagents:
         if scope.subagent_delegate is None:
             raise AIError(ErrorCode.RUNTIME_DEPENDENCY_NOT_READY)
-        capabilities.append(
-            LinkToolsSubagents(
-                scope.binding.snapshot.subagents,
-                scope.subagent_delegate,
-                scope.subagent_descriptions,
-            )
+        subagent_capability = LinkToolsSubagents(
+            scope.binding.snapshot.subagents,
+            scope.subagent_delegate,
+            scope.subagent_descriptions,
         )
-    if scope.mode == "plan":
-        prepare_tools = _plan_mode_prepare(
-            business_descriptors=business_descriptors,
-            business_plan_safe=frozenset(business_plan_safe),
-            plan_mode=True,
+        capabilities.append(subagent_capability)
+    prepare_tools = _plan_mode_prepare(
+        plan_mode=scope.mode == "plan",
+        compaction_policy=compaction_policy,
+    )
+    capabilities.append(
+        PrepareTools(
+            prepare_tools,
+            id=(
+                "linktools.plan-mode"
+                if scope.mode == "plan"
+                else "linktools.semantic-capture"
+            ),
         )
-        capabilities.append(PrepareTools(prepare_tools, id="linktools.plan-mode"))
+    )
 
     tool_metrics = (
         None
@@ -728,7 +731,6 @@ async def _materialize_agent(
         if (toolset := capability.get_toolset()) is not None
     )
     if workspace_toolset_values:
-        workspace_descriptors = _workspace_descriptors(workspace_names)
         raw_toolsets.append(
             RuntimeToolBoundaryToolset(
                 workspace_toolset_values,
@@ -754,25 +756,21 @@ async def _materialize_agent(
             ),
             execution_root=str(scope.context.workspace.root),
         )
-        for mcp_toolset in mcp_toolsets:
+        for materialized in mcp_toolsets:
             raw_toolsets.append(
                 RuntimeToolBoundaryToolset(
                     (
                         cast(
                             "AbstractToolset[AgentContext[object]]",
-                            mcp_toolset,
+                            materialized.toolset,
                         ),
                     ),
                     {},
                     id="linktools.mcp",
+                    descriptor=materialized.descriptor,
                     tool_operations=scope.tool_operations,
                     tool_metrics=tool_metrics,
                     background_tasks=scope.background_tasks,
-                    default_descriptor=ManagedToolDescriptor(
-                        effect_owner="tool_operation",
-                        effect="non_replay_safe",
-                        tool_class="mcp",
-                    ),
                 )
             )
     if business_tools:
@@ -808,12 +806,10 @@ async def _materialize_agent(
         memory_scope=scope.context.memory_scope,
         step_store=scope.step_store,
         memory_store=scope.memory_store,
-        runtime_tool_names=runtime_tool_names,
+        ordinary_tool_policy=definition.ordinary_tool_policy,
+        compaction_policy=compaction_policy,
+        planning=scope.planning,
         context_target_tokens=scope.context_target_tokens,
-        workspace_read_available=(
-            scope.sandbox_session is not None
-            and any(name in WORKSPACE_FILESYSTEM_READ_TOOL_NAMES for name in workspace_names)
-        ),
         parent_step_run_id=scope.parent_step_run_id,
         plan_store_resolver=scope.plan_store_resolver,
         deferred_pause_sink=deferred_pause_sink,
@@ -877,96 +873,74 @@ async def _materialize_agent(
             toolsets=tuple(raw_toolsets),
         ),
     )
-    return (
-        agent,
-        tuple(capabilities),
-        runtime_tool_names,
+    return agent, tuple(capabilities)
+
+
+def _frozen_tool_metadata(
+    candidate: "CapabilityContribution[object]",
+) -> Mapping[str, object]:
+    contract = candidate.semantic_contract
+    metadata = contract.get("metadata")
+    if not isinstance(metadata, Mapping):
+        raise AIError(ErrorCode.CAPABILITY_RESOLUTION_INVALID)
+    validate_tool_semantic_metadata(metadata, require_effect=True)
+    return metadata
+
+
+def _tool_with_metadata(
+    tool: "Tool[AgentContext[object]]",
+    metadata: Mapping[str, object],
+) -> "Tool[AgentContext[object]]":
+    return Tool(
+        tool.function,
+        takes_ctx=tool.takes_ctx,
+        max_retries=tool.max_retries,
+        name=tool.name,
+        description=tool.description,
+        prepare=tool.prepare,
+        args_validator=tool.args_validator,
+        docstring_format=tool.docstring_format,
+        require_parameter_descriptions=tool.require_parameter_descriptions,
+        strict=tool.strict,
+        sequential=tool.sequential,
+        requires_approval=tool.requires_approval,
+        metadata=dict(metadata),
+        timeout=tool.timeout,
+        defer_loading=tool.defer_loading,
+        include_return_schema=tool.include_return_schema,
+        function_schema=tool.function_schema,
     )
-
-
-def _workspace_descriptors(
-    names: Sequence[str],
-) -> dict[str, ManagedToolDescriptor]:
-    descriptors: dict[str, ManagedToolDescriptor] = {}
-    for name in names:
-        if name in WORKSPACE_FILESYSTEM_TOOL_NAMES:
-            tool_class = (
-                "filesystem.read"
-                if name in WORKSPACE_FILESYSTEM_READ_TOOL_NAMES
-                else "filesystem.write"
-            )
-            effect = "none" if tool_class == "filesystem.read" else "non_replay_safe"
-            descriptors[name] = ManagedToolDescriptor(
-                effect_owner=("none" if effect == "none" else "tool_operation"),
-                effect=cast(
-                    "Literal['none', 'replay_safe', 'non_replay_safe']",
-                    effect,
-                ),
-                tool_class=cast(
-                    "Literal['filesystem.read', 'filesystem.write']",
-                    tool_class,
-                ),
-                workspace_path_fields=("path",),
-            )
-        elif name in WORKSPACE_SHELL_TOOL_NAMES:
-            effect = "none" if name == "check_command" else "non_replay_safe"
-            descriptors[name] = ManagedToolDescriptor(
-                effect_owner=("none" if effect == "none" else "tool_operation"),
-                effect=cast(
-                    "Literal['none', 'replay_safe', 'non_replay_safe']",
-                    effect,
-                ),
-                tool_class="shell",
-            )
-        else:
-            raise AIError(ErrorCode.CAPABILITY_RESOLUTION_INVALID)
-    return descriptors
 
 
 def _plan_mode_prepare(
     *,
-    business_descriptors: Mapping[str, ManagedToolDescriptor],
-    business_plan_safe: frozenset[str],
     plan_mode: bool,
+    compaction_policy: RuntimeCompactionPolicy | None = None,
 ) -> Callable[[PydanticRunContext[AgentContext[object]], list[ToolDefinition]], Any]:
     async def prepare(
         _ctx: PydanticRunContext[AgentContext[object]],
         tool_defs: list[ToolDefinition],
     ) -> list[ToolDefinition]:
+        if compaction_policy is not None:
+            keep_result_tools: set[str] = set()
+            context_dedupe_by_tool: dict[str, str] = {}
+            for tool_def in tool_defs:
+                metadata = tool_def.metadata
+                validate_tool_semantic_metadata(metadata)
+                if tool_compaction_keep_result_from_metadata(metadata):
+                    keep_result_tools.add(tool_def.name)
+                dedupe = tool_context_dedupe_from_metadata(metadata)
+                if dedupe is not None:
+                    context_dedupe_by_tool[tool_def.name] = dedupe
+            compaction_policy.keep_result_tools = frozenset(keep_result_tools)
+            compaction_policy.context_dedupe_by_tool = context_dedupe_by_tool
         if not plan_mode:
             return tool_defs
-        selected: list[ToolDefinition] = []
-        for tool_def in tool_defs:
-            if tool_def.tool_kind in {"capability-load", "tool-search"}:
-                selected.append(tool_def)
-                continue
-            if tool_def.name in SKILL_TOOL_NAMES:
-                selected.append(tool_def)
-                continue
-            if tool_def.name in {
-                "read_memory",
-                "search_memory",
-                "write_plan",
-                "list_subagents",
-            }:
-                selected.append(tool_def)
-                continue
-            descriptor = business_descriptors.get(tool_def.name)
-            if descriptor is not None:
-                if tool_def.name in business_plan_safe:
-                    selected.append(tool_def)
-                continue
-            if tool_def.name in WORKSPACE_FILESYSTEM_TOOL_NAMES:
-                if tool_def.name in WORKSPACE_FILESYSTEM_READ_TOOL_NAMES:
-                    selected.append(tool_def)
-                continue
-            if tool_def.name == "check_command":
-                selected.append(tool_def)
-                continue
-            metadata = tool_def.metadata or {}
-            if metadata.get(PLAN_SAFE_METADATA_KEY) is True:
-                selected.append(tool_def)
-        return selected
+        return [
+            tool_def
+            for tool_def in tool_defs
+            if tool_plan_safe_from_metadata(tool_def.metadata)
+        ]
 
     return prepare
 

--- a/linktools-ai/src/linktools/ai/runtime/_capabilities.py
+++ b/linktools-ai/src/linktools/ai/runtime/_capabilities.py
@@ -9,6 +9,7 @@ from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, cast
 
+from linktools.core import environ
 from pydantic_ai.capabilities import (
     AbstractCapability,
     AgentNode,
@@ -20,61 +21,38 @@ from pydantic_ai.messages import ModelMessage, ModelResponse
 from pydantic_ai.models import ModelRequestContext
 from pydantic_ai.run import AgentRunResult
 from pydantic_ai.tools import DeferredToolRequests, RunContext as PydanticRunContext
-from pydantic_ai_harness.planning import Planning
 from pydantic_ai_harness.step_persistence import StepPersistence
 
-from ..capability import SUBAGENT_TOOL_NAMES
-from ._compaction import ExternalModelRequestObserver, RuntimeCompaction
+from ..errors import AIError, ErrorCode
+from ._compaction import (
+    ExternalModelRequestObserver,
+    RuntimeCompaction,
+    RuntimeCompactionPolicy,
+)
 from ._harness import (
     HarnessPlanStoreAdapter,
     HarnessStepStoreAdapter,
 )
-from ._harness_memory import build_harness_memory
+from ._harness_memory import (
+    build_harness_memory,
+    select_harness_memory_tools,
+)
+from ._harness_planning import build_harness_planning
+from ._journal import (
+    MODEL_USAGE_CACHE_READ_METADATA_KEY,
+    MODEL_USAGE_CACHE_WRITE_METADATA_KEY,
+    MODEL_USAGE_INPUT_METADATA_KEY,
+    MODEL_USAGE_OUTPUT_METADATA_KEY,
+)
 from ._memory import MemoryStore
 from ._plan import RuntimePlanStore
-from .state._step_contracts import (
-    StepStore,
-)
-from ..errors import AIError, ErrorCode
+from .state._step_contracts import StepStore
 
 if TYPE_CHECKING:
     from ._journal import ModelRequestFact, ModelRequestJournal
 
-MEMORY_TOOL_NAMES = (
-    "delete_memory",
-    "read_memory",
-    "search_memory",
-    "write_memory",
-)
-MEMORY_READ_TOOL_NAMES = ("read_memory", "search_memory")
-PLANNING_TOOL_NAMES = ("write_plan",)
 _MEMORY_CAPABILITY_ID = "linktools.ai.memory"
-_PLANNING_CAPABILITY_ID = "linktools.ai.planning"
-
-
-def _tool_name_allowed(name: str, allow_tools: tuple[str, ...]) -> bool:
-    return "*" in allow_tools or name in allow_tools
-
-
-def select_runtime_tool_names(
-    *,
-    ordinary_tool_policy: tuple[str, ...],
-    memory_scope: str | None,
-    subagent_available: bool = False,
-    planning: bool = False,
-) -> tuple[str, ...]:
-    names: set[str] = set()
-    if memory_scope is not None:
-        names.update(
-            name
-            for name in MEMORY_TOOL_NAMES
-            if _tool_name_allowed(name, ordinary_tool_policy)
-        )
-    if planning:
-        names.update(PLANNING_TOOL_NAMES)
-    if subagent_available:
-        names.update(SUBAGENT_TOOL_NAMES)
-    return tuple(sorted(names))
+_logger = environ.get_logger("ai.runtime.capabilities")
 
 
 @dataclass(kw_only=True, eq=False)
@@ -137,16 +115,16 @@ class _RuntimeStepPersistence(StepPersistence[None]):
             usage = response.usage
             metadata.update(
                 {
-                    "linktools.ai.model_usage.input_tokens": str(
+                    MODEL_USAGE_INPUT_METADATA_KEY: str(
                         usage.input_tokens
                     ),
-                    "linktools.ai.model_usage.output_tokens": str(
+                    MODEL_USAGE_OUTPUT_METADATA_KEY: str(
                         usage.output_tokens
                     ),
-                    "linktools.ai.model_usage.cache_read_tokens": str(
+                    MODEL_USAGE_CACHE_READ_METADATA_KEY: str(
                         usage.cache_read_tokens
                     ),
-                    "linktools.ai.model_usage.cache_write_tokens": str(
+                    MODEL_USAGE_CACHE_WRITE_METADATA_KEY: str(
                         usage.cache_write_tokens
                     ),
                 }
@@ -324,12 +302,13 @@ async def compose_platform_capabilities(
     memory_scope: str | None,
     step_store: StepStore,
     memory_store: MemoryStore | None,
-    runtime_tool_names: tuple[str, ...],
+    ordinary_tool_policy: tuple[str, ...],
+    compaction_policy: RuntimeCompactionPolicy,
+    planning: bool,
     context_target_tokens: int | None,
     parent_step_run_id: str | None,
     plan_store_resolver: Callable[[PydanticRunContext[None]], RuntimePlanStore] | None,
     deferred_pause_sink: Callable[[int], None] | None = None,
-    workspace_read_available: bool = False,
     model_journal: "ModelRequestJournal | None" = None,
     model_observation_enabled: bool = False,
     model_request_observer: "ExternalModelRequestObserver | None" = None,
@@ -356,19 +335,17 @@ async def compose_platform_capabilities(
         model_observation_enabled=model_observation_enabled,
     )
     capabilities.append(persistence)
-    selected = frozenset(runtime_tool_names)
-    selected_memory = tuple(name for name in MEMORY_TOOL_NAMES if name in selected)
-    if selected_memory:
-        if memory_store is None or memory_scope is None:
+    selected_memory = select_harness_memory_tools(ordinary_tool_policy)
+    if memory_scope is not None and selected_memory:
+        if memory_store is None:
             raise AIError(ErrorCode.RUNTIME_DEPENDENCY_NOT_READY)
-        capabilities.append(
-            build_harness_memory(
-                memory_store,
-                selected_tool_names=selected_memory,
-                capability_id=_MEMORY_CAPABILITY_ID,
-            )
+        memory_capability = build_harness_memory(
+            memory_store,
+            allow_tools=ordinary_tool_policy,
+            capability_id=_MEMORY_CAPABILITY_ID,
         )
-    if any(name in selected for name in PLANNING_TOOL_NAMES):
+        capabilities.append(memory_capability)
+    if planning:
         if plan_store_resolver is None:
             raise AIError(ErrorCode.RUNTIME_DEPENDENCY_NOT_READY)
 
@@ -380,30 +357,28 @@ async def compose_platform_capabilities(
                 raise AIError(ErrorCode.RUNTIME_DEPENDENCY_NOT_READY)
             return HarnessPlanStoreAdapter(store)
 
-        capabilities.append(
-            Planning(
-                id=_PLANNING_CAPABILITY_ID,
-                tools=PLANNING_TOOL_NAMES,
-                store_resolver=resolve_plan_store,
-            )
-        )
+        planning_capability = build_harness_planning(resolve_plan_store)
+        capabilities.append(planning_capability)
     capabilities.append(
         RuntimeCompaction(
             context_target_tokens,
-            workspace_read_available=workspace_read_available,
+            policy=compaction_policy,
             journal=model_journal,
             observer=model_request_observer,
             projection_sink=persistence.remember_context_projection,
         )
     )
+    _logger.debug(
+        "platform capabilities composed: agent=%s step=%s memory_tools=%s "
+        "planning=%s compaction_policy=per-run",
+        agent_name,
+        step_run_id,
+        selected_memory,
+        planning,
+    )
     return tuple(capabilities)
 
 
 __all__ = [
-    "MEMORY_READ_TOOL_NAMES",
-    "MEMORY_TOOL_NAMES",
-    "PLANNING_TOOL_NAMES",
-    "SUBAGENT_TOOL_NAMES",
     "compose_platform_capabilities",
-    "select_runtime_tool_names",
 ]

--- a/linktools-ai/src/linktools/ai/runtime/_capabilities.py
+++ b/linktools-ai/src/linktools/ai/runtime/_capabilities.py
@@ -39,6 +39,7 @@ from ._harness_memory import (
 )
 from ._harness_planning import build_harness_planning
 from ._journal import (
+    DURATION_NS_METADATA_KEY,
     MODEL_USAGE_CACHE_READ_METADATA_KEY,
     MODEL_USAGE_CACHE_WRITE_METADATA_KEY,
     MODEL_USAGE_INPUT_METADATA_KEY,
@@ -110,7 +111,7 @@ class _RuntimeStepPersistence(StepPersistence[None]):
             ),
         )
         if not self.model_observation_enabled:
-            metadata.pop("linktools.ai.duration_ns", None)
+            metadata.pop(DURATION_NS_METADATA_KEY, None)
         if response is not None:
             usage = response.usage
             metadata.update(

--- a/linktools-ai/src/linktools/ai/runtime/_compaction.py
+++ b/linktools-ai/src/linktools/ai/runtime/_compaction.py
@@ -6,10 +6,11 @@ from __future__ import annotations
 
 import asyncio
 import json
-from collections.abc import Sequence
-from dataclasses import replace
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field, replace
 from typing import Any, Protocol
 
+from linktools.core import environ
 from pydantic_ai.capabilities import AbstractCapability, WrapModelRequestHandler
 from pydantic_ai.messages import ModelMessage, ModelResponse, ToolCallPart
 from pydantic_ai.models import Model, ModelRequestContext, ModelRequestParameters
@@ -31,24 +32,15 @@ from ._message import binary_content_usage, project_transient_binary_content
 
 _KEEP_COMPLETED_PAIRS = 3
 _SUMMARY_TAIL_MESSAGES = 20
-_CONTROL_TOOL_NAMES = frozenset(
-    {
-        "delegate_task",
-        "list_skills",
-        "list_subagents",
-        "load_skill",
-        "load_subagent",
-        "memory",
-        "read_memory",
-        "search_memory",
-        "write_memory",
-        "delete_memory",
-        "search_tools",
-        "subagent",
-        "tool_search",
-        "write_plan",
-    }
-)
+_logger = environ.get_logger("ai.runtime.compaction")
+
+
+@dataclass(slots=True)
+class RuntimeCompactionPolicy:
+    """Ephemeral compaction rules derived for one agent run."""
+
+    keep_result_tools: frozenset[str] = field(default_factory=frozenset)
+    context_dedupe_by_tool: Mapping[str, str] = field(default_factory=dict)
 
 
 class ExternalModelRequestObserver(Protocol):
@@ -156,7 +148,7 @@ class RuntimeCompaction(AbstractCapability[None]):
         journal: ModelRequestJournal | None = None,
         observer: ExternalModelRequestObserver | None = None,
         projection_sink: _ContextProjectionSink | None = None,
-        workspace_read_available: bool = False,
+        policy: RuntimeCompactionPolicy | None = None,
     ) -> None:
         self.id = "linktools.ai.compaction"
         if target_tokens is not None and (
@@ -165,17 +157,18 @@ class RuntimeCompaction(AbstractCapability[None]):
             or target_tokens <= 0
         ):
             raise AIError(ErrorCode.REQUEST_FIELD_INVALID)
-        if not isinstance(workspace_read_available, bool):
-            raise AIError(ErrorCode.REQUEST_FIELD_INVALID)
         self._target_tokens = target_tokens
         self._journal = journal
         self._observer = observer
         self._projection_sink = projection_sink
+        self._policy = policy
+        self._keep_result_tools: frozenset[str] = frozenset()
+        self._context_dedupe_by_tool: dict[str, str] = {}
+        self._refresh_policy()
         self._deduplicate = DeduplicateFileReads(
-            file_key=(
-                _workspace_file_key
-                if workspace_read_available
-                else lambda _call: None
+            file_key=lambda call: _context_dedupe_file_key(
+                call,
+                self._context_dedupe_by_tool,
             )
         )
 
@@ -186,6 +179,7 @@ class RuntimeCompaction(AbstractCapability[None]):
         request_context: ModelRequestContext,
         handler: WrapModelRequestHandler,
     ) -> ModelResponse:
+        self._refresh_policy()
         source = tuple(request_context.messages)
         binary_projected = project_transient_binary_content(source)
         projected_context = replace(
@@ -213,7 +207,7 @@ class RuntimeCompaction(AbstractCapability[None]):
                     ClearToolResults(
                         max_tokens=1,
                         keep_pairs=_KEEP_COMPLETED_PAIRS,
-                        exclude_tools=_CONTROL_TOOL_NAMES,
+                        exclude_tools=self._keep_result_tools,
                     ),
                     SummarizingCompaction(
                         model=summary_model,
@@ -235,6 +229,29 @@ class RuntimeCompaction(AbstractCapability[None]):
             )
         return await handler(projected_context)
 
+    def _refresh_policy(self) -> None:
+        if self._policy is None:
+            return
+        keep_result_tools = frozenset(self._policy.keep_result_tools)
+        context_dedupe_by_tool = dict(self._policy.context_dedupe_by_tool)
+        if any(
+            value != "workspace_file_read_v1"
+            for value in context_dedupe_by_tool.values()
+        ):
+            raise AIError(ErrorCode.CAPABILITY_RESOLUTION_INVALID)
+        if (
+            keep_result_tools == self._keep_result_tools
+            and context_dedupe_by_tool == self._context_dedupe_by_tool
+        ):
+            return
+        self._keep_result_tools = keep_result_tools
+        self._context_dedupe_by_tool = context_dedupe_by_tool
+        _logger.debug(
+            "runtime compaction policy refreshed: keep_results=%s dedupe_tools=%s",
+            tuple(sorted(keep_result_tools)),
+            tuple(sorted(context_dedupe_by_tool)),
+        )
+
 
 def _validate_pending_binary_content(
     ctx: PydanticRunContext[Any],
@@ -252,9 +269,16 @@ def _validate_pending_binary_content(
         raise AIError(ErrorCode.REQUEST_FIELD_INVALID)
 
 
-def _workspace_file_key(call: ToolCallPart) -> str | None:
-    if call.tool_name != "read_file":
+def _context_dedupe_file_key(
+    call: ToolCallPart,
+    policies: Mapping[str, str],
+) -> str | None:
+    if policies.get(call.tool_name) != "workspace_file_read_v1":
         return None
+    return _workspace_file_key(call)
+
+
+def _workspace_file_key(call: ToolCallPart) -> str | None:
     try:
         arguments = call.args_as_dict()
     except (TypeError, ValueError):
@@ -285,4 +309,7 @@ def _workspace_file_key(call: ToolCallPart) -> str | None:
     )
 
 
-__all__ = ["ExternalModelRequestObserver", "RuntimeCompaction"]
+__all__ = [
+    "ExternalModelRequestObserver",
+    "RuntimeCompaction",
+]

--- a/linktools-ai/src/linktools/ai/runtime/_execution.py
+++ b/linktools-ai/src/linktools/ai/runtime/_execution.py
@@ -82,7 +82,7 @@ from .service_api import (
     ExecutionView,
     ForkExecutionRequest,
     ListExecutionRequest,
-    _project_execution_view,
+    project_execution_view as _project_execution_view,
     RetryExecutionRequest,
     TranscriptItem,
 )

--- a/linktools-ai/src/linktools/ai/runtime/_execution.py
+++ b/linktools-ai/src/linktools/ai/runtime/_execution.py
@@ -75,11 +75,14 @@ from .service_api import (
     ExecutionHandle,
     ExecutionHistoryItem,
     ExecutionHistoryReader,
+    ExecutionHistoryService,
     ExecutionRequest,
     ExecutionResult,
     ExecutionTraceItem,
     ExecutionView,
     ForkExecutionRequest,
+    ListExecutionRequest,
+    _project_execution_view,
     RetryExecutionRequest,
     TranscriptItem,
 )
@@ -352,6 +355,7 @@ class DefaultExecutionService:
         live_broker: _LiveExecutionStreamBroker,
         operation_ids: "Callable[[], str] | None" = None,
         history_reader: ExecutionHistoryReader,
+        history_service: "ExecutionHistoryService | None" = None,
         release_terminal: _ExecutionReleaseCallback | None = None,
         instruction_resolver: "_RepositoryInstructionResolver | None" = None,
         object_key_factory: "RuntimeObjectKeyFactory | None" = None,
@@ -369,6 +373,7 @@ class DefaultExecutionService:
         self._live_broker = live_broker
         self._operation_ids = operation_ids or (lambda: uuid.uuid4().hex)
         self._history_reader = history_reader
+        self._history_service = history_service
         self._release_terminal = release_terminal or _no_release_terminal
         if not isinstance(session_execution_ready, bool):
             raise TypeError("session_execution_ready must be bool")
@@ -1672,6 +1677,11 @@ class DefaultExecutionService:
                 raise failure
         return _execution_view(execution)
 
+    async def list(self, request: ListExecutionRequest) -> Page[ExecutionView]:
+        if self._history_service is None:
+            raise AIError(ErrorCode.RUNTIME_DEPENDENCY_NOT_READY)
+        return await self._history_service.list(request)
+
     @consumed_query
     async def result(
         self, execution_id: str, *, principal: Principal
@@ -2664,15 +2674,7 @@ class DefaultExecutionService:
 
 
 def _execution_view(execution: ExecutionRecord) -> ExecutionView:
-    return ExecutionView(
-        execution.execution_id,
-        execution.binding.agent_spec.id,
-        execution.status,
-        execution.lineage_kind,
-        execution.parent_execution_id,
-        execution.root_execution_id,
-        execution.parent_invocation_id,
-    )
+    return _project_execution_view(execution)
 
 
 def _terminal_error(

--- a/linktools-ai/src/linktools/ai/runtime/_factory.py
+++ b/linktools-ai/src/linktools/ai/runtime/_factory.py
@@ -53,6 +53,7 @@ from ._external import DefaultExternalService
 from ._execution import DefaultExecutionService, _ExecutionRuntimeBridge
 from ._execution_tree import ExecutionTreeBroker, ExecutionTreeStreamer
 from ._history import StepExecutionHistoryReader, StepSessionHistoryReader
+from ._history_service import DefaultExecutionHistoryService
 from ._input import ExecutionInputMaterializer
 from ._local import LocalExecutionBackend
 from ._memory import MemoryStore, RuntimeMemoryStore
@@ -115,7 +116,9 @@ async def compose_runtime_components(
     owned_workspace_assets: tuple[AssetStore, DirectoryAssetBackend] | None = None
     selected_state: RuntimeState | None = None
     workspace_access: WorkspaceAccess | None = None
+    input_materializer: ExecutionInputMaterializer | None = None
     initialized = False
+    ownership_transferred = False
     try:
         if workspace_groups:
             effective_groups: tuple[CapabilityGroup[object], ...] = cast(
@@ -216,35 +219,39 @@ async def compose_runtime_components(
             object_key_factory=object_key_factory,
             payload_policy=payload_policy,
         )
+        grant_key = _grant_key(workspace)
+        history_reader = _execution_history_reader(
+            workspace,
+            selected_state,
+        )
+        session_history_reader = StepSessionHistoryReader(
+            store=selected_state.steps.read_store(RuntimeDomain.CONVERSATION),
+            cursor_signer=HmacCursorSigner("session-history", grant_key),
+        )
+        memory_store_factory = _memory_store_factory(workspace, selected_state)
+        authorization = TenantAuthorizationPolicy(effective_tenant_id)
         owned_workspace_close = (
             None
             if owned_workspace_assets is None
             else partial(_close_owned_workspace_assets, *owned_workspace_assets)
         )
+        ownership_transferred = True
         return await _build_local_components(
             state=selected_state,
             catalog=catalog,
             compiler=compiler,
-            authorization=TenantAuthorizationPolicy(effective_tenant_id),
+            authorization=authorization,
             tenant_id=effective_tenant_id,
             namespace=workspace.workspace_id,
             workspace=workspace,
             app=app,
             task_handlers=task_handlers,
             task_expanders=task_expanders,
-            history_reader=_execution_history_reader(
-                workspace,
-                selected_state,
-            ),
-            session_history_reader=StepSessionHistoryReader(
-                store=selected_state.steps.read_store(RuntimeDomain.CONVERSATION),
-                cursor_signer=HmacCursorSigner(
-                    "session-history", _grant_key(workspace)
-                ),
-            ),
-            memory_store_factory=_memory_store_factory(workspace, selected_state),
+            history_reader=history_reader,
+            session_history_reader=session_history_reader,
+            memory_store_factory=memory_store_factory,
             skill_sources=skill_sources,
-            grant_key=_grant_key(workspace),
+            grant_key=grant_key,
             instruction_resolver=instruction_resolver,
             object_key_factory=object_key_factory,
             payload_policy=payload_policy,
@@ -254,14 +261,14 @@ async def compose_runtime_components(
             owned_workspace_close=owned_workspace_close,
         )
     except BaseException:
-        try:
-            if initialized and selected_state is not None:
-                await selected_state.close()
-        finally:
-            if workspace_access is not None:
-                await workspace_access.close()
-            if owned_workspace_assets is not None:
-                await _close_owned_workspace_assets(*owned_workspace_assets)
+        if not ownership_transferred:
+            await _cleanup_compose_resources(
+                selected_state=selected_state,
+                initialized=initialized,
+                input_materializer=input_materializer,
+                workspace_access=workspace_access,
+                owned_workspace_assets=owned_workspace_assets,
+            )
         raise
 
 
@@ -309,6 +316,92 @@ async def _close_owned_workspace_assets(
 ) -> None:
     await store.close()
     await backend.close()
+
+
+def _runtime_close_actions(
+    *,
+    graph_service: DefaultTaskGraphService | None,
+    task_launcher: LocalTaskGraphLauncher | None,
+    execution: DefaultExecutionService,
+    backend: LocalExecutionBackend | None,
+    input_materializer: ExecutionInputMaterializer,
+    metric_buffer: _RuntimeMetricBuffer | None,
+    state: RuntimeState,
+    owned_workspace_close: "Callable[[], Awaitable[None]] | None",
+) -> tuple[tuple[str, Callable[[], Awaitable[None]]], ...]:
+    actions: list[tuple[str, Callable[[], Awaitable[None]]]] = []
+    if graph_service is not None:
+        actions.extend(
+            (
+                ("runtime.graph.finalizers", graph_service.drain_owned_finalizers),
+                ("runtime.graph.preflight", graph_service.preflight_close),
+            )
+        )
+    if task_launcher is not None:
+        actions.append(("runtime.task_launcher", task_launcher.shutdown))
+    if graph_service is not None:
+        actions.append(
+            ("runtime.graph.metrics", graph_service.drain_metric_projector)
+        )
+    actions.append(("runtime.execution.preflight", execution.preflight_close))
+    if backend is not None:
+        actions.append(("runtime.backend", backend.close))
+    actions.append(("runtime.input", input_materializer.close))
+    if metric_buffer is not None:
+        actions.append(("runtime.metrics", metric_buffer.close))
+    actions.append(("runtime.state", state.close))
+    if owned_workspace_close is not None:
+        actions.append(("runtime.workspace", owned_workspace_close))
+    return tuple(actions)
+
+
+async def _run_cleanup_actions(
+    actions: Sequence[tuple[str, Callable[[], Awaitable[None]]]],
+    *,
+    stop_on_error: bool = True,
+) -> None:
+    for phase, action in actions:
+        try:
+            await action()
+        except BaseException as error:
+            _log_secondary_cleanup(phase, error)
+            if stop_on_error:
+                return
+
+
+async def _cleanup_compose_resources(
+    *,
+    selected_state: RuntimeState | None,
+    initialized: bool,
+    input_materializer: ExecutionInputMaterializer | None,
+    workspace_access: WorkspaceAccess | None,
+    owned_workspace_assets: tuple[AssetStore, DirectoryAssetBackend] | None,
+) -> None:
+    actions: list[tuple[str, Callable[[], Awaitable[None]]]] = []
+    if input_materializer is not None:
+        actions.append(("runtime.compose.input", input_materializer.close))
+    elif workspace_access is not None:
+        actions.append(("runtime.compose.workspace_access", workspace_access.close))
+    if initialized and selected_state is not None:
+        actions.append(("runtime.compose.state", selected_state.close))
+    if owned_workspace_assets is not None:
+        actions.append(
+            (
+                "runtime.compose.workspace",
+                partial(_close_owned_workspace_assets, *owned_workspace_assets),
+            )
+        )
+    await _run_cleanup_actions(actions, stop_on_error=False)
+
+
+def _log_secondary_cleanup(phase: str, error: BaseException) -> None:
+    code = error.code.value if isinstance(error, AIError) else None
+    _logger.error(
+        "secondary cleanup failed: phase=%s code=%s exception_type=%s",
+        phase,
+        code,
+        type(error).__name__,
+    )
 
 
 def _validate_candidate_uniqueness(
@@ -434,11 +527,8 @@ async def _build_local_components(
     metrics: "Metrics | None",
     owned_workspace_close: "Callable[[], Awaitable[None]] | None" = None,
 ) -> _RuntimeComponents:
-    if not state.ready:
-        raise AIError(ErrorCode.RUNTIME_DEPENDENCY_NOT_READY)
-    _require_state_identity(state, namespace=namespace, tenant_id=tenant_id)
-    metric_buffer = None if metrics is None else _RuntimeMetricBuffer(metrics)
-    metric_source_namespace = None if metric_buffer is None else namespace
+    metric_buffer: _RuntimeMetricBuffer | None = None
+    metric_source_namespace: str | None = None
     backend: LocalExecutionBackend | None = None
 
     async def release_execution_handoff(
@@ -457,36 +547,60 @@ async def _build_local_components(
             tenant_id=tenant_id,
         )
 
-    runtime_bridge = _ExecutionRuntimeBridge()
-    live_broker = LiveExecutionEventBroker()
-    execution = DefaultExecutionService(
-        state.execution,
-        state.object_store(RuntimeDomain.EXECUTION),
-        authorization,
-        sessions=state.conversation.sessions,
-        catalog=catalog,
-        compiler=compiler,
-        runtime_bridge=runtime_bridge,
-        live_broker=live_broker,
-        history_reader=history_reader,
-        release_terminal=release_execution_handoff,
-        instruction_resolver=instruction_resolver,
-        object_key_factory=object_key_factory,
-        payload_policy=payload_policy,
-        input_materializer=input_materializer,
-        session_execution_ready=session_execution_ready,
-    )
-    execution_tree_broker = ExecutionTreeBroker()
-    dispatcher = SubagentDispatcher(
-        catalog,
-        compiler,
-        execution,
-        child_observer=execution_tree_broker,
-    )
-    executor = AgentExecutor(
-        skill_sources,
-        metrics=metric_buffer,
-    )
+    try:
+        if not state.ready:
+            raise AIError(ErrorCode.RUNTIME_DEPENDENCY_NOT_READY)
+        _require_state_identity(state, namespace=namespace, tenant_id=tenant_id)
+        metric_buffer = None if metrics is None else _RuntimeMetricBuffer(metrics)
+        metric_source_namespace = None if metric_buffer is None else namespace
+        runtime_bridge = _ExecutionRuntimeBridge()
+        live_broker = LiveExecutionEventBroker()
+        history_service = DefaultExecutionHistoryService(
+            state.execution.executions,
+            authorization,
+            history_reader,
+            HmacCursorSigner("execution", grant_key),
+        )
+        execution = DefaultExecutionService(
+            state.execution,
+            state.object_store(RuntimeDomain.EXECUTION),
+            authorization,
+            sessions=state.conversation.sessions,
+            catalog=catalog,
+            compiler=compiler,
+            runtime_bridge=runtime_bridge,
+            live_broker=live_broker,
+            history_reader=history_reader,
+            history_service=history_service,
+            release_terminal=release_execution_handoff,
+            instruction_resolver=instruction_resolver,
+            object_key_factory=object_key_factory,
+            payload_policy=payload_policy,
+            input_materializer=input_materializer,
+            session_execution_ready=session_execution_ready,
+        )
+        execution_tree_broker = ExecutionTreeBroker()
+        dispatcher = SubagentDispatcher(
+            catalog,
+            compiler,
+            execution,
+            child_observer=execution_tree_broker,
+        )
+        executor = AgentExecutor(
+            skill_sources,
+            metrics=metric_buffer,
+        )
+    except BaseException:
+        actions: list[tuple[str, Callable[[], Awaitable[None]]]] = [
+            ("runtime.build.input", input_materializer.close),
+        ]
+        if metric_buffer is not None:
+            actions.append(("runtime.build.metrics", metric_buffer.close))
+        actions.append(("runtime.build.state", state.close))
+        if owned_workspace_close is not None:
+            actions.append(("runtime.build.workspace", owned_workspace_close))
+        await _run_cleanup_actions(actions)
+        raise
 
     def build_memory_store(
         memory_tenant: str,
@@ -515,6 +629,7 @@ async def _build_local_components(
 
     task_launcher: LocalTaskGraphLauncher | None = None
     graph_service: DefaultTaskGraphService | None = None
+    coordinator: _RuntimeCloseCoordinator | None = None
     try:
         backend = LocalExecutionBackend(
             state.conversation,
@@ -655,34 +770,42 @@ async def _build_local_components(
             local_coordinator,
             execution_tree_broker,
         )
-        close_actions: list[Callable[[], Awaitable[None]]] = [
-            graph_service.drain_owned_finalizers,
-            graph_service.preflight_close,
-            task_launcher.shutdown,
-            graph_service.drain_metric_projector,
-            execution.preflight_close,
-            backend.close,
-        ]
-        close_actions.append(input_materializer.close)
-        if metric_buffer is not None:
-            close_actions.append(metric_buffer.close)
-        close_actions.append(state.close)
-        if owned_workspace_close is not None:
-            close_actions.append(owned_workspace_close)
-        coordinator = _RuntimeCloseCoordinator(tuple(close_actions))
+        close_actions = _runtime_close_actions(
+            graph_service=graph_service,
+            task_launcher=task_launcher,
+            execution=execution,
+            backend=backend,
+            input_materializer=input_materializer,
+            metric_buffer=metric_buffer,
+            state=state,
+            owned_workspace_close=owned_workspace_close,
+        )
+        coordinator = _RuntimeCloseCoordinator(
+            tuple(action for _, action in close_actions)
+        )
         await _restore_recovery_bindings(catalog, compiler, state, tenant_id=tenant_id)
         if RuntimeDomain.RECOVERY in state.plan.durable_domains:
             await backend.reconcile()
         await graph_service.recover_pending()
     except BaseException:
-        if task_launcher is not None:
-            await task_launcher.shutdown()
-        if graph_service is not None:
-            await graph_service.drain_metric_projector()
-        if backend is not None:
-            await backend.close()
-        if metric_buffer is not None:
-            await metric_buffer.close()
+        if coordinator is not None:
+            try:
+                await coordinator.close()
+            except BaseException as error:
+                _log_secondary_cleanup("runtime.build.close", error)
+        else:
+            await _run_cleanup_actions(
+                _runtime_close_actions(
+                    graph_service=graph_service,
+                    task_launcher=task_launcher,
+                    execution=execution,
+                    backend=backend,
+                    input_materializer=input_materializer,
+                    metric_buffer=metric_buffer,
+                    state=state,
+                    owned_workspace_close=owned_workspace_close,
+                )
+            )
         raise
     return _RuntimeComponents(
         catalog=catalog,

--- a/linktools-ai/src/linktools/ai/runtime/_factory.py
+++ b/linktools-ai/src/linktools/ai/runtime/_factory.py
@@ -803,7 +803,7 @@ async def _build_local_components(
                 owned_workspace_close=owned_workspace_close,
             )
         )
-        await _run_cleanup_actions(abort_actions, stop_on_error=False)
+        await _run_cleanup_actions(abort_actions)
         raise
     return _RuntimeComponents(
         catalog=catalog,

--- a/linktools-ai/src/linktools/ai/runtime/_factory.py
+++ b/linktools-ai/src/linktools/ai/runtime/_factory.py
@@ -599,7 +599,7 @@ async def _build_local_components(
         actions.append(("runtime.build.state", state.close))
         if owned_workspace_close is not None:
             actions.append(("runtime.build.workspace", owned_workspace_close))
-        await _run_cleanup_actions(actions)
+        await _run_cleanup_actions(actions, stop_on_error=False)
         raise
 
     def build_memory_store(
@@ -630,6 +630,7 @@ async def _build_local_components(
     task_launcher: LocalTaskGraphLauncher | None = None
     graph_service: DefaultTaskGraphService | None = None
     coordinator: _RuntimeCloseCoordinator | None = None
+    close_actions: tuple[tuple[str, Callable[[], Awaitable[None]]], ...] | None = None
     try:
         backend = LocalExecutionBackend(
             state.conversation,
@@ -788,24 +789,21 @@ async def _build_local_components(
             await backend.reconcile()
         await graph_service.recover_pending()
     except BaseException:
-        if coordinator is not None:
-            try:
-                await coordinator.close()
-            except BaseException as error:
-                _log_secondary_cleanup("runtime.build.close", error)
-        else:
-            await _run_cleanup_actions(
-                _runtime_close_actions(
-                    graph_service=graph_service,
-                    task_launcher=task_launcher,
-                    execution=execution,
-                    backend=backend,
-                    input_materializer=input_materializer,
-                    metric_buffer=metric_buffer,
-                    state=state,
-                    owned_workspace_close=owned_workspace_close,
-                )
+        abort_actions = (
+            close_actions
+            if close_actions is not None
+            else _runtime_close_actions(
+                graph_service=graph_service,
+                task_launcher=task_launcher,
+                execution=execution,
+                backend=backend,
+                input_materializer=input_materializer,
+                metric_buffer=metric_buffer,
+                state=state,
+                owned_workspace_close=owned_workspace_close,
             )
+        )
+        await _run_cleanup_actions(abort_actions, stop_on_error=False)
         raise
     return _RuntimeComponents(
         catalog=catalog,

--- a/linktools-ai/src/linktools/ai/runtime/_harness_memory.py
+++ b/linktools-ai/src/linktools/ai/runtime/_harness_memory.py
@@ -4,9 +4,11 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
+from typing import cast
 
-from pydantic_ai.toolsets import AbstractToolset, FilteredToolset
+from pydantic_ai.toolsets import AbstractToolset, FilteredToolset, FunctionToolset
 from pydantic_ai_harness.memory import (
     Memory,
     MemoryFile,
@@ -14,6 +16,37 @@ from pydantic_ai_harness.memory import (
     MemoryOperation,
     MemoryStore,
 )
+
+from ..capability import (
+    TOOL_COMPACTION_KEEP_RESULT_METADATA_KEY,
+    TOOL_PLAN_SAFE_METADATA_KEY,
+    tool_semantic_metadata,
+)
+
+_MEMORY_TOOL_DECLARATIONS: dict[str, Mapping[str, object]] = {
+    "delete_memory": tool_semantic_metadata(compaction_keep_result=True),
+    "read_memory": tool_semantic_metadata(
+        plan_safe=True,
+        compaction_keep_result=True,
+    ),
+    "search_memory": tool_semantic_metadata(
+        plan_safe=True,
+        compaction_keep_result=True,
+    ),
+    "write_memory": tool_semantic_metadata(compaction_keep_result=True),
+}
+
+
+def select_harness_memory_tools(
+    allow_tools: Sequence[str],
+) -> tuple[str, ...]:
+    """Select the Memory tools owned by this Runtime capability."""
+    if "*" in allow_tools:
+        return tuple(_MEMORY_TOOL_DECLARATIONS)
+    return tuple(
+        name for name in _MEMORY_TOOL_DECLARATIONS if name in allow_tools
+    )
+
 
 class HarnessMemoryStoreAdapter:
     """Expose the Runtime memory store through Harness' public contract."""
@@ -58,6 +91,7 @@ class HarnessMemoryStoreAdapter:
     async def list_paths(self, prefix: str = "", *, limit: int) -> list[str]:
         return await self._store.list_paths(prefix, limit=limit)
 
+
 @dataclass
 class HarnessSelectedMemory(Memory[None]):
     """Harness Memory with Runtime-selected tool exposure."""
@@ -65,23 +99,31 @@ class HarnessSelectedMemory(Memory[None]):
     selected_tool_names: tuple[str, ...] = ()
 
     def get_toolset(self) -> AbstractToolset[None] | None:
-        toolset = super().get_toolset()
+        toolset = cast(
+            "FunctionToolset[None] | None",
+            super().get_toolset(),
+        )
         if toolset is None:
             return None
+        for name in self.selected_tool_names:
+            toolset.tools[name].metadata = tool_semantic_metadata(
+                base=toolset.tools[name].metadata,
+                **_memory_metadata_kwargs(name),
+            )
         selected = frozenset(self.selected_tool_names)
         return FilteredToolset(
             toolset,
             lambda _ctx, tool: tool.name in selected,
         )
 
-
 def build_harness_memory(
     store: MemoryStore,
     *,
-    selected_tool_names: tuple[str, ...],
+    allow_tools: Sequence[str],
     capability_id: str,
 ) -> HarnessSelectedMemory:
     """Build the Harness Memory capability over one Runtime memory store."""
+    selected_tool_names = select_harness_memory_tools(allow_tools)
     guidance = (
         "Use the available persistent-memory tools when durable notes are useful: "
         + ", ".join(f"`{name}`" for name in selected_tool_names)
@@ -97,8 +139,19 @@ def build_harness_memory(
     )
 
 
+def _memory_metadata_kwargs(name: str) -> dict[str, object]:
+    metadata = _MEMORY_TOOL_DECLARATIONS[name]
+    return {
+        "plan_safe": metadata.get(TOOL_PLAN_SAFE_METADATA_KEY),
+        "compaction_keep_result": metadata.get(
+            TOOL_COMPACTION_KEEP_RESULT_METADATA_KEY
+        ),
+    }
+
+
 __all__ = [
     "HarnessMemoryStoreAdapter",
     "HarnessSelectedMemory",
     "build_harness_memory",
+    "select_harness_memory_tools",
 ]

--- a/linktools-ai/src/linktools/ai/runtime/_harness_planning.py
+++ b/linktools-ai/src/linktools/ai/runtime/_harness_planning.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Harness Planning adapter for the Runtime-owned plan store."""
+
+from collections.abc import Callable
+
+from pydantic_ai.toolsets import AbstractToolset
+from pydantic_ai.tools import RunContext as PydanticRunContext
+from pydantic_ai_harness.planning import Planning
+
+from ..capability import tool_semantic_metadata
+from ._harness import HarnessPlanStoreAdapter
+
+_PLANNING_CAPABILITY_ID = "linktools.ai.planning"
+_PLANNING_TOOL_NAME = "write_plan"
+
+
+class HarnessPlanning(Planning[None]):
+    """Expose only the Runtime-supported Planning tool with its semantics."""
+
+    def get_toolset(self) -> AbstractToolset[None] | None:
+        toolset = super().get_toolset()
+        if toolset is not None:
+            tool = toolset.tools[_PLANNING_TOOL_NAME]
+            tool.metadata = tool_semantic_metadata(
+                base=tool.metadata,
+                plan_safe=True,
+                compaction_keep_result=True,
+            )
+        return toolset
+
+def build_harness_planning(
+    store_resolver: Callable[
+        [PydanticRunContext[None]],
+        HarnessPlanStoreAdapter,
+    ],
+) -> HarnessPlanning:
+    """Build the Runtime-owned Planning capability."""
+    return HarnessPlanning(
+        id=_PLANNING_CAPABILITY_ID,
+        tools=(_PLANNING_TOOL_NAME,),
+        store_resolver=store_resolver,
+    )
+
+
+__all__ = ["HarnessPlanning", "build_harness_planning"]

--- a/linktools-ai/src/linktools/ai/runtime/_history.py
+++ b/linktools-ai/src/linktools/ai/runtime/_history.py
@@ -26,11 +26,13 @@ from ..core import (
 )
 from ..errors import AIError, ErrorCode
 from ._journal import (
+    DURATION_NS_METADATA_KEY,
     MODEL_USAGE_CACHE_READ_METADATA_KEY,
     MODEL_USAGE_CACHE_WRITE_METADATA_KEY,
     MODEL_USAGE_INPUT_METADATA_KEY,
     MODEL_USAGE_METADATA_KEYS,
     MODEL_USAGE_OUTPUT_METADATA_KEY,
+    OBSERVATION_ID_METADATA_KEY,
     OUTPUT_RETRY_INDEX_METADATA_KEY,
     REQUEST_PURPOSE_METADATA_KEY,
     REQUEST_SEQUENCE_METADATA_KEY,
@@ -50,8 +52,6 @@ from .state._views import (
 )
 
 _logger = environ.get_logger("ai.runtime.history")
-_OBSERVATION_ID_METADATA_KEY = "linktools.ai.observation_id"
-_DURATION_NS_METADATA_KEY = "linktools.ai.duration_ns"
 
 
 @dataclass(frozen=True, slots=True)
@@ -780,12 +780,12 @@ def _trace_item(
         "depth": depth,
         "occurred_at": _event_timestamp(event).isoformat(),
     }
-    observation_id = event.metadata.get(_OBSERVATION_ID_METADATA_KEY)
+    observation_id = event.metadata.get(OBSERVATION_ID_METADATA_KEY)
     if observation_id is not None:
         if not observation_id:
             raise AIError(ErrorCode.STORAGE_INTEGRITY_ERROR)
         payload["observation_id"] = observation_id
-    duration_ns = event.metadata.get(_DURATION_NS_METADATA_KEY)
+    duration_ns = event.metadata.get(DURATION_NS_METADATA_KEY)
     if duration_ns is not None:
         if not duration_ns.isdigit():
             raise AIError(ErrorCode.STORAGE_INTEGRITY_ERROR)

--- a/linktools-ai/src/linktools/ai/runtime/_history.py
+++ b/linktools-ai/src/linktools/ai/runtime/_history.py
@@ -26,6 +26,11 @@ from ..core import (
 )
 from ..errors import AIError, ErrorCode
 from ._journal import (
+    MODEL_USAGE_CACHE_READ_METADATA_KEY,
+    MODEL_USAGE_CACHE_WRITE_METADATA_KEY,
+    MODEL_USAGE_INPUT_METADATA_KEY,
+    MODEL_USAGE_METADATA_KEYS,
+    MODEL_USAGE_OUTPUT_METADATA_KEY,
     OUTPUT_RETRY_INDEX_METADATA_KEY,
     REQUEST_PURPOSE_METADATA_KEY,
     REQUEST_SEQUENCE_METADATA_KEY,
@@ -45,20 +50,8 @@ from .state._views import (
 )
 
 _logger = environ.get_logger("ai.runtime.history")
-_MODEL_USAGE_INPUT_METADATA_KEY = "linktools.ai.model_usage.input_tokens"
-_MODEL_USAGE_OUTPUT_METADATA_KEY = "linktools.ai.model_usage.output_tokens"
-_MODEL_USAGE_CACHE_READ_METADATA_KEY = "linktools.ai.model_usage.cache_read_tokens"
-_MODEL_USAGE_CACHE_WRITE_METADATA_KEY = "linktools.ai.model_usage.cache_write_tokens"
 _OBSERVATION_ID_METADATA_KEY = "linktools.ai.observation_id"
 _DURATION_NS_METADATA_KEY = "linktools.ai.duration_ns"
-_MODEL_USAGE_METADATA_KEYS = frozenset(
-    {
-        _MODEL_USAGE_INPUT_METADATA_KEY,
-        _MODEL_USAGE_OUTPUT_METADATA_KEY,
-        _MODEL_USAGE_CACHE_READ_METADATA_KEY,
-        _MODEL_USAGE_CACHE_WRITE_METADATA_KEY,
-    }
-)
 
 
 @dataclass(frozen=True, slots=True)
@@ -831,25 +824,25 @@ def _trace_item(
 
 def _model_token_usage(event: StepEvent) -> "dict[str, JsonValue] | None":
     metadata = event.metadata
-    present = _MODEL_USAGE_METADATA_KEYS.intersection(metadata)
+    present = MODEL_USAGE_METADATA_KEYS.intersection(metadata)
     if not present:
         return None
     if (
-        _MODEL_USAGE_INPUT_METADATA_KEY not in metadata
-        or _MODEL_USAGE_OUTPUT_METADATA_KEY not in metadata
+        MODEL_USAGE_INPUT_METADATA_KEY not in metadata
+        or MODEL_USAGE_OUTPUT_METADATA_KEY not in metadata
     ):
         raise AIError(ErrorCode.STORAGE_INTEGRITY_ERROR)
     return {
-        "input_tokens": _metadata_token(metadata, _MODEL_USAGE_INPUT_METADATA_KEY),
-        "output_tokens": _metadata_token(metadata, _MODEL_USAGE_OUTPUT_METADATA_KEY),
+        "input_tokens": _metadata_token(metadata, MODEL_USAGE_INPUT_METADATA_KEY),
+        "output_tokens": _metadata_token(metadata, MODEL_USAGE_OUTPUT_METADATA_KEY),
         "cache_read_tokens": _metadata_token(
             metadata,
-            _MODEL_USAGE_CACHE_READ_METADATA_KEY,
+            MODEL_USAGE_CACHE_READ_METADATA_KEY,
             required=False,
         ),
         "cache_write_tokens": _metadata_token(
             metadata,
-            _MODEL_USAGE_CACHE_WRITE_METADATA_KEY,
+            MODEL_USAGE_CACHE_WRITE_METADATA_KEY,
             required=False,
         ),
     }

--- a/linktools-ai/src/linktools/ai/runtime/_history_service.py
+++ b/linktools-ai/src/linktools/ai/runtime/_history_service.py
@@ -1,16 +1,30 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-"""Authorized read-only execution history service."""
+"""Authorized read-only execution query and history service."""
 
-from ..core import AuthorizationAction, AuthorizationPolicy, Page, Principal
+import time
+
+from ..core import (
+    AuthorizationAction,
+    AuthorizationPolicy,
+    CursorPayload,
+    CursorSigner,
+    Page,
+    Principal,
+    canonical_sha256,
+    principal_identity_payload,
+)
 from ..errors import AIError, ErrorCode
 from .service_api import (
     ExecutionHistoryItem,
     ExecutionHistoryReader,
     ExecutionTraceItem,
+    ExecutionView,
+    ListExecutionRequest,
     TranscriptItem,
+    _project_execution_view,
 )
-from .state._contracts import ExecutionRepository
+from .state._contracts import ExecutionRecord, ExecutionRepository
 
 
 class DefaultExecutionHistoryService:
@@ -21,10 +35,96 @@ class DefaultExecutionHistoryService:
         executions: ExecutionRepository,
         authorization: AuthorizationPolicy,
         reader: ExecutionHistoryReader,
+        cursor_signer: "CursorSigner | None" = None,
     ) -> None:
         self._executions = executions
         self._authorization = authorization
         self._reader = reader
+        self._cursor_signer = cursor_signer
+
+    async def inspect(
+        self, execution_id: str, *, principal: Principal
+    ) -> ExecutionView:
+        return _project_execution_view(await self._authorize(execution_id, principal))
+
+    async def list(self, request: ListExecutionRequest) -> Page[ExecutionView]:
+        signer = self._cursor_signer
+        if signer is None:
+            raise AIError(ErrorCode.RUNTIME_DEPENDENCY_NOT_READY)
+        filter_digest = _execution_filter_digest(request)
+        repository_cursor = _decode_execution_cursor(
+            request.cursor,
+            tenant_id=request.principal.tenant_id,
+            filter_digest=filter_digest,
+            signer=signer,
+        )
+        views: list[ExecutionView] = []
+        scanned = 0
+        while scanned < 1000:
+            page = await self._executions.list_candidates(
+                tenant_id=request.principal.tenant_id,
+                session_id=request.session_id,
+                parent_execution_id=request.parent_execution_id,
+                cursor=repository_cursor,
+                limit=1000 - scanned,
+            )
+            if not page.items:
+                break
+            for index, candidate in enumerate(page.items):
+                scanned += 1
+                record = candidate.record
+                if request.session_id is not None and (
+                    record.session_id != request.session_id
+                ):
+                    continue
+                if request.parent_execution_id is not None and (
+                    record.parent_execution_id != request.parent_execution_id
+                ):
+                    continue
+                if request.agent_id is not None and record.agent_id != request.agent_id:
+                    continue
+                header = await self._executions.get_header(
+                    record.execution_id,
+                    tenant_id=request.principal.tenant_id,
+                )
+                if header is None:
+                    continue
+                try:
+                    await self._authorization.authorize(
+                        request.principal,
+                        AuthorizationAction.EXECUTION_READ,
+                        header,
+                    )
+                except AIError as error:
+                    if error.code is not ErrorCode.AUTHORIZATION_DENIED:
+                        raise
+                    continue
+                views.append(_project_execution_view(record))
+                if len(views) == request.limit:
+                    has_more = page.has_more or index + 1 < len(page.items)
+                    return Page(
+                        tuple(views),
+                        _encode_execution_cursor(
+                            request.principal.tenant_id,
+                            filter_digest,
+                            candidate.cursor,
+                            signer,
+                        )
+                        if has_more
+                        else None,
+                    )
+            repository_cursor = page.items[-1].cursor
+            if not page.has_more:
+                break
+        next_cursor = None
+        if scanned >= 1000 and page.items and page.has_more:
+            next_cursor = _encode_execution_cursor(
+                request.principal.tenant_id,
+                filter_digest,
+                page.items[-1].cursor,
+                signer,
+            )
+        return Page(tuple(views), next_cursor)
 
     async def trace(
         self,
@@ -34,10 +134,10 @@ class DefaultExecutionHistoryService:
         cursor: "str | None" = None,
         limit: int = 100,
     ) -> Page[ExecutionTraceItem]:
-        tenant_id = await self._authorize(execution_id, principal)
+        record = await self._authorize(execution_id, principal)
         return await self._reader.trace(
             execution_id,
-            tenant_id=tenant_id,
+            tenant_id=record.tenant_id,
             cursor=cursor,
             limit=limit,
         )
@@ -50,10 +150,10 @@ class DefaultExecutionHistoryService:
         cursor: "str | None" = None,
         limit: int = 100,
     ) -> Page[TranscriptItem]:
-        tenant_id = await self._authorize(execution_id, principal)
+        record = await self._authorize(execution_id, principal)
         return await self._reader.transcript(
             execution_id,
-            tenant_id=tenant_id,
+            tenant_id=record.tenant_id,
             cursor=cursor,
             limit=limit,
         )
@@ -66,10 +166,10 @@ class DefaultExecutionHistoryService:
         cursor: "str | None" = None,
         limit: int = 100,
     ) -> Page[ExecutionHistoryItem]:
-        tenant_id = await self._authorize(execution_id, principal)
+        record = await self._authorize(execution_id, principal)
         return await self._reader.history(
             execution_id,
-            tenant_id=tenant_id,
+            tenant_id=record.tenant_id,
             cursor=cursor,
             limit=limit,
         )
@@ -78,7 +178,7 @@ class DefaultExecutionHistoryService:
         self,
         execution_id: str,
         principal: Principal,
-    ) -> str:
+    ) -> ExecutionRecord:
         tenant_id = principal.tenant_id
         header = await self._executions.get_header(
             execution_id,
@@ -97,7 +197,62 @@ class DefaultExecutionHistoryService:
         )
         if record is None:
             raise AIError(ErrorCode.AUTHORIZATION_DENIED)
-        return record.tenant_id
+        return record
+
+
+def _execution_filter_digest(request: ListExecutionRequest) -> str:
+    return canonical_sha256(
+        {
+            "principal": principal_identity_payload(request.principal),
+            "session_id": request.session_id,
+            "agent_id": request.agent_id,
+            "parent_execution_id": request.parent_execution_id,
+        }
+    )
+
+
+def _encode_execution_cursor(
+    tenant_id: str,
+    filter_digest: str,
+    repository_cursor: str,
+    signer: CursorSigner,
+) -> str:
+    return signer.encode(
+        CursorPayload(
+            1,
+            tenant_id,
+            "EXECUTION",
+            filter_digest,
+            repository_cursor,
+            0,
+            int(time.time()) + 3600,
+        )
+    )
+
+
+def _decode_execution_cursor(
+    cursor: str | None,
+    *,
+    tenant_id: str,
+    filter_digest: str,
+    signer: CursorSigner,
+) -> str | None:
+    if cursor is None:
+        return None
+    try:
+        payload = signer.decode(cursor)
+    except AIError as error:
+        raise AIError(ErrorCode.CURSOR_INVALID) from error
+    if (
+        payload.cursor_version != 1
+        or payload.tenant_id != tenant_id
+        or payload.resource_kind != "EXECUTION"
+        or payload.filter_digest != filter_digest
+        or payload.snapshot_or_store_revision != 0
+        or not payload.sort_key
+    ):
+        raise AIError(ErrorCode.CURSOR_INVALID)
+    return payload.sort_key
 
 
 __all__ = ["DefaultExecutionHistoryService"]

--- a/linktools-ai/src/linktools/ai/runtime/_history_service.py
+++ b/linktools-ai/src/linktools/ai/runtime/_history_service.py
@@ -24,7 +24,7 @@ from .service_api import (
     ExecutionView,
     ListExecutionRequest,
     TranscriptItem,
-    _project_execution_view,
+    project_execution_view,
 )
 from .state._contracts import ExecutionRecord, ExecutionRepository
 
@@ -47,7 +47,7 @@ class DefaultExecutionHistoryService:
     async def inspect(
         self, execution_id: str, *, principal: Principal
     ) -> ExecutionView:
-        return _project_execution_view(await self._authorize(execution_id, principal))
+        return project_execution_view(await self._authorize(execution_id, principal))
 
     async def list(self, request: ListExecutionRequest) -> Page[ExecutionView]:
         signer = self._cursor_signer
@@ -100,7 +100,7 @@ class DefaultExecutionHistoryService:
                     if error.code is not ErrorCode.AUTHORIZATION_DENIED:
                         raise
                     continue
-                views.append(_project_execution_view(record))
+                views.append(project_execution_view(record))
                 if len(views) == request.limit:
                     has_more = page.has_more or index + 1 < len(page.items)
                     return Page(

--- a/linktools-ai/src/linktools/ai/runtime/_history_service.py
+++ b/linktools-ai/src/linktools/ai/runtime/_history_service.py
@@ -11,6 +11,8 @@ from ..core import (
     CursorSigner,
     Page,
     Principal,
+    ResourceKind,
+    ResourceRef,
     canonical_sha256,
     principal_identity_payload,
 )
@@ -83,17 +85,16 @@ class DefaultExecutionHistoryService:
                     continue
                 if request.agent_id is not None and record.agent_id != request.agent_id:
                     continue
-                header = await self._executions.get_header(
+                resource = ResourceRef(
+                    ResourceKind.EXECUTION,
                     record.execution_id,
-                    tenant_id=request.principal.tenant_id,
+                    request.principal.tenant_id,
                 )
-                if header is None:
-                    continue
                 try:
                     await self._authorization.authorize(
                         request.principal,
                         AuthorizationAction.EXECUTION_READ,
-                        header,
+                        resource,
                     )
                 except AIError as error:
                     if error.code is not ErrorCode.AUTHORIZATION_DENIED:

--- a/linktools-ai/src/linktools/ai/runtime/_input.py
+++ b/linktools-ai/src/linktools/ai/runtime/_input.py
@@ -27,7 +27,6 @@ from pydantic_ai.messages import (
 from ..capability import WorkspaceAccess
 from ..core import JsonValue, canonical_json_bytes, normalize_json_value
 from ..errors import AIError, ErrorCode
-from ..model import LinkToolsUploadedFile, declared_uploaded_file_media_type
 from ..storage import ObjectStore, PayloadPolicy, StoredPayload, payload_fits_inline
 from ..workspace import WorkspacePolicy, normalize_workspace_path
 from ._input_contract import (
@@ -401,7 +400,7 @@ def _encode_user_content_item(item: UserContent) -> JsonValue:
                 "kind": "uploaded-file",
                 "file_id": item.file_id,
                 "provider_name": item.provider_name,
-                "media_type": declared_uploaded_file_media_type(item),
+                "media_type": item.media_type,
                 "identifier": item.identifier,
                 "vendor_metadata": normalize_json_value(item.vendor_metadata),
             }
@@ -483,7 +482,7 @@ def _decode_user_content_item(value: object) -> UserContent:
             or "vendor_metadata" not in value
         ):
             raise ValueError("uploaded file is invalid")
-        return LinkToolsUploadedFile(
+        return UploadedFile(
             file_id,
             provider_name,
             media_type=media_type,

--- a/linktools-ai/src/linktools/ai/runtime/_input.py
+++ b/linktools-ai/src/linktools/ai/runtime/_input.py
@@ -27,6 +27,7 @@ from pydantic_ai.messages import (
 from ..capability import WorkspaceAccess
 from ..core import JsonValue, canonical_json_bytes, normalize_json_value
 from ..errors import AIError, ErrorCode
+from ..model import LinkToolsUploadedFile, declared_uploaded_file_media_type
 from ..storage import ObjectStore, PayloadPolicy, StoredPayload, payload_fits_inline
 from ..workspace import WorkspacePolicy, normalize_workspace_path
 from ._input_contract import (
@@ -400,7 +401,7 @@ def _encode_user_content_item(item: UserContent) -> JsonValue:
                 "kind": "uploaded-file",
                 "file_id": item.file_id,
                 "provider_name": item.provider_name,
-                "media_type": item.media_type,
+                "media_type": declared_uploaded_file_media_type(item),
                 "identifier": item.identifier,
                 "vendor_metadata": normalize_json_value(item.vendor_metadata),
             }
@@ -482,7 +483,7 @@ def _decode_user_content_item(value: object) -> UserContent:
             or "vendor_metadata" not in value
         ):
             raise ValueError("uploaded file is invalid")
-        return UploadedFile(
+        return LinkToolsUploadedFile(
             file_id,
             provider_name,
             media_type=media_type,

--- a/linktools-ai/src/linktools/ai/runtime/_input_contract.py
+++ b/linktools-ai/src/linktools/ai/runtime/_input_contract.py
@@ -19,6 +19,7 @@ from pydantic_ai.messages import (
 
 from ..core import normalize_json_value, validate_user_prompt
 from ..errors import AIError, ErrorCode
+from ..model import LinkToolsUploadedFile
 
 UserPromptInput: TypeAlias = str | Sequence[UserContent]
 CanonicalUserInput: TypeAlias = str | tuple[UserContent, ...]
@@ -54,6 +55,13 @@ def validate_user_input(value: UserPromptInput) -> CanonicalUserInput:
 def validate_user_content(content: Sequence[UserContent]) -> None:
     for item in content:
         if not isinstance(item, _USER_CONTENT_TYPES):
+            raise AIError(ErrorCode.REQUEST_FIELD_INVALID)
+        if isinstance(item, UploadedFile) and not isinstance(
+            item,
+            LinkToolsUploadedFile,
+        ):
+            # Upstream UploadedFile exposes a computed media_type and does not
+            # retain omission provenance through its public API.
             raise AIError(ErrorCode.REQUEST_FIELD_INVALID)
         if isinstance(item, BinaryContent) and (
             not isinstance(item.data, bytes)

--- a/linktools-ai/src/linktools/ai/runtime/_input_contract.py
+++ b/linktools-ai/src/linktools/ai/runtime/_input_contract.py
@@ -19,7 +19,6 @@ from pydantic_ai.messages import (
 
 from ..core import normalize_json_value, validate_user_prompt
 from ..errors import AIError, ErrorCode
-from ..model import LinkToolsUploadedFile
 
 UserPromptInput: TypeAlias = str | Sequence[UserContent]
 CanonicalUserInput: TypeAlias = str | tuple[UserContent, ...]
@@ -55,13 +54,6 @@ def validate_user_input(value: UserPromptInput) -> CanonicalUserInput:
 def validate_user_content(content: Sequence[UserContent]) -> None:
     for item in content:
         if not isinstance(item, _USER_CONTENT_TYPES):
-            raise AIError(ErrorCode.REQUEST_FIELD_INVALID)
-        if isinstance(item, UploadedFile) and not isinstance(
-            item,
-            LinkToolsUploadedFile,
-        ):
-            # Upstream UploadedFile exposes a computed media_type and does not
-            # retain omission provenance through its public API.
             raise AIError(ErrorCode.REQUEST_FIELD_INVALID)
         if isinstance(item, BinaryContent) and (
             not isinstance(item.data, bytes)

--- a/linktools-ai/src/linktools/ai/runtime/_journal.py
+++ b/linktools-ai/src/linktools/ai/runtime/_journal.py
@@ -14,6 +14,8 @@ ModelRequestPurpose = Literal["agent", "compaction"]
 REQUEST_PURPOSE_METADATA_KEY = "linktools.ai.request_purpose"
 REQUEST_SEQUENCE_METADATA_KEY = "linktools.ai.request_sequence"
 OUTPUT_RETRY_INDEX_METADATA_KEY = "linktools.ai.output_retry_index"
+OBSERVATION_ID_METADATA_KEY = "linktools.ai.observation_id"
+DURATION_NS_METADATA_KEY = "linktools.ai.duration_ns"
 MODEL_USAGE_INPUT_METADATA_KEY = "linktools.ai.model_usage.input_tokens"
 MODEL_USAGE_OUTPUT_METADATA_KEY = "linktools.ai.model_usage.output_tokens"
 MODEL_USAGE_CACHE_READ_METADATA_KEY = "linktools.ai.model_usage.cache_read_tokens"
@@ -47,11 +49,11 @@ class ModelRequestFact:
             REQUEST_PURPOSE_METADATA_KEY: self.purpose,
         }
         if include_observation:
-            values["linktools.ai.observation_id"] = self.observation_id
+            values[OBSERVATION_ID_METADATA_KEY] = self.observation_id
         if self.output_retry_index is not None:
             values[OUTPUT_RETRY_INDEX_METADATA_KEY] = str(self.output_retry_index)
         if self.duration_ns is not None:
-            values["linktools.ai.duration_ns"] = str(self.duration_ns)
+            values[DURATION_NS_METADATA_KEY] = str(self.duration_ns)
         return values
 
 
@@ -154,6 +156,7 @@ class ModelRequestJournal:
 
 
 __all__ = [
+    "DURATION_NS_METADATA_KEY",
     "MODEL_USAGE_CACHE_READ_METADATA_KEY",
     "MODEL_USAGE_CACHE_WRITE_METADATA_KEY",
     "MODEL_USAGE_INPUT_METADATA_KEY",
@@ -162,6 +165,7 @@ __all__ = [
     "ModelRequestFact",
     "ModelRequestJournal",
     "ModelRequestPurpose",
+    "OBSERVATION_ID_METADATA_KEY",
     "OUTPUT_RETRY_INDEX_METADATA_KEY",
     "REQUEST_PURPOSE_METADATA_KEY",
     "REQUEST_SEQUENCE_METADATA_KEY",

--- a/linktools-ai/src/linktools/ai/runtime/_journal.py
+++ b/linktools-ai/src/linktools/ai/runtime/_journal.py
@@ -14,6 +14,18 @@ ModelRequestPurpose = Literal["agent", "compaction"]
 REQUEST_PURPOSE_METADATA_KEY = "linktools.ai.request_purpose"
 REQUEST_SEQUENCE_METADATA_KEY = "linktools.ai.request_sequence"
 OUTPUT_RETRY_INDEX_METADATA_KEY = "linktools.ai.output_retry_index"
+MODEL_USAGE_INPUT_METADATA_KEY = "linktools.ai.model_usage.input_tokens"
+MODEL_USAGE_OUTPUT_METADATA_KEY = "linktools.ai.model_usage.output_tokens"
+MODEL_USAGE_CACHE_READ_METADATA_KEY = "linktools.ai.model_usage.cache_read_tokens"
+MODEL_USAGE_CACHE_WRITE_METADATA_KEY = "linktools.ai.model_usage.cache_write_tokens"
+MODEL_USAGE_METADATA_KEYS = frozenset(
+    {
+        MODEL_USAGE_INPUT_METADATA_KEY,
+        MODEL_USAGE_OUTPUT_METADATA_KEY,
+        MODEL_USAGE_CACHE_READ_METADATA_KEY,
+        MODEL_USAGE_CACHE_WRITE_METADATA_KEY,
+    }
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -142,6 +154,11 @@ class ModelRequestJournal:
 
 
 __all__ = [
+    "MODEL_USAGE_CACHE_READ_METADATA_KEY",
+    "MODEL_USAGE_CACHE_WRITE_METADATA_KEY",
+    "MODEL_USAGE_INPUT_METADATA_KEY",
+    "MODEL_USAGE_METADATA_KEYS",
+    "MODEL_USAGE_OUTPUT_METADATA_KEY",
     "ModelRequestFact",
     "ModelRequestJournal",
     "ModelRequestPurpose",

--- a/linktools-ai/src/linktools/ai/runtime/_local.py
+++ b/linktools-ai/src/linktools/ai/runtime/_local.py
@@ -41,7 +41,7 @@ from ._agent_executor import (
     LiveDelta,
     _RunScope,
 )
-from ._capabilities import MEMORY_TOOL_NAMES, select_runtime_tool_names
+from ._harness_memory import select_harness_memory_tools
 from ._input import CanonicalUserInput, ExecutionInputMaterializer
 from ._plan import RuntimePlanStore
 from ..core import (
@@ -4016,17 +4016,11 @@ class LocalExecutionBackend:
                 and self._subagent_dispatcher is not None
                 and bool(subagent_refs)
             )
-            runtime_tool_names = select_runtime_tool_names(
-                ordinary_tool_policy=definition.ordinary_tool_policy,
-                memory_scope=current.memory_scope,
-                planning=current.planning,
-                subagent_available=subagent_available,
-            )
             memory = None
-            selected_memory = tuple(
-                name for name in runtime_tool_names if name in MEMORY_TOOL_NAMES
+            selected_memory = select_harness_memory_tools(
+                definition.ordinary_tool_policy
             )
-            if selected_memory:
+            if current.memory_scope is not None and selected_memory:
                 if self._memory_store_factory is None:
                     raise AIError(ErrorCode.RUNTIME_DEPENDENCY_NOT_READY)
                 memory = self._memory_store_factory(

--- a/linktools-ai/src/linktools/ai/runtime/_mcp.py
+++ b/linktools-ai/src/linktools/ai/runtime/_mcp.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """Materialize the MCP transport selected by a compiled runtime binding."""
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, replace
 from pathlib import Path
 
@@ -14,9 +14,16 @@ from ..capability import mcp_server_namespace, tool_semantic_metadata
 from ..core import Principal, ResourceRef
 from ..errors import AIError, ErrorCode
 from ..spec import MCPServerSpec, parse_mcp_tool_selector
-from ._tool_boundary import ManagedToolDescriptor
+from ._tool_boundary import (
+    ManagedToolDescriptor,
+    managed_tool_descriptor_from_metadata,
+)
 
 _logger = environ.get_logger("ai.runtime.mcp")
+_MCP_TOOL_METADATA = tool_semantic_metadata(
+    effect="non_replay_safe",
+    tool_class="mcp",
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -25,6 +32,12 @@ class MCPMaterializedToolset:
 
     toolset: AbstractToolset[object]
     descriptor: ManagedToolDescriptor
+
+
+def _mcp_tool_metadata(base: Mapping[str, object] | None) -> dict[str, object]:
+    metadata = tool_semantic_metadata(base=base)
+    metadata.update(_MCP_TOOL_METADATA)
+    return metadata
 
 
 class _MCPSemanticToolset(WrapperToolset[object]):
@@ -38,11 +51,7 @@ class _MCPSemanticToolset(WrapperToolset[object]):
         for tool in tools.values():
             tool.tool_def = replace(
                 tool.tool_def,
-                metadata=tool_semantic_metadata(
-                    effect="non_replay_safe",
-                    tool_class="mcp",
-                    base=tool.tool_def.metadata,
-                ),
+                metadata=_mcp_tool_metadata(tool.tool_def.metadata),
             )
         return tools
 
@@ -63,6 +72,7 @@ async def materialize_mcp_servers(
     if principal.tenant_id != execution.tenant_id:
         raise AIError(ErrorCode.AUTHORIZATION_DENIED)
     policy = _selector_policy(selectors)
+    descriptor = managed_tool_descriptor_from_metadata(_MCP_TOOL_METADATA)
     values: list[MCPMaterializedToolset] = []
     seen_namespaces: set[str] = set()
     for server in servers:
@@ -95,16 +105,7 @@ async def materialize_mcp_servers(
             namespace,
             tuple(sorted(allowed or ("*",))),
         )
-        values.append(
-            MCPMaterializedToolset(
-                prefixed,
-                ManagedToolDescriptor(
-                    effect_owner="tool_operation",
-                    effect="non_replay_safe",
-                    tool_class="mcp",
-                ),
-            )
-        )
+        values.append(MCPMaterializedToolset(prefixed, descriptor))
     return tuple(values)
 
 

--- a/linktools-ai/src/linktools/ai/runtime/_mcp.py
+++ b/linktools-ai/src/linktools/ai/runtime/_mcp.py
@@ -3,17 +3,48 @@
 """Materialize the MCP transport selected by a compiled runtime binding."""
 
 from collections.abc import Sequence
+from dataclasses import dataclass, replace
 from pathlib import Path
 
-from pydantic_ai.toolsets import AbstractToolset
+from linktools.core import environ
+from pydantic_ai.toolsets import AbstractToolset, ToolsetTool, WrapperToolset
+from pydantic_ai.tools import RunContext as PydanticRunContext
 
-from ..capability import (
-    mcp_selector_server,
-    mcp_server_namespace,
-)
+from ..capability import mcp_server_namespace, tool_semantic_metadata
 from ..core import Principal, ResourceRef
 from ..errors import AIError, ErrorCode
-from ..spec import MCPServerSpec
+from ..spec import MCPServerSpec, parse_mcp_tool_selector
+from ._tool_boundary import ManagedToolDescriptor
+
+_logger = environ.get_logger("ai.runtime.mcp")
+
+
+@dataclass(frozen=True, slots=True)
+class MCPMaterializedToolset:
+    """Pair an MCP toolset with the descriptor supplied by its owner."""
+
+    toolset: AbstractToolset[object]
+    descriptor: ManagedToolDescriptor
+
+
+class _MCPSemanticToolset(WrapperToolset[object]):
+    """Attach MCP effect and class semantics at the materialization boundary."""
+
+    async def get_tools(
+        self,
+        ctx: PydanticRunContext[object],
+    ) -> dict[str, ToolsetTool[object]]:
+        tools = await self.wrapped.get_tools(ctx)
+        for tool in tools.values():
+            tool.tool_def = replace(
+                tool.tool_def,
+                metadata=tool_semantic_metadata(
+                    effect="non_replay_safe",
+                    tool_class="mcp",
+                    base=tool.tool_def.metadata,
+                ),
+            )
+        return tools
 
 
 async def materialize_mcp_servers(
@@ -23,7 +54,7 @@ async def materialize_mcp_servers(
     principal: Principal,
     execution: ResourceRef,
     execution_root: str,
-) -> "tuple[AbstractToolset[object], ...]":
+) -> tuple[MCPMaterializedToolset, ...]:
     """Materialize only compiler-selected stdio servers."""
     from fastmcp import Client
     from fastmcp.client.transports import StdioTransport
@@ -32,7 +63,7 @@ async def materialize_mcp_servers(
     if principal.tenant_id != execution.tenant_id:
         raise AIError(ErrorCode.AUTHORIZATION_DENIED)
     policy = _selector_policy(selectors)
-    values: list[AbstractToolset[object]] = []
+    values: list[MCPMaterializedToolset] = []
     seen_namespaces: set[str] = set()
     for server in servers:
         namespace = mcp_server_namespace(server.id)
@@ -55,15 +86,32 @@ async def materialize_mcp_servers(
             toolset = toolset.filtered(
                 lambda _ctx, tool_def, selected=names: tool_def.name in selected
             )
-        prefixed = toolset.prefixed(f"mcp__{namespace}__")
-        values.append(prefixed)
+        prefixed = _MCPSemanticToolset(
+            toolset.prefixed(f"mcp__{namespace}__")
+        )
+        _logger.debug(
+            "MCP server materialized: server=%s namespace=%s selected_tools=%s",
+            server.id,
+            namespace,
+            tuple(sorted(allowed or ("*",))),
+        )
+        values.append(
+            MCPMaterializedToolset(
+                prefixed,
+                ManagedToolDescriptor(
+                    effect_owner="tool_operation",
+                    effect="non_replay_safe",
+                    tool_class="mcp",
+                ),
+            )
+        )
     return tuple(values)
 
 
 def _selector_policy(selectors: Sequence[str]) -> "dict[str, frozenset[str]]":
     result: dict[str, set[str] | None] = {}
     for selector in selectors:
-        parsed = mcp_selector_server(selector)
+        parsed = parse_mcp_tool_selector(selector)
         if parsed is None:
             continue
         namespace, tool = parsed
@@ -83,4 +131,4 @@ def _selector_policy(selectors: Sequence[str]) -> "dict[str, frozenset[str]]":
     }
 
 
-__all__ = ["materialize_mcp_servers"]
+__all__ = ["MCPMaterializedToolset", "materialize_mcp_servers"]

--- a/linktools-ai/src/linktools/ai/runtime/_message.py
+++ b/linktools-ai/src/linktools/ai/runtime/_message.py
@@ -4,27 +4,21 @@
 
 import json
 import math
-from collections.abc import Mapping, Sequence
+from collections.abc import Sequence
 from dataclasses import replace
 from typing import cast
 
 from pydantic_ai import ModelMessagesTypeAdapter
 from pydantic_ai.messages import (
-    BaseToolReturnPart,
     BinaryContent,
     ModelMessage,
     ModelRequest,
     ModelResponse,
-    UploadedFile,
     UserPromptPart,
 )
 
 from ..core import JsonValue, canonical_json_bytes
 from ..errors import AIError, ErrorCode
-from ..model import (
-    LinkToolsUploadedFile,
-    declared_uploaded_file_media_type,
-)
 
 _CONSUMED_BINARY_MARKER = "[binary content already consumed]"
 
@@ -124,67 +118,11 @@ def binary_content_usage(messages: Sequence[ModelMessage]) -> tuple[int, int]:
     return count, total_bytes
 
 
-def _restore_uploaded_file_media_types(
-    encoded: object,
-    messages: Sequence[ModelMessage],
-) -> object:
-    if not isinstance(encoded, list) or len(encoded) != len(messages):
-        return encoded
-    for encoded_message, message in zip(encoded, messages):
-        if not isinstance(encoded_message, dict):
-            continue
-        encoded_parts = encoded_message.get("parts")
-        if not isinstance(encoded_parts, list):
-            continue
-        for encoded_part, part in zip(encoded_parts, message.parts):
-            if not isinstance(encoded_part, dict):
-                continue
-            if isinstance(part, UserPromptPart):
-                _restore_uploaded_file_media_types_in_value(
-                    encoded_part.get("content"),
-                    part.content,
-                )
-            elif isinstance(part, BaseToolReturnPart):
-                _restore_uploaded_file_media_types_in_value(
-                    encoded_part.get("content"),
-                    part.content,
-                )
-    return encoded
-
-
-def _restore_uploaded_file_media_types_in_value(
-    encoded: object,
-    original: object,
-) -> None:
-    if isinstance(original, UploadedFile):
-        if isinstance(encoded, dict):
-            encoded["media_type"] = declared_uploaded_file_media_type(original)
-        return
-    if isinstance(original, Mapping) and isinstance(encoded, dict):
-        for key, original_item in original.items():
-            if isinstance(key, str) and key in encoded:
-                _restore_uploaded_file_media_types_in_value(
-                    encoded[key],
-                    original_item,
-                )
-        return
-    if isinstance(original, Sequence) and not isinstance(
-        original,
-        (str, bytes, bytearray),
-    ) and isinstance(encoded, list):
-        for encoded_item, original_item in zip(encoded, original):
-            _restore_uploaded_file_media_types_in_value(
-                encoded_item,
-                original_item,
-            )
-
-
 def encode_model_messages(messages: Sequence[ModelMessage]) -> bytes:
     value = ModelMessagesTypeAdapter.dump_python(
         list(messages),
         mode="json",
     )
-    _restore_uploaded_file_media_types(value, messages)
     return canonical_json_bytes(_json_value(value, reading=False))
 
 
@@ -200,86 +138,7 @@ def decode_model_messages(raw: bytes) -> tuple[ModelMessage, ...]:
         messages = ModelMessagesTypeAdapter.validate_json(raw)
     except ValueError as error:
         raise AIError(ErrorCode.STORAGE_INTEGRITY_ERROR) from error
-    return _rehydrate_uploaded_files(messages, json_value)
-
-
-def _rehydrate_uploaded_files(
-    messages: Sequence[ModelMessage],
-    encoded: object,
-) -> tuple[ModelMessage, ...]:
-    if not isinstance(encoded, list) or len(encoded) != len(messages):
-        return tuple(messages)
-    result: list[ModelMessage] = []
-    for message, encoded_message in zip(messages, encoded):
-        if not isinstance(encoded_message, dict):
-            result.append(message)
-            continue
-        encoded_parts = encoded_message.get("parts")
-        if not isinstance(encoded_parts, list):
-            result.append(message)
-            continue
-        parts = []
-        changed = False
-        for index, part in enumerate(message.parts):
-            if index >= len(encoded_parts) or not isinstance(
-                encoded_parts[index],
-                dict,
-            ):
-                parts.append(part)
-                continue
-            encoded_part = encoded_parts[index]
-            if isinstance(part, (UserPromptPart, BaseToolReturnPart)):
-                content = _rehydrate_uploaded_files_in_value(
-                    part.content,
-                    encoded_part.get("content"),
-                )
-                if content is not part.content:
-                    parts.append(replace(part, content=content))
-                    changed = True
-                    continue
-            parts.append(part)
-        result.append(replace(message, parts=parts) if changed else message)
-    return tuple(result)
-
-
-def _rehydrate_uploaded_files_in_value(
-    value: object,
-    encoded: object,
-) -> object:
-    if isinstance(value, UploadedFile):
-        if not isinstance(encoded, Mapping):
-            raise AIError(ErrorCode.STORAGE_INTEGRITY_ERROR)
-        media_type = encoded.get("media_type")
-        if media_type is not None and not isinstance(media_type, str):
-            raise AIError(ErrorCode.STORAGE_INTEGRITY_ERROR)
-        return LinkToolsUploadedFile(
-            value.file_id,
-            value.provider_name,
-            media_type=media_type,
-            identifier=value.identifier,
-            vendor_metadata=value.vendor_metadata,
-        )
-    if isinstance(value, Mapping) and isinstance(encoded, Mapping):
-        changed = False
-        result: dict[object, object] = {}
-        for key, item in value.items():
-            encoded_item = encoded.get(key)
-            restored = _rehydrate_uploaded_files_in_value(item, encoded_item)
-            result[key] = restored
-            changed = changed or restored is not item
-        return result if changed else value
-    if (
-        isinstance(value, Sequence)
-        and not isinstance(value, (str, bytes, bytearray))
-        and isinstance(encoded, list)
-    ):
-        restored_items = [
-            _rehydrate_uploaded_files_in_value(item, encoded_item)
-            for item, encoded_item in zip(value, encoded)
-        ]
-        if any(restored is not item for restored, item in zip(restored_items, value)):
-            return restored_items
-    return value
+    return tuple(messages)
 
 
 __all__ = [

--- a/linktools-ai/src/linktools/ai/runtime/_message.py
+++ b/linktools-ai/src/linktools/ai/runtime/_message.py
@@ -4,21 +4,27 @@
 
 import json
 import math
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import replace
 from typing import cast
 
 from pydantic_ai import ModelMessagesTypeAdapter
 from pydantic_ai.messages import (
+    BaseToolReturnPart,
     BinaryContent,
     ModelMessage,
     ModelRequest,
     ModelResponse,
+    UploadedFile,
     UserPromptPart,
 )
 
 from ..core import JsonValue, canonical_json_bytes
 from ..errors import AIError, ErrorCode
+from ..model import (
+    LinkToolsUploadedFile,
+    declared_uploaded_file_media_type,
+)
 
 _CONSUMED_BINARY_MARKER = "[binary content already consumed]"
 
@@ -118,11 +124,67 @@ def binary_content_usage(messages: Sequence[ModelMessage]) -> tuple[int, int]:
     return count, total_bytes
 
 
+def _restore_uploaded_file_media_types(
+    encoded: object,
+    messages: Sequence[ModelMessage],
+) -> object:
+    if not isinstance(encoded, list) or len(encoded) != len(messages):
+        return encoded
+    for encoded_message, message in zip(encoded, messages):
+        if not isinstance(encoded_message, dict):
+            continue
+        encoded_parts = encoded_message.get("parts")
+        if not isinstance(encoded_parts, list):
+            continue
+        for encoded_part, part in zip(encoded_parts, message.parts):
+            if not isinstance(encoded_part, dict):
+                continue
+            if isinstance(part, UserPromptPart):
+                _restore_uploaded_file_media_types_in_value(
+                    encoded_part.get("content"),
+                    part.content,
+                )
+            elif isinstance(part, BaseToolReturnPart):
+                _restore_uploaded_file_media_types_in_value(
+                    encoded_part.get("content"),
+                    part.content,
+                )
+    return encoded
+
+
+def _restore_uploaded_file_media_types_in_value(
+    encoded: object,
+    original: object,
+) -> None:
+    if isinstance(original, UploadedFile):
+        if isinstance(encoded, dict):
+            encoded["media_type"] = declared_uploaded_file_media_type(original)
+        return
+    if isinstance(original, Mapping) and isinstance(encoded, dict):
+        for key, original_item in original.items():
+            if isinstance(key, str) and key in encoded:
+                _restore_uploaded_file_media_types_in_value(
+                    encoded[key],
+                    original_item,
+                )
+        return
+    if isinstance(original, Sequence) and not isinstance(
+        original,
+        (str, bytes, bytearray),
+    ) and isinstance(encoded, list):
+        for encoded_item, original_item in zip(encoded, original):
+            _restore_uploaded_file_media_types_in_value(
+                encoded_item,
+                original_item,
+            )
+
+
 def encode_model_messages(messages: Sequence[ModelMessage]) -> bytes:
     value = ModelMessagesTypeAdapter.dump_python(
         list(messages),
         mode="json",
     )
+    _restore_uploaded_file_media_types(value, messages)
     return canonical_json_bytes(_json_value(value, reading=False))
 
 
@@ -138,7 +200,86 @@ def decode_model_messages(raw: bytes) -> tuple[ModelMessage, ...]:
         messages = ModelMessagesTypeAdapter.validate_json(raw)
     except ValueError as error:
         raise AIError(ErrorCode.STORAGE_INTEGRITY_ERROR) from error
-    return tuple(messages)
+    return _rehydrate_uploaded_files(messages, json_value)
+
+
+def _rehydrate_uploaded_files(
+    messages: Sequence[ModelMessage],
+    encoded: object,
+) -> tuple[ModelMessage, ...]:
+    if not isinstance(encoded, list) or len(encoded) != len(messages):
+        return tuple(messages)
+    result: list[ModelMessage] = []
+    for message, encoded_message in zip(messages, encoded):
+        if not isinstance(encoded_message, dict):
+            result.append(message)
+            continue
+        encoded_parts = encoded_message.get("parts")
+        if not isinstance(encoded_parts, list):
+            result.append(message)
+            continue
+        parts = []
+        changed = False
+        for index, part in enumerate(message.parts):
+            if index >= len(encoded_parts) or not isinstance(
+                encoded_parts[index],
+                dict,
+            ):
+                parts.append(part)
+                continue
+            encoded_part = encoded_parts[index]
+            if isinstance(part, (UserPromptPart, BaseToolReturnPart)):
+                content = _rehydrate_uploaded_files_in_value(
+                    part.content,
+                    encoded_part.get("content"),
+                )
+                if content is not part.content:
+                    parts.append(replace(part, content=content))
+                    changed = True
+                    continue
+            parts.append(part)
+        result.append(replace(message, parts=parts) if changed else message)
+    return tuple(result)
+
+
+def _rehydrate_uploaded_files_in_value(
+    value: object,
+    encoded: object,
+) -> object:
+    if isinstance(value, UploadedFile):
+        if not isinstance(encoded, Mapping):
+            raise AIError(ErrorCode.STORAGE_INTEGRITY_ERROR)
+        media_type = encoded.get("media_type")
+        if media_type is not None and not isinstance(media_type, str):
+            raise AIError(ErrorCode.STORAGE_INTEGRITY_ERROR)
+        return LinkToolsUploadedFile(
+            value.file_id,
+            value.provider_name,
+            media_type=media_type,
+            identifier=value.identifier,
+            vendor_metadata=value.vendor_metadata,
+        )
+    if isinstance(value, Mapping) and isinstance(encoded, Mapping):
+        changed = False
+        result: dict[object, object] = {}
+        for key, item in value.items():
+            encoded_item = encoded.get(key)
+            restored = _rehydrate_uploaded_files_in_value(item, encoded_item)
+            result[key] = restored
+            changed = changed or restored is not item
+        return result if changed else value
+    if (
+        isinstance(value, Sequence)
+        and not isinstance(value, (str, bytes, bytearray))
+        and isinstance(encoded, list)
+    ):
+        restored_items = [
+            _rehydrate_uploaded_files_in_value(item, encoded_item)
+            for item, encoded_item in zip(value, encoded)
+        ]
+        if any(restored is not item for restored, item in zip(restored_items, value)):
+            return restored_items
+    return value
 
 
 __all__ = [

--- a/linktools-ai/src/linktools/ai/runtime/_object.py
+++ b/linktools-ai/src/linktools/ai/runtime/_object.py
@@ -15,21 +15,9 @@ from ..storage import (
     read_object,
     runtime_object_key,
 )
-from .state import RuntimeDomain
+from .state import RuntimeDomain, runtime_domain_uses_object_store
 
 _DIGEST = re.compile(r"[0-9a-f]{64}\Z")
-_OBJECT_DOMAINS = frozenset(
-    {
-        RuntimeDomain.CONVERSATION,
-        RuntimeDomain.EXECUTION,
-        RuntimeDomain.MEMORY,
-        RuntimeDomain.ARTIFACT,
-        RuntimeDomain.RECOVERY,
-        RuntimeDomain.TASK,
-    }
-)
-
-
 @dataclass(frozen=True, slots=True)
 class RuntimeObjectKeyFactory:
     namespace: str
@@ -43,7 +31,7 @@ class RuntimeObjectKeyFactory:
         return namespace_digest(self.namespace)
 
     def key(self, runtime_domain: RuntimeDomain, tenant_id: str, digest: str) -> str:
-        if runtime_domain not in _OBJECT_DOMAINS:
+        if not runtime_domain_uses_object_store(runtime_domain):
             raise ValueError("Runtime object identity is invalid")
         tenant_id = validate_tenant_id(tenant_id)
         if _DIGEST.fullmatch(digest) is None:

--- a/linktools-ai/src/linktools/ai/runtime/_runtime_history.py
+++ b/linktools-ai/src/linktools/ai/runtime/_runtime_history.py
@@ -5,6 +5,8 @@
 from collections.abc import AsyncIterator
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
 
+from linktools.core import environ
+
 from ..core import (
     AuthorizationPolicy,
     HmacCursorSigner,
@@ -18,8 +20,17 @@ from ..workspace import Workspace
 from ._factory import _default_runtime_state, _grant_key
 from ._history import StepExecutionHistoryReader
 from ._history_service import DefaultExecutionHistoryService
-from .service_api import ExecutionHistoryItem, ExecutionTraceItem, TranscriptItem
+from .service_api import (
+    ExecutionHistoryItem,
+    ExecutionHistoryService,
+    ExecutionTraceItem,
+    ExecutionView,
+    ListExecutionRequest,
+    TranscriptItem,
+)
 from .state import RuntimeDomain, RuntimeState
+
+_logger = environ.get_logger("ai.runtime.history")
 
 
 class RuntimeHistory:
@@ -27,7 +38,7 @@ class RuntimeHistory:
 
     def __init__(
         self,
-        service: DefaultExecutionHistoryService,
+        service: ExecutionHistoryService,
         *,
         tenant_id: str,
     ) -> None:
@@ -37,6 +48,16 @@ class RuntimeHistory:
     @property
     def tenant_id(self) -> str:
         return self._tenant_id
+
+    async def inspect_execution(
+        self, execution_id: str, *, principal: Principal
+    ) -> ExecutionView:
+        return await self._service.inspect(execution_id, principal=principal)
+
+    async def list_executions(
+        self, request: ListExecutionRequest
+    ) -> Page[ExecutionView]:
+        return await self._service.list(request)
 
     @classmethod
     def open(
@@ -115,6 +136,7 @@ async def _open_runtime_history(
     if not isinstance(selected_state, RuntimeState):
         raise TypeError("state must be RuntimeState")
     initialized = False
+    body_error: BaseException | None = None
     try:
         await selected_state.initialize(
             namespace=workspace.workspace_id,
@@ -143,11 +165,30 @@ async def _open_runtime_history(
                 else authorization
             ),
             reader,
+            cursor_signer=HmacCursorSigner("execution", _grant_key(workspace)),
         )
         yield RuntimeHistory(service, tenant_id=effective_tenant_id)
+    except BaseException as error:
+        body_error = error
+        raise
     finally:
         if initialized:
-            await selected_state.close()
+            try:
+                await selected_state.close()
+            except BaseException as error:
+                if body_error is None:
+                    raise
+                _log_secondary_cleanup("history.close", error)
+
+
+def _log_secondary_cleanup(phase: str, error: BaseException) -> None:
+    code = error.code.value if isinstance(error, AIError) else None
+    _logger.error(
+        "secondary cleanup failed: phase=%s code=%s exception_type=%s",
+        phase,
+        code,
+        type(error).__name__,
+    )
 
 
 __all__ = ["RuntimeHistory"]

--- a/linktools-ai/src/linktools/ai/runtime/_runtime_service.py
+++ b/linktools-ai/src/linktools/ai/runtime/_runtime_service.py
@@ -913,8 +913,8 @@ class Runtime(Generic[AppT]):
                     task.result()
                 except asyncio.CancelledError:
                     pass
-                except BaseException:  # noqa: BLE001
-                    _logger.exception("runtime close failed after caller cancellation")
+                except BaseException as error:  # noqa: BLE001
+                    _log_secondary_cleanup("runtime.close", error)
             raise
         except BaseException:
             async with self._close_lock:
@@ -927,8 +927,8 @@ class Runtime(Generic[AppT]):
             task.result()
         except asyncio.CancelledError:
             pass
-        except BaseException:  # noqa: BLE001
-            _logger.exception("runtime close task failed")
+        except BaseException as error:  # noqa: BLE001
+            _log_secondary_cleanup("runtime.close", error)
 
     async def _cleanup(self) -> None:
         if self._close_callback is not None:
@@ -1008,18 +1008,31 @@ async def _open_runtime(
             metric_control=components.metric_control,
         )
     except BaseException:
-        await components.close_callback()
+        try:
+            await components.close_callback()
+        except BaseException as error:
+            _log_secondary_cleanup("runtime.construct", error)
         raise
     try:
         yield runtime
-    except BaseException as body_error:
+    except BaseException:
         try:
             await runtime.close()
-        except BaseException as close_error:
-            raise close_error from body_error
+        except BaseException as error:
+            _log_secondary_cleanup("runtime.body", error)
         raise
     else:
         await runtime.close()
+
+
+def _log_secondary_cleanup(phase: str, error: BaseException) -> None:
+    code = error.code.value if isinstance(error, AIError) else None
+    _logger.error(
+        "secondary cleanup failed: phase=%s code=%s exception_type=%s",
+        phase,
+        code,
+        type(error).__name__,
+    )
 
 
 __all__ = ["Runtime"]

--- a/linktools-ai/src/linktools/ai/runtime/_tool_boundary.py
+++ b/linktools-ai/src/linktools/ai/runtime/_tool_boundary.py
@@ -24,7 +24,12 @@ from pydantic_ai.messages import ToolCallPart
 from pydantic_ai.tools import RunContext as PydanticRunContext, ToolDefinition
 from pydantic_ai.toolsets import AbstractToolset, ToolsetTool
 
-from ..capability import AgentContext, workspace_tool_path_fields_from_metadata
+from ..capability import (
+    AgentContext,
+    tool_class_from_metadata,
+    tool_effect_from_metadata,
+    tool_path_fields_from_metadata,
+)
 from ..core import canonical_sha256, normalize_json_value
 from ..errors import AIError, ErrorCode
 from ..workspace import SandboxSession, WorkspaceToolPermissionPolicy
@@ -84,6 +89,25 @@ class ManagedToolDescriptor:
             raise ValueError("tool-operation tools require an effect")
 
 
+def managed_tool_descriptor_from_metadata(
+    metadata: Mapping[str, object] | None,
+) -> ManagedToolDescriptor:
+    """Build a leaf descriptor from one validated Tool semantic declaration."""
+    effect = tool_effect_from_metadata(metadata, require=True)
+    tool_class = tool_class_from_metadata(metadata)
+    path_fields = tool_path_fields_from_metadata(metadata)
+    if effect is None or tool_class is None:
+        raise AIError(ErrorCode.CAPABILITY_RESOLUTION_INVALID)
+    if tool_class == "business" and path_fields:
+        raise AIError(ErrorCode.CAPABILITY_RESOLUTION_INVALID)
+    return ManagedToolDescriptor(
+        effect_owner="none" if effect == "none" else "tool_operation",
+        effect=effect,
+        tool_class=tool_class,
+        workspace_path_fields=path_fields,
+    )
+
+
 class RuntimeToolBoundaryToolset(AbstractToolset[AgentContext[object]]):
     """Apply workspace policy and effect durability at the final leaf call."""
 
@@ -93,7 +117,7 @@ class RuntimeToolBoundaryToolset(AbstractToolset[AgentContext[object]]):
         descriptors: Mapping[str, ManagedToolDescriptor],
         *,
         id: str,
-        default_descriptor: ManagedToolDescriptor | None = None,
+        descriptor: ManagedToolDescriptor | None = None,
         workspace_policy: WorkspaceToolPermissionPolicy | None = None,
         sandbox_session: SandboxSession | None = None,
         tool_operations: ToolOperationBridge | None = None,
@@ -105,8 +129,8 @@ class RuntimeToolBoundaryToolset(AbstractToolset[AgentContext[object]]):
             raise ValueError("toolset id must be non-empty")
         self._toolsets = tuple(toolsets)
         self._descriptors = dict(descriptors)
+        self._descriptor = descriptor
         self._id = id
-        self._default_descriptor = default_descriptor
         self._workspace_policy = workspace_policy
         self._sandbox_session = sandbox_session
         self._tool_operations = tool_operations
@@ -163,8 +187,10 @@ class RuntimeToolBoundaryToolset(AbstractToolset[AgentContext[object]]):
             for name, raw_tool in raw_tools.items():
                 if name in result:
                     raise AIError(ErrorCode.CAPABILITY_RESOLUTION_INVALID)
-                if name not in self._descriptors and self._default_descriptor is None:
-                    raise AIError(ErrorCode.CAPABILITY_RESOLUTION_INVALID)
+                if name not in self._descriptors:
+                    if self._descriptor is None:
+                        raise AIError(ErrorCode.CAPABILITY_RESOLUTION_INVALID)
+                    self._descriptors[name] = self._descriptor
                 result[name] = ToolsetTool(
                     toolset=self,
                     tool_def=raw_tool.tool_def,
@@ -184,16 +210,10 @@ class RuntimeToolBoundaryToolset(AbstractToolset[AgentContext[object]]):
     ) -> Any:
         if not isinstance(tool_args, dict):
             raise AIError(ErrorCode.REQUEST_FIELD_INVALID)
-        descriptor = self._descriptors.get(name, self._default_descriptor)
+        descriptor = self._descriptors.get(name)
         if descriptor is None or tool.toolset is not self:
             raise AIError(ErrorCode.CAPABILITY_RESOLUTION_INVALID)
         path_fields = descriptor.workspace_path_fields
-        if descriptor.tool_class.startswith("filesystem"):
-            declared_fields = workspace_tool_path_fields_from_metadata(
-                tool.tool_def.metadata
-            )
-            if declared_fields:
-                path_fields = declared_fields
         raw_toolset, raw_tool = await self._raw_tool(name, ctx)
         final_args = await self._canonicalize_args(tool_args, path_fields)
         call_id = ctx.tool_call_id
@@ -408,6 +428,7 @@ def _is_workspace_pre_effect_retry(
 
 __all__ = [
     "ManagedToolDescriptor",
+    "managed_tool_descriptor_from_metadata",
     "RepositoryInstructionBoundary",
     "RuntimeToolBoundaryToolset",
 ]

--- a/linktools-ai/src/linktools/ai/runtime/service_api.py
+++ b/linktools-ai/src/linktools/ai/runtime/service_api.py
@@ -4,7 +4,7 @@
 
 from collections.abc import AsyncIterator, Mapping, Sequence
 from dataclasses import dataclass, field
-from typing import Protocol
+from typing import Protocol, cast
 
 from pydantic_ai.messages import UserContent
 
@@ -163,17 +163,18 @@ class ExecutionView:
     session_id: str | None = None
 
 
-def project_execution_view(source: _ExecutionViewSource) -> ExecutionView:
+def project_execution_view(source: object) -> ExecutionView:
     """Project an internal execution source into the stable public view."""
+    value = cast(_ExecutionViewSource, source)
     return ExecutionView(
-        source.execution_id,
-        source.agent_id,
-        source.status,
-        source.lineage_kind,
-        source.parent_execution_id,
-        source.root_execution_id,
-        source.parent_invocation_id,
-        source.session_id,
+        value.execution_id,
+        value.agent_id,
+        value.status,
+        value.lineage_kind,
+        value.parent_execution_id,
+        value.root_execution_id,
+        value.parent_invocation_id,
+        value.session_id,
     )
 
 

--- a/linktools-ai/src/linktools/ai/runtime/service_api.py
+++ b/linktools-ai/src/linktools/ai/runtime/service_api.py
@@ -140,6 +140,17 @@ class ExecutionHandle:
     execution_id: str
 
 
+class _ExecutionViewSource(Protocol):
+    execution_id: str
+    agent_id: str
+    status: ExecutionStatus
+    lineage_kind: ExecutionLineageKind
+    parent_execution_id: str | None
+    root_execution_id: str
+    parent_invocation_id: str | None
+    session_id: str | None
+
+
 @dataclass(frozen=True, slots=True)
 class ExecutionView:
     execution_id: str
@@ -149,6 +160,20 @@ class ExecutionView:
     parent_execution_id: str | None
     root_execution_id: str
     parent_invocation_id: str | None
+    session_id: str | None = None
+
+
+def _project_execution_view(source: _ExecutionViewSource) -> ExecutionView:
+    return ExecutionView(
+        source.execution_id,
+        source.agent_id,
+        source.status,
+        source.lineage_kind,
+        source.parent_execution_id,
+        source.root_execution_id,
+        source.parent_invocation_id,
+        source.session_id,
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -346,6 +371,24 @@ class ListSessionRequest:
     principal: Principal
     cursor: "str | None" = None
     limit: int = 100
+
+
+@dataclass(frozen=True, slots=True)
+class ListExecutionRequest:
+    principal: Principal
+    session_id: str | None = None
+    agent_id: str | None = None
+    parent_execution_id: str | None = None
+    cursor: str | None = None
+    limit: int = 100
+
+    def __post_init__(self) -> None:
+        if (
+            isinstance(self.limit, bool)
+            or not isinstance(self.limit, int)
+            or not 1 <= self.limit <= 200
+        ):
+            raise AIError(ErrorCode.PAGE_LIMIT_INVALID)
 
 
 @dataclass(frozen=True, slots=True)
@@ -719,6 +762,14 @@ class ArtifactDownload:
 
 
 class ExecutionHistoryService(Protocol):
+    async def inspect(
+        self, execution_id: str, *, principal: Principal
+    ) -> ExecutionView: ...
+
+    async def list(
+        self, request: ListExecutionRequest
+    ) -> "Page[ExecutionView]": ...
+
     async def trace(
         self,
         execution_id: str,
@@ -786,6 +837,9 @@ class ExecutionService(Protocol):
     async def inspect(
         self, execution_id: str, *, principal: Principal
     ) -> ExecutionView: ...
+    async def list(
+        self, request: ListExecutionRequest
+    ) -> "Page[ExecutionView]": ...
     async def result(
         self, execution_id: str, *, principal: Principal
     ) -> ExecutionResult: ...
@@ -994,6 +1048,7 @@ __all__ = [
     "ExternalSupplyResult",
     "ForkExecutionRequest",
     "ForkSessionRequest",
+    "ListExecutionRequest",
     "ListSessionRequest",
     "LoadedSession",
     "Page",

--- a/linktools-ai/src/linktools/ai/runtime/service_api.py
+++ b/linktools-ai/src/linktools/ai/runtime/service_api.py
@@ -163,7 +163,8 @@ class ExecutionView:
     session_id: str | None = None
 
 
-def _project_execution_view(source: _ExecutionViewSource) -> ExecutionView:
+def project_execution_view(source: _ExecutionViewSource) -> ExecutionView:
+    """Project an internal execution source into the stable public view."""
     return ExecutionView(
         source.execution_id,
         source.agent_id,
@@ -1063,4 +1064,5 @@ __all__ = [
     "TaskGraphRunEvent",
     "TranscriptItem",
     "UpdateSessionRequest",
+    "project_execution_view",
 ]

--- a/linktools-ai/src/linktools/ai/runtime/state/__init__.py
+++ b/linktools-ai/src/linktools/ai/runtime/state/__init__.py
@@ -7,6 +7,7 @@ from ._plan import (
     RuntimeRetentionMode,
     RuntimeStatePlan,
     RuntimeStateRoute,
+    runtime_domain_uses_object_store,
 )
 from ._root import RuntimeState
 
@@ -16,4 +17,5 @@ __all__ = [
     "RuntimeState",
     "RuntimeStatePlan",
     "RuntimeStateRoute",
+    "runtime_domain_uses_object_store",
 ]

--- a/linktools-ai/src/linktools/ai/runtime/state/_contracts.py
+++ b/linktools-ai/src/linktools/ai/runtime/state/_contracts.py
@@ -502,6 +502,22 @@ class ExecutionRecord:
     def binding_digest(self) -> str:
         return self.binding.binding_digest
 
+    @property
+    def agent_id(self) -> str:
+        return self.binding.agent_spec.id
+
+
+@dataclass(frozen=True, slots=True)
+class ExecutionCandidate:
+    record: ExecutionRecord
+    cursor: str
+
+
+@dataclass(frozen=True, slots=True)
+class ExecutionCandidatePage:
+    items: tuple[ExecutionCandidate, ...]
+    has_more: bool
+
 
 @dataclass(frozen=True, slots=True)
 class ExecutionRunSealHead:
@@ -1349,6 +1365,15 @@ class ExecutionRepository(RuntimeRepository, Protocol):
     async def list_children(
         self, execution_id: str, *, tenant_id: str
     ) -> tuple[ExecutionRecord, ...]: ...
+    async def list_candidates(
+        self,
+        *,
+        tenant_id: str,
+        session_id: str | None,
+        parent_execution_id: str | None,
+        cursor: str | None,
+        limit: int,
+    ) -> ExecutionCandidatePage: ...
     async def claim_start(self, claim: ExecutionStartClaim) -> ExecutionRecord: ...
     async def reserve_start(
         self, reservation: ExecutionStartReservation

--- a/linktools-ai/src/linktools/ai/runtime/state/_maintenance.py
+++ b/linktools-ai/src/linktools/ai/runtime/state/_maintenance.py
@@ -17,7 +17,7 @@ from ._codec import (
     _iter_enveloped_runtime_object_refs,
     decode_envelope,
 )
-from ._plan import RuntimeDomain
+from ._plan import RuntimeDomain, runtime_domain_uses_object_store
 from ._store import (
     FactScanCursor,
     OperationScanCursor,
@@ -29,16 +29,6 @@ from ._store import (
 )
 
 _logger = environ.get_logger("ai.runtime.state.maintenance")
-_OBJECT_DOMAINS = frozenset(
-    {
-        RuntimeDomain.CONVERSATION,
-        RuntimeDomain.EXECUTION,
-        RuntimeDomain.MEMORY,
-        RuntimeDomain.ARTIFACT,
-        RuntimeDomain.RECOVERY,
-        RuntimeDomain.TASK,
-    }
-)
 _MAINTENANCE_PAGE_SIZE = 128
 _ENVELOPED_FACT_KINDS = frozenset(
     {
@@ -164,7 +154,7 @@ class RuntimeStorageInspection:
     def object_inspection_stores(self) -> tuple[ObjectStoreInspection, ...]:
         stores: dict[int, ObjectStoreInspection] = {}
         for domain in self._durable_domains:
-            if domain not in _OBJECT_DOMAINS:
+            if not runtime_domain_uses_object_store(domain):
                 continue
             object_store = self._objects.object_store(domain)
             if not isinstance(object_store, ObjectStoreInspection):
@@ -175,7 +165,7 @@ class RuntimeStorageInspection:
     def object_maintenance_stores(self) -> tuple[ObjectStoreMaintenance, ...]:
         stores: dict[int, ObjectStoreMaintenance] = {}
         for domain in self._durable_domains:
-            if domain not in _OBJECT_DOMAINS:
+            if not runtime_domain_uses_object_store(domain):
                 continue
             object_store = self._objects.object_store(domain)
             if not isinstance(object_store, ObjectStoreMaintenance):

--- a/linktools-ai/src/linktools/ai/runtime/state/_materializer.py
+++ b/linktools-ai/src/linktools/ai/runtime/state/_materializer.py
@@ -42,6 +42,7 @@ from ._plan import (
     RuntimeRetentionMode,
     RuntimeStatePlan,
     RuntimeStateRoute,
+    runtime_domain_uses_object_store,
 )
 from ._recovery_repositories import build_recovery_repository_bundle
 from ._repositories import OperationLedgerRepository, build_repository_bundle
@@ -57,16 +58,6 @@ from ._steps import (
 from ._task_repository import TaskAdmissionRepositoryImpl, TaskRepositoryImpl
 
 _logger = environ.get_logger("ai.runtime.state.materializer")
-_OBJECT_DOMAINS = frozenset(
-    {
-        RuntimeDomain.CONVERSATION,
-        RuntimeDomain.EXECUTION,
-        RuntimeDomain.MEMORY,
-        RuntimeDomain.ARTIFACT,
-        RuntimeDomain.RECOVERY,
-        RuntimeDomain.TASK,
-    }
-)
 _STEP_DOMAINS = (
     RuntimeDomain.CONVERSATION,
     RuntimeDomain.EXECUTION,
@@ -259,7 +250,10 @@ async def materialize_runtime_state(
                 from ._schema import build_runtime_sql_metadata
 
                 build_runtime_sql_metadata(frozenset(domains), metadata=metadata)
-                if object_store is None and set(domains) & _OBJECT_DOMAINS:
+                if object_store is None and any(
+                    runtime_domain_uses_object_store(domain)
+                    for domain in domains
+                ):
                     build_object_sql_metadata(metadata=metadata)
                 group = SqlStateStorageGroup(
                     context,
@@ -396,8 +390,15 @@ async def materialize_runtime_state(
         for cleanup in reversed(cleanups):
             try:
                 await cleanup()
-            except BaseException:
-                _logger.exception("runtime materialization cleanup failed")
+            except BaseException as error:
+                code = error.code.value if isinstance(error, AIError) else None
+                _logger.error(
+                    "runtime materialization cleanup failed: phase=%s code=%s "
+                    "exception_type=%s",
+                    "runtime.state.materialize",
+                    code,
+                    type(error).__name__,
+                )
         raise
 
 
@@ -458,7 +459,9 @@ def _build_object_router(
     values: dict[RuntimeDomain, ObjectStore] = {}
     close_guard_stores: list[ObjectStore] = []
     sql_objects: dict[int, SqlObjectStore] = {}
-    for domain in _OBJECT_DOMAINS:
+    for domain in RuntimeDomain:
+        if not runtime_domain_uses_object_store(domain):
+            continue
         route = plan.route(domain)
         if route.retention is RuntimeRetentionMode.DURABLE and external is not None:
             values[domain] = external

--- a/linktools-ai/src/linktools/ai/runtime/state/_plan.py
+++ b/linktools-ai/src/linktools/ai/runtime/state/_plan.py
@@ -25,6 +25,25 @@ class RuntimeDomain(str, Enum):
     RECOVERY = "recovery"
 
 
+_OBJECT_STORE_DOMAINS = frozenset(
+    {
+        RuntimeDomain.CONVERSATION,
+        RuntimeDomain.EXECUTION,
+        RuntimeDomain.MEMORY,
+        RuntimeDomain.ARTIFACT,
+        RuntimeDomain.TASK,
+        RuntimeDomain.RECOVERY,
+    }
+)
+
+
+def runtime_domain_uses_object_store(domain: RuntimeDomain) -> bool:
+    """Return whether a Runtime domain owns object-store data."""
+    if not isinstance(domain, RuntimeDomain):
+        raise TypeError("domain must be RuntimeDomain")
+    return domain in _OBJECT_STORE_DOMAINS
+
+
 class RuntimeRetentionMode(str, Enum):
     __str__ = str.__str__
     __format__ = str.__format__
@@ -253,4 +272,10 @@ def _normalize_path(value: "str | Path") -> Path:
     return Path(value).expanduser().resolve(strict=False)
 
 
-__all__ = ["RuntimeDomain", "RuntimeRetentionMode", "RuntimeStatePlan", "RuntimeStateRoute"]
+__all__ = [
+    "RuntimeDomain",
+    "RuntimeRetentionMode",
+    "RuntimeStatePlan",
+    "RuntimeStateRoute",
+    "runtime_domain_uses_object_store",
+]

--- a/linktools-ai/src/linktools/ai/runtime/state/_repositories.py
+++ b/linktools-ai/src/linktools/ai/runtime/state/_repositories.py
@@ -57,6 +57,8 @@ from ._contracts import (
     ConversationHistoryIndexNodeRecord,
     ConversationHistoryRecord,
     EvaluationRecord,
+    ExecutionCandidate,
+    ExecutionCandidatePage,
     ExecutionCancelRequestCommit,
     ExecutionEventAppend,
     ExecutionEventRecord,
@@ -298,6 +300,40 @@ class _RepositoryBase:
             ) > (last.sort_key, last.key_digest):
                 return (*records, probe[0])
             return records
+
+        return await self._store.read(read)
+
+    async def _has_records(
+        self,
+        kind: str,
+        *,
+        scope: bytes | None = None,
+        parent: bytes | None = None,
+        states: frozenset[str] | None = None,
+        sort_key_prefix: str | None = None,
+        cursor: str | None = None,
+    ) -> bool:
+        after_sort_key, after_key_digest = _decode_record_cursor(cursor)
+
+        async def read(transaction: StateTransaction) -> bool:
+            records = await transaction.list_records(
+                RecordQuery(
+                    partition_digest=(
+                        self._partition(kind)
+                        if scope is None and parent is None
+                        else None
+                    ),
+                    scope_digest=scope,
+                    parent_digest=parent,
+                    kind=kind,
+                    states=states,
+                    sort_key_prefix=sort_key_prefix,
+                    after_sort_key=after_sort_key,
+                    after_key_digest=after_key_digest,
+                    limit=1,
+                )
+            )
+            return bool(records)
 
         return await self._store.read(read)
 
@@ -1961,6 +1997,62 @@ class ExecutionRepositoryImpl(_ResourceRepository[ExecutionRecord]):
         )
         return tuple(
             [await self._decode(record, ExecutionRecord) for record in records]
+        )
+
+    async def list_candidates(
+        self,
+        *,
+        tenant_id: str,
+        session_id: str | None,
+        parent_execution_id: str | None,
+        cursor: str | None,
+        limit: int,
+    ) -> ExecutionCandidatePage:
+        if tenant_id != self._tenant_id:
+            return ExecutionCandidatePage((), False)
+        if (
+            isinstance(limit, bool)
+            or not isinstance(limit, int)
+            or not 1 <= limit <= 1000
+        ):
+            raise AIError(ErrorCode.PAGE_LIMIT_INVALID)
+        scope = (
+            None
+            if session_id is None or parent_execution_id is not None
+            else self._scope("execution", "session", session_id)
+        )
+        parent = (
+            None
+            if parent_execution_id is None
+            else self._parent("execution", "execution", parent_execution_id)
+        )
+        records = await self._records(
+            "execution",
+            scope=scope,
+            parent=parent,
+            cursor=cursor,
+            limit=limit,
+        )
+        selected = records[:limit]
+        candidates: list[ExecutionCandidate] = []
+        for record in selected:
+            candidates.append(
+                ExecutionCandidate(
+                    await self._decode(record, ExecutionRecord),
+                    _record_cursor(record),
+                )
+            )
+        has_more = False
+        if len(records) == limit:
+            has_more = await self._has_records(
+                "execution",
+                scope=scope,
+                parent=parent,
+                cursor=_record_cursor(records[-1]),
+            )
+        return ExecutionCandidatePage(
+            tuple(candidates),
+            has_more,
         )
 
     async def get_in_transaction(

--- a/linktools-ai/src/linktools/ai/runtime/state/_root.py
+++ b/linktools-ai/src/linktools/ai/runtime/state/_root.py
@@ -25,6 +25,7 @@ from ._plan import (
     RuntimeRetentionMode,
     RuntimeStatePlan,
     RuntimeStateRoute,
+    runtime_domain_uses_object_store,
 )
 
 if TYPE_CHECKING:
@@ -356,16 +357,8 @@ def _validate_state_configuration(
 ) -> None:
     if not isinstance(plan, RuntimeStatePlan):
         raise TypeError("plan must be a RuntimeStatePlan")
-    object_domains = {
-        RuntimeDomain.CONVERSATION,
-        RuntimeDomain.EXECUTION,
-        RuntimeDomain.MEMORY,
-        RuntimeDomain.ARTIFACT,
-        RuntimeDomain.RECOVERY,
-        RuntimeDomain.TASK,
-    }
     if object_store is not None and not any(
-        domain in object_domains
+        runtime_domain_uses_object_store(domain)
         and plan.route(domain).retention is RuntimeRetentionMode.DURABLE
         for domain in RuntimeDomain
     ):

--- a/linktools-ai/src/linktools/ai/spec/__init__.py
+++ b/linktools-ai/src/linktools/ai/spec/__init__.py
@@ -20,6 +20,7 @@ from ._contract import (
     ThinkingValue,
     canonical_selectors,
     normalize_thinking,
+    parse_mcp_tool_selector,
 )
 
 __all__ = [
@@ -38,4 +39,5 @@ __all__ = [
     "ThinkingValue",
     "canonical_selectors",
     "normalize_thinking",
+    "parse_mcp_tool_selector",
 ]

--- a/linktools-ai/src/linktools/ai/spec/_contract.py
+++ b/linktools-ai/src/linktools/ai/spec/_contract.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 """Immutable declaration contracts for Agent, Skill, and MCP specifications."""
 
+import re
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Literal
@@ -12,6 +13,35 @@ from ..core import (
     normalize_thinking,
 )
 from ..errors import AIError, ErrorCode
+
+_MCP_NAMESPACE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
+def parse_mcp_tool_selector(selector: str) -> "tuple[str, str | None] | None":
+    """Parse one MCP selector into its namespace and optional exact tool."""
+    if not isinstance(selector, str) or not selector.startswith("mcp__"):
+        return None
+    parts = selector[5:].split("__")
+    if len(parts) == 1:
+        namespace = parts[0]
+        tool = None
+    elif len(parts) == 2:
+        namespace, tool = parts
+        if not tool or tool == "*":
+            if tool != "*":
+                raise AIError(ErrorCode.CAPABILITY_RESOLUTION_INVALID)
+            tool = None
+    else:
+        raise AIError(ErrorCode.CAPABILITY_RESOLUTION_INVALID)
+    if not namespace or _MCP_NAMESPACE.fullmatch(namespace) is None:
+        raise AIError(ErrorCode.CAPABILITY_RESOLUTION_INVALID)
+    if tool is not None and (
+        not tool
+        or tool != tool.strip()
+        or "*" in tool
+    ):
+        raise AIError(ErrorCode.CAPABILITY_RESOLUTION_INVALID)
+    return namespace, tool
 
 
 def canonical_selectors(
@@ -31,30 +61,31 @@ def canonical_selectors(
         if not mcp and "*" in raw:
             raise AIError(ErrorCode.CAPABILITY_RESOLUTION_INVALID, f"{field_name} contains an invalid selector")
         selector = raw
-        if mcp and raw.startswith("mcp__"):
-            parts = raw.split("__")
-            if len(parts) == 2 and parts[1]:
-                selector = f"{raw}__*"
-            elif len(parts) != 3 or not parts[1] or not parts[2]:
-                raise AIError(ErrorCode.CAPABILITY_RESOLUTION_INVALID, f"{field_name} contains an invalid MCP selector")
-            elif "*" in parts[2] and parts[2] != "*":
-                raise AIError(ErrorCode.CAPABILITY_RESOLUTION_INVALID, f"{field_name} contains an invalid MCP selector")
+        parsed = parse_mcp_tool_selector(raw) if mcp else None
+        if parsed is not None:
+            namespace, tool = parsed
+            selector = (
+                f"mcp__{namespace}__*"
+                if tool is None
+                else f"mcp__{namespace}__{tool}"
+            )
         elif "*" in raw:
             raise AIError(ErrorCode.CAPABILITY_RESOLUTION_INVALID, f"{field_name} contains an invalid selector")
         selectors.add(selector)
     if mcp:
         wildcard_servers = {
-            selector.removesuffix("__*")
+            parsed[0]
             for selector in selectors
-            if selector.startswith("mcp__") and selector.endswith("__*")
+            if (parsed := parse_mcp_tool_selector(selector)) is not None
+            and parsed[1] is None
         }
         selectors = {
             selector
             for selector in selectors
-            if not (
-                selector.startswith("mcp__")
-                and any(selector.startswith(f"{server}__") for server in wildcard_servers)
-                and selector not in {f"{server}__*" for server in wildcard_servers}
+            if (
+                (parsed := parse_mcp_tool_selector(selector)) is None
+                or parsed[0] not in wildcard_servers
+                or parsed[1] is None
             )
         }
     return tuple(sorted(selectors))
@@ -247,4 +278,5 @@ __all__ = [
     "ThinkingValue",
     "canonical_selectors",
     "normalize_thinking",
+    "parse_mcp_tool_selector",
 ]

--- a/linktools-ai/src/linktools/ai/workspace/_root.py
+++ b/linktools-ai/src/linktools/ai/workspace/_root.py
@@ -45,12 +45,9 @@ _PERMISSION_DECISION_RANK: Mapping[PermissionDecision, int] = {
 }
 _TOOL_PERMISSION_CLASSES = frozenset(
     {
-        "control",
         "filesystem.read",
         "filesystem.write",
         "shell",
-        "memory.read",
-        "memory.write",
     }
 )
 

--- a/tests/ai/_runtime_test_helpers.py
+++ b/tests/ai/_runtime_test_helpers.py
@@ -2,6 +2,13 @@
 # -*- coding: utf-8 -*-
 """Shared v1 execution-owner fields for persistence fixtures."""
 
+from collections.abc import Callable
+from typing import Any
+
+from pydantic_ai import Tool
+
+from linktools.ai.capability import tool_semantic_metadata
+from linktools.ai.runtime._tool_boundary import ManagedToolDescriptor
 from linktools.ai.runtime.state._contracts import StoredUserInput
 from linktools.ai.storage import StoredPayload
 
@@ -15,3 +22,19 @@ def execution_owner_fields(prompt: str = "prompt") -> dict[str, object]:
             StoredPayload.inline_text(prompt),
         ),
     }
+
+
+def semantic_tool(
+    function: Callable[..., Any],
+    descriptor: ManagedToolDescriptor,
+) -> Tool[Any]:
+    """Build a test leaf with the metadata required by the final boundary."""
+    path_fields = list(descriptor.workspace_path_fields) or None
+    return Tool(
+        function,
+        metadata=tool_semantic_metadata(
+            effect=descriptor.effect,
+            tool_class=descriptor.tool_class,
+            path_fields=path_fields,
+        ),
+    )

--- a/tests/ai/fixtures/agent_binding_subagent_v1_golden.json
+++ b/tests/ai/fixtures/agent_binding_subagent_v1_golden.json
@@ -18,6 +18,7 @@
   "base_model": {
     "model_identity": "openai:gpt-test",
     "provider": "openai",
+    "vision": false,
     "settings": {}
   },
   "selected": [],

--- a/tests/ai/fixtures/persistence/workspace_tool_semantics_v1.json
+++ b/tests/ai/fixtures/persistence/workspace_tool_semantics_v1.json
@@ -1,79 +1,79 @@
 {
   "attach_files": {
     "description": "<summary>Attach Workspace files to the next model request.</summary>\n<returns>\n<description>Lightweight file metadata plus the file content for the next model request.</description>\n</returns>",
-    "metadata": {"linktools.ai.workspace_tool_class": "filesystem.read", "linktools.ai.workspace_path_fields": ["paths"]},
+    "metadata": {"linktools.ai.effect": "none", "linktools.ai.plan_safe": true, "linktools.ai.tool_class": "filesystem.read", "linktools.ai.path_fields": ["paths"]},
     "parameters": {"additionalProperties": false, "properties": {"paths": {"description": "File paths relative to the root directory.", "items": {"type": "string"}, "type": "array"}}, "required": ["paths"], "type": "object"},
     "return_schema": {}, "strict": null, "version": 1
   },
   "check_command": {
     "description": "<summary>Check the status and recent output of a background command.</summary>\n<returns>\n<description>Status and recent output of the background command.</description>\n</returns>",
-    "metadata": {"linktools.ai.workspace_tool_class": "shell"},
+    "metadata": {"linktools.ai.effect": "none", "linktools.ai.plan_safe": true, "linktools.ai.tool_class": "shell"},
     "parameters": {"additionalProperties": false, "properties": {"command_id": {"description": "The ID returned by start_command.", "type": "string"}}, "required": ["command_id"], "type": "object"},
     "return_schema": {"type": "string"}, "strict": null, "version": 1
   },
   "create_directory": {
     "description": "<summary>Create a directory and any missing parents.</summary>\n<returns>\n<description>Confirmation message.</description>\n</returns>",
-    "metadata": {"linktools.ai.workspace_tool_class": "filesystem.write", "linktools.ai.workspace_path_fields": ["path"]},
+    "metadata": {"linktools.ai.effect": "non_replay_safe", "linktools.ai.tool_class": "filesystem.write", "linktools.ai.path_fields": ["path"]},
     "parameters": {"additionalProperties": false, "properties": {"path": {"description": "Directory path relative to the root directory.", "type": "string"}}, "required": ["path"], "type": "object"},
     "return_schema": {"type": "string"}, "strict": null, "version": 1
   },
   "edit_file": {
     "description": "<summary>Edit a file by exact string replacement with conflict detection.\n\nThe old_text must appear exactly once in the file. Include surrounding\ncontext lines to ensure uniqueness.</summary>\n<returns>\n<description>Summary with new hash for subsequent operations.</description>\n</returns>",
-    "metadata": {"linktools.ai.workspace_tool_class": "filesystem.write", "linktools.ai.workspace_path_fields": ["path"]},
+    "metadata": {"linktools.ai.effect": "non_replay_safe", "linktools.ai.tool_class": "filesystem.write", "linktools.ai.path_fields": ["path"]},
     "parameters": {"additionalProperties": false, "properties": {"expected_hash": {"anyOf": [{"type": "string"}, {"type": "null"}], "default": null, "description": "If provided, rejects the edit when the file's\ncurrent hash doesn't match (optimistic concurrency)."}, "new_text": {"description": "The replacement text.", "type": "string"}, "old_text": {"description": "The exact text to find (must appear exactly once).", "type": "string"}, "path": {"description": "File path relative to the root directory.", "type": "string"}}, "required": ["path", "old_text", "new_text"], "type": "object"},
     "return_schema": {"type": "string"}, "strict": null, "version": 1
   },
   "file_info": {
     "description": "<summary>Get metadata about a file or directory.</summary>\n<returns>\n<description>Formatted metadata including size, type, and permissions.</description>\n</returns>",
-    "metadata": {"linktools.ai.workspace_tool_class": "filesystem.read", "linktools.ai.workspace_path_fields": ["path"]},
+    "metadata": {"linktools.ai.effect": "none", "linktools.ai.plan_safe": true, "linktools.ai.tool_class": "filesystem.read", "linktools.ai.path_fields": ["path"]},
     "parameters": {"additionalProperties": false, "properties": {"path": {"description": "File or directory path relative to the root directory.", "type": "string"}}, "required": ["path"], "type": "object"},
     "return_schema": {"type": "string"}, "strict": null, "version": 1
   },
   "find_files": {
     "description": "<summary>Find files by glob pattern (name matching, not content search).</summary>\n<returns>\n<description>Newline-separated list of matching file paths relative to root.</description>\n</returns>",
-    "metadata": {"linktools.ai.workspace_tool_class": "filesystem.read", "linktools.ai.workspace_path_fields": ["path"]},
+    "metadata": {"linktools.ai.effect": "none", "linktools.ai.plan_safe": true, "linktools.ai.tool_class": "filesystem.read", "linktools.ai.path_fields": ["path"]},
     "parameters": {"additionalProperties": false, "properties": {"path": {"default": ".", "description": "Directory to search in, relative to the root directory.", "type": "string"}, "pattern": {"description": "Glob pattern to match, relative to `path` (e.g. '*.py',\n'**/*.json'). Absolute patterns are rejected.", "type": "string"}}, "required": ["pattern"], "type": "object"},
     "return_schema": {"type": "string"}, "strict": null, "version": 1
   },
   "list_directory": {
     "description": "<summary>List the contents of a directory.</summary>\n<returns>\n<description>A newline-separated listing with type indicators and sizes.</description>\n</returns>",
-    "metadata": {"linktools.ai.workspace_tool_class": "filesystem.read", "linktools.ai.workspace_path_fields": ["path"]},
+    "metadata": {"linktools.ai.effect": "none", "linktools.ai.plan_safe": true, "linktools.ai.tool_class": "filesystem.read", "linktools.ai.path_fields": ["path"]},
     "parameters": {"additionalProperties": false, "properties": {"path": {"default": ".", "description": "Directory path relative to the root directory.", "type": "string"}}, "type": "object"},
     "return_schema": {"type": "string"}, "strict": null, "version": 1
   },
   "read_file": {
     "description": "<summary>Read a text file with line numbers.</summary>\n<returns>\n<description>File content with line numbers, plus metadata header.</description>\n</returns>",
-    "metadata": {"linktools.ai.workspace_tool_class": "filesystem.read", "linktools.ai.workspace_path_fields": ["path"]},
+    "metadata": {"linktools.ai.effect": "none", "linktools.ai.plan_safe": true, "linktools.ai.tool_class": "filesystem.read", "linktools.ai.path_fields": ["path"], "linktools.ai.context_dedupe": "workspace_file_read_v1"},
     "parameters": {"additionalProperties": false, "properties": {"limit": {"anyOf": [{"type": "integer"}, {"type": "null"}], "default": null, "description": "Maximum number of lines to return (default: 2000)."}, "offset": {"default": 0, "description": "Zero-based line offset to start reading from.", "type": "integer"}, "path": {"description": "File path relative to the root directory.", "type": "string"}}, "required": ["path"], "type": "object"},
     "return_schema": {"type": "string"}, "strict": null, "version": 1
   },
   "run_command": {
     "description": "<summary>Execute a shell command and return its output.</summary>\n<returns>\n<description>Labeled stdout/stderr output with exit code on non-zero exit.</description>\n</returns>",
-    "metadata": {"linktools.ai.workspace_tool_class": "shell"},
+    "metadata": {"linktools.ai.effect": "non_replay_safe", "linktools.ai.tool_class": "shell"},
     "parameters": {"additionalProperties": false, "properties": {"command": {"description": "The shell command to run.", "type": "string"}, "timeout_seconds": {"anyOf": [{"type": "number"}, {"type": "null"}], "default": null, "description": "Maximum seconds to wait (default: 30)."}}, "required": ["command"], "type": "object"},
     "return_schema": {"type": "string"}, "strict": null, "version": 1
   },
   "search_files": {
     "description": "<summary>Search file contents using a regular expression.</summary>\n<returns>\n<type>str</type>\n<description>Matching lines formatted as file:line_number:text.</description>\n</returns>",
-    "metadata": {"linktools.ai.workspace_tool_class": "filesystem.read", "linktools.ai.workspace_path_fields": ["path"]},
+    "metadata": {"linktools.ai.effect": "none", "linktools.ai.plan_safe": true, "linktools.ai.tool_class": "filesystem.read", "linktools.ai.path_fields": ["path"]},
     "parameters": {"additionalProperties": false, "properties": {"include_glob": {"anyOf": [{"type": "string"}, {"type": "null"}], "default": null, "description": "If provided, only search files matching this glob (e.g. '*.py')."}, "path": {"default": ".", "description": "Directory to search in, relative to the root directory.", "type": "string"}, "pattern": {"description": "Regex pattern to search for.", "type": "string"}}, "required": ["pattern"], "type": "object"},
     "return_schema": {"type": "string"}, "strict": null, "version": 1
   },
   "start_command": {
     "description": "<summary>Start a long-running command in the background (e.g. a server or watcher).\n\nCallers MUST call `stop_command(command_id)` when done to terminate the\nprocess and clean up temporary output files.</summary>\n<returns>\n<description>A message containing the unique command ID for later check/stop calls.</description>\n</returns>",
-    "metadata": {"linktools.ai.workspace_tool_class": "shell"},
+    "metadata": {"linktools.ai.effect": "non_replay_safe", "linktools.ai.tool_class": "shell"},
     "parameters": {"additionalProperties": false, "properties": {"command": {"description": "The shell command to run in the background.", "type": "string"}}, "required": ["command"], "type": "object"},
     "return_schema": {"type": "string"}, "strict": null, "version": 1
   },
   "stop_command": {
     "description": "<summary>Stop a background command and return its final output.</summary>\n<returns>\n<description>Final output and exit status of the stopped command.</description>\n</returns>",
-    "metadata": {"linktools.ai.workspace_tool_class": "shell"},
+    "metadata": {"linktools.ai.effect": "non_replay_safe", "linktools.ai.tool_class": "shell"},
     "parameters": {"additionalProperties": false, "properties": {"command_id": {"description": "The ID returned by start_command.", "type": "string"}}, "required": ["command_id"], "type": "object"},
     "return_schema": {"type": "string"}, "strict": null, "version": 1
   },
   "write_file": {
     "description": "<summary>Create or overwrite a file with conflict detection.</summary>\n<returns>\n<description>Confirmation message with new hash.</description>\n</returns>",
-    "metadata": {"linktools.ai.workspace_tool_class": "filesystem.write", "linktools.ai.workspace_path_fields": ["path"]},
+    "metadata": {"linktools.ai.effect": "non_replay_safe", "linktools.ai.tool_class": "filesystem.write", "linktools.ai.path_fields": ["path"]},
     "parameters": {"additionalProperties": false, "properties": {"content": {"description": "The text content to write.", "type": "string"}, "expected_hash": {"anyOf": [{"type": "string"}, {"type": "null"}], "default": null, "description": "If provided, the write is rejected when the file exists\nand its current hash doesn't match (optimistic concurrency)."}, "path": {"description": "File path relative to the root directory.", "type": "string"}}, "required": ["path", "content"], "type": "object"},
     "return_schema": {"type": "string"}, "strict": null, "version": 1
   }

--- a/tests/ai/test_attach_files_tool.py
+++ b/tests/ai/test_attach_files_tool.py
@@ -90,7 +90,7 @@ async def _boundary(
                 effect_owner="none",
                 effect="none",
                 tool_class="filesystem.read",
-                workspace_path_fields=("path",),
+                workspace_path_fields=("paths",),
             )
         },
         id="workspace-boundary",
@@ -109,8 +109,10 @@ def test_attach_files_declares_multi_path_workspace_metadata(tmp_path: Path) -> 
     tool = next(item.value for item in contributions if item.id == "attach_files")
 
     assert tool.tool_def.metadata == {  # type: ignore[attr-defined]
-        "linktools.ai.workspace_tool_class": "filesystem.read",
-        "linktools.ai.workspace_path_fields": ["paths"],
+        "linktools.ai.effect": "none",
+        "linktools.ai.plan_safe": True,
+        "linktools.ai.tool_class": "filesystem.read",
+        "linktools.ai.path_fields": ["paths"],
     }
 
 

--- a/tests/ai/test_closure_fix.py
+++ b/tests/ai/test_closure_fix.py
@@ -43,6 +43,7 @@ from pydantic_ai.models.test import TestModel
 from pydantic_ai.toolsets import FunctionToolset
 from pydantic_ai.tools import RunContext, ToolDefinition
 from pydantic_ai.usage import RunUsage
+from ._runtime_test_helpers import semantic_tool
 
 
 class _StepStore:
@@ -253,14 +254,15 @@ async def test_replay_safe_model_retry_is_a_known_failure() -> None:
     async def retry_tool() -> None:
         raise ModelRetry("retry")
 
+    descriptor = ManagedToolDescriptor(
+        effect_owner="tool_operation",
+        effect="replay_safe",
+        tool_class="business",
+    )
     boundary = RuntimeToolBoundaryToolset(
-        (FunctionToolset([retry_tool]),),
+        (FunctionToolset([semantic_tool(retry_tool, descriptor)]),),
         {
-            "retry_tool": ManagedToolDescriptor(
-                effect_owner="tool_operation",
-                effect="replay_safe",
-                tool_class="business",
-            )
+            "retry_tool": descriptor
         },
         id="business",
         tool_operations=bridge,  # type: ignore[arg-type]
@@ -284,14 +286,15 @@ async def test_non_replay_safe_model_retry_requires_effect_verification() -> Non
     async def retry_tool() -> None:
         raise ModelRetry("retry")
 
+    descriptor = ManagedToolDescriptor(
+        effect_owner="tool_operation",
+        effect="non_replay_safe",
+        tool_class="business",
+    )
     boundary = RuntimeToolBoundaryToolset(
-        (FunctionToolset([retry_tool]),),
+        (FunctionToolset([semantic_tool(retry_tool, descriptor)]),),
         {
-            "retry_tool": ManagedToolDescriptor(
-                effect_owner="tool_operation",
-                effect="non_replay_safe",
-                tool_class="business",
-            )
+            "retry_tool": descriptor
         },
         id="business",
         tool_operations=bridge,  # type: ignore[arg-type]

--- a/tests/ai/test_compaction_harness_observability.py
+++ b/tests/ai/test_compaction_harness_observability.py
@@ -5,7 +5,10 @@
 from collections.abc import Sequence
 
 import pytest
-from linktools.ai.runtime._compaction import RuntimeCompaction
+from linktools.ai.runtime._compaction import (
+    RuntimeCompaction,
+    RuntimeCompactionPolicy,
+)
 from linktools.ai.runtime._journal import ModelRequestFact, ModelRequestJournal
 from pydantic_ai.messages import (
     ModelMessage,
@@ -157,12 +160,12 @@ def test_journal_rejects_double_finish() -> None:
     journal.consume(fact.request_sequence)
 
 
-def _duplicate_read_history() -> list[ModelMessage]:
+def _duplicate_file_history() -> list[ModelMessage]:
     return [
         ModelResponse(
             parts=[
                 ToolCallPart(
-                    "read_file",
+                    "inspect_document",
                     {"path": "same.txt"},
                     tool_call_id="read-1",
                 )
@@ -171,7 +174,7 @@ def _duplicate_read_history() -> list[ModelMessage]:
         ModelRequest(
             parts=[
                 ToolReturnPart(
-                    "read_file",
+                    "inspect_document",
                     "old content",
                     tool_call_id="read-1",
                 )
@@ -180,7 +183,7 @@ def _duplicate_read_history() -> list[ModelMessage]:
         ModelResponse(
             parts=[
                 ToolCallPart(
-                    "read_file",
+                    "inspect_document",
                     {"path": "same.txt"},
                     tool_call_id="read-2",
                 )
@@ -189,7 +192,7 @@ def _duplicate_read_history() -> list[ModelMessage]:
         ModelRequest(
             parts=[
                 ToolReturnPart(
-                    "read_file",
+                    "inspect_document",
                     "new content",
                     tool_call_id="read-2",
                 )
@@ -207,7 +210,7 @@ async def test_compaction_target_does_not_rewrite_history_below_threshold() -> N
         usage=RunUsage(),
         run_id="run",
     )
-    messages = _duplicate_read_history()
+    messages = _duplicate_file_history()
     request_context = ModelRequestContext(
         model=model,
         messages=list(messages),
@@ -218,7 +221,11 @@ async def test_compaction_target_does_not_rewrite_history_below_threshold() -> N
     provider_context = await _provider_context(
         RuntimeCompaction(
             1_000_000,
-            workspace_read_available=True,
+            policy=RuntimeCompactionPolicy(
+                context_dedupe_by_tool={
+                    "inspect_document": "workspace_file_read_v1",
+                },
+            ),
         ),
         ctx,  # type: ignore[arg-type]
         request_context,
@@ -237,7 +244,7 @@ async def test_compaction_without_target_still_deduplicates_file_reads() -> None
         usage=RunUsage(),
         run_id="run",
     )
-    messages = _duplicate_read_history()
+    messages = _duplicate_file_history()
     request_context = ModelRequestContext(
         model=model,
         messages=list(messages),
@@ -248,7 +255,11 @@ async def test_compaction_without_target_still_deduplicates_file_reads() -> None
     provider_context = await _provider_context(
         RuntimeCompaction(
             None,
-            workspace_read_available=True,
+            policy=RuntimeCompactionPolicy(
+                context_dedupe_by_tool={
+                    "inspect_document": "workspace_file_read_v1",
+                },
+            ),
         ),
         ctx,  # type: ignore[arg-type]
         request_context,
@@ -257,3 +268,66 @@ async def test_compaction_without_target_still_deduplicates_file_reads() -> None
     assert provider_context.messages != messages
     assert "[superseded file read]" in str(provider_context.messages)
     assert request_context.messages == messages
+
+
+@pytest.mark.asyncio
+async def test_compaction_keeps_semantic_control_results() -> None:
+    model = TestModel()
+    ctx = RunContext(
+        deps=None,
+        model=model,
+        usage=RunUsage(),
+        run_id="run",
+    )
+    messages: list[ModelMessage] = []
+    for index in range(5):
+        name = "hidden_control" if index == 0 else "ordinary"
+        call_id = f"call-{index}"
+        messages.extend(
+            (
+                ModelResponse(
+                    parts=[
+                        ToolCallPart(
+                            name,
+                            {"value": index},
+                            tool_call_id=call_id,
+                        )
+                    ]
+                ),
+                ModelRequest(
+                    parts=[
+                        ToolReturnPart(
+                            name,
+                            f"result-{index}",
+                            tool_call_id=call_id,
+                        )
+                    ]
+                ),
+            )
+        )
+    request_context = ModelRequestContext(
+        model=model,
+        messages=messages,
+        model_settings=None,
+        model_request_parameters=ModelRequestParameters(),
+    )
+    provider_context = await _provider_context(
+        RuntimeCompaction(
+            1,
+            policy=RuntimeCompactionPolicy(
+                keep_result_tools=frozenset({"hidden_control"}),
+            ),
+        ),
+        ctx,  # type: ignore[arg-type]
+        request_context,
+    )
+
+    returns = [
+        part
+        for message in provider_context.messages
+        if isinstance(message, ModelRequest)
+        for part in message.parts
+        if isinstance(part, ToolReturnPart)
+    ]
+    assert returns[0].content == "result-0"
+    assert returns[1].content == "[tool result cleared]"

--- a/tests/ai/test_deferred_frontier_contract.py
+++ b/tests/ai/test_deferred_frontier_contract.py
@@ -22,6 +22,7 @@ from pydantic_ai.models.test import TestModel
 from pydantic_ai.toolsets import FunctionToolset
 from pydantic_ai.tools import DeferredToolRequests, RunContext
 from pydantic_ai.usage import RunUsage
+from ._runtime_test_helpers import semantic_tool
 
 
 class _Bridge:
@@ -132,14 +133,15 @@ async def test_ask_boundary_defers_before_runtime_operation() -> None:
     async def read_file(path: str) -> str:
         return path
 
+    descriptor = ManagedToolDescriptor(
+        effect_owner="none",
+        effect="none",
+        tool_class="filesystem.read",
+    )
     boundary = RuntimeToolBoundaryToolset(
-        (FunctionToolset([read_file]),),
+        (FunctionToolset([semantic_tool(read_file, descriptor)]),),
         {
-            "read_file": ManagedToolDescriptor(
-                effect_owner="none",
-                effect="none",
-                tool_class="filesystem.read",
-            )
+            "read_file": descriptor
         },
         id="workspace",
         workspace_policy=WorkspaceToolPermissionPolicy(

--- a/tests/ai/test_deferred_native_conformance.py
+++ b/tests/ai/test_deferred_native_conformance.py
@@ -27,6 +27,7 @@ from linktools.ai.runtime._tool_boundary import (
 from linktools.ai.workspace import (
     WorkspaceToolPermissionPolicy,
 )
+from ._runtime_test_helpers import semantic_tool
 
 
 class _Bridge:
@@ -78,14 +79,15 @@ async def test_approval_frontier_is_persisted_as_interrupted(tmp_path: Path) -> 
     bridge = _Bridge()
     captured: list[int] = []
     del tmp_path
+    descriptor = ManagedToolDescriptor(
+        effect_owner="tool_operation",
+        effect="non_replay_safe",
+        tool_class="filesystem.read",
+    )
     boundary = RuntimeToolBoundaryToolset(
-        (FunctionToolset([_read_file]),),
+        (FunctionToolset([semantic_tool(_read_file, descriptor)]),),
         {
-            "_read_file": ManagedToolDescriptor(
-                effect_owner="tool_operation",
-                effect="non_replay_safe",
-                tool_class="filesystem.read",
-            )
+            "_read_file": descriptor
         },
         id="workspace",
             workspace_policy=WorkspaceToolPermissionPolicy(default="ask"),

--- a/tests/ai/test_error_review_regressions.py
+++ b/tests/ai/test_error_review_regressions.py
@@ -15,7 +15,7 @@ from linktools.ai.core import ExecutionLineageKind, ExecutionStatus, OperationSt
 from linktools.ai.errors import ErrorCode
 from linktools.ai.runtime._agent_executor import AgentExecutor
 from linktools.ai.runtime._capabilities import compose_platform_capabilities
-from linktools.ai.runtime._compaction import RuntimeCompaction
+from linktools.ai.runtime._compaction import RuntimeCompaction, RuntimeCompactionPolicy
 from linktools.ai.runtime._execution import (
     CancelEffectOutcome,
     DefaultExecutionService,
@@ -63,7 +63,9 @@ async def test_default_platform_composition_keeps_file_read_deduplication() -> N
         memory_scope=None,
         step_store=StagingStepStore(),
         memory_store=None,
-        runtime_tool_names=(),
+        ordinary_tool_policy=(),
+        compaction_policy=RuntimeCompactionPolicy(),
+        planning=False,
         context_target_tokens=None,
         parent_step_run_id=None,
         plan_store_resolver=None,

--- a/tests/ai/test_file_input_regressions.py
+++ b/tests/ai/test_file_input_regressions.py
@@ -82,7 +82,7 @@ async def test_text_materialization_keeps_text_codec() -> None:
     access = WorkspaceAccess(_Sandbox(_Session({})), root=Path("."))
     materializer = ExecutionInputMaterializer(
         access,
-        Workspace.load(".").policy,
+        Workspace.load(".", workspace_id="workspace").policy,
     )
     try:
         canonical = await materializer.materialize("plain text", ())
@@ -115,7 +115,7 @@ async def test_execution_freezes_materialized_input_once() -> None:
     access = WorkspaceAccess(_Sandbox(session), root=Path("."))
     materializer = ExecutionInputMaterializer(
         access,
-        Workspace.load(".").policy,
+        Workspace.load(".", workspace_id="workspace").policy,
     )
     service = object.__new__(DefaultExecutionService)
     service._input_materializer = materializer  # type: ignore[attr-defined]

--- a/tests/ai/test_file_input_regressions.py
+++ b/tests/ai/test_file_input_regressions.py
@@ -22,6 +22,7 @@ from linktools.ai.runtime._tool_boundary import (
 )
 from linktools.ai.storage import StoredPayload
 from linktools.ai.workspace import SandboxResource, SandboxSession, Workspace
+from ._runtime_test_helpers import semantic_tool
 
 
 class _Session:
@@ -81,7 +82,7 @@ async def test_text_materialization_keeps_text_codec() -> None:
     access = WorkspaceAccess(_Sandbox(_Session({})), root=Path("."))
     materializer = ExecutionInputMaterializer(
         access,
-        Workspace.load(".", workspace_id="workspace").policy,
+        Workspace.load(".").policy,
     )
     try:
         canonical = await materializer.materialize("plain text", ())
@@ -114,7 +115,7 @@ async def test_execution_freezes_materialized_input_once() -> None:
     access = WorkspaceAccess(_Sandbox(session), root=Path("."))
     materializer = ExecutionInputMaterializer(
         access,
-        Workspace.load(".", workspace_id="workspace").policy,
+        Workspace.load(".").policy,
     )
     service = object.__new__(DefaultExecutionService)
     service._input_materializer = materializer  # type: ignore[attr-defined]
@@ -153,16 +154,15 @@ def _context() -> RunContext[None]:
 @pytest.mark.asyncio
 async def test_final_tool_boundary_canonicalizes_workspace_arguments() -> None:
     session = _Session({})
+    descriptor = ManagedToolDescriptor(
+        effect_owner="none",
+        effect="none",
+        tool_class="filesystem.read",
+        workspace_path_fields=("path",),
+    )
     boundary = RuntimeToolBoundaryToolset(
-        (FunctionToolset([_echo_path]),),
-        {
-            "_echo_path": ManagedToolDescriptor(
-                effect_owner="none",
-                effect="none",
-                tool_class="filesystem.read",
-                workspace_path_fields=("path",),
-            )
-        },
+        (FunctionToolset([semantic_tool(_echo_path, descriptor)]),),
+        {"_echo_path": descriptor},
         id="workspace",
         sandbox_session=session,  # type: ignore[arg-type]
     )
@@ -183,16 +183,15 @@ async def test_final_tool_boundary_canonicalizes_workspace_arguments() -> None:
 
 @pytest.mark.asyncio
 async def test_final_tool_boundary_does_not_freeze_transient_sandbox_failure() -> None:
+    descriptor = ManagedToolDescriptor(
+        effect_owner="none",
+        effect="none",
+        tool_class="filesystem.read",
+        workspace_path_fields=("path",),
+    )
     boundary = RuntimeToolBoundaryToolset(
-        (FunctionToolset([_echo_path]),),
-        {
-            "_echo_path": ManagedToolDescriptor(
-                effect_owner="none",
-                effect="none",
-                tool_class="filesystem.read",
-                workspace_path_fields=("path",),
-            )
-        },
+        (FunctionToolset([semantic_tool(_echo_path, descriptor)]),),
+        {"_echo_path": descriptor},
         id="workspace",
         sandbox_session=_UnavailableAccess(),  # type: ignore[arg-type]
     )

--- a/tests/ai/test_metrics.py
+++ b/tests/ai/test_metrics.py
@@ -467,6 +467,17 @@ def test_metric_codec_rejects_invalid_persisted_types() -> None:
 
 def test_complete_sql_schema_includes_metrics_tables() -> None:
     metadata = build_sql_schema_metadata()
-    assert len(metadata.tables) == 12
-    assert "ai_metric_definitions" in metadata.tables
-    assert "ai_metric_observations" in metadata.tables
+    assert {
+        "ai_asset_changes",
+        "ai_asset_entries",
+        "ai_asset_heads",
+        "ai_metric_definitions",
+        "ai_metric_observations",
+        "ai_object_chunks",
+        "ai_objects",
+        "ai_state_aliases",
+        "ai_state_facts",
+        "ai_state_operations",
+        "ai_state_records",
+        "ai_state_sequences",
+    }.issubset(metadata.tables)

--- a/tests/ai/test_model_route_settings.py
+++ b/tests/ai/test_model_route_settings.py
@@ -6,10 +6,38 @@ from typing import Any
 
 import pytest
 from linktools.ai.errors import AIError, ErrorCode
-from linktools.ai.model import ModelRegistry
+from linktools.ai.model import LinkToolsUploadedFile, ModelRegistry
 from linktools.ai.model._openai import _RetryingModel
+from pydantic_ai.messages import (
+    BinaryContent,
+    ImageUrl,
+    ModelMessage,
+    ModelRequest,
+    UserPromptPart,
+)
+from pydantic_ai.models import ModelRequestParameters, ModelResponse, ModelSettings
 from pydantic_ai.models.openai import OpenAIChatModel
+from pydantic_ai.models.test import TestModel
 from pydantic_ai.providers.openai import OpenAIProvider
+
+
+class _CountingModel(TestModel):
+    def __init__(self) -> None:
+        super().__init__()
+        self.calls = 0
+
+    async def request(
+        self,
+        messages: list[ModelMessage],
+        model_settings: ModelSettings | None,
+        model_request_parameters: ModelRequestParameters,
+    ) -> ModelResponse:
+        self.calls += 1
+        return await super().request(
+            messages,
+            model_settings,
+            model_request_parameters,
+        )
 
 
 def test_openai_operational_settings_do_not_change_durable_identity() -> None:
@@ -43,8 +71,151 @@ def test_openai_custom_endpoint_is_operational_configuration() -> None:
     assert dict(binding.semantic_payload) == {
         "provider": "openai",
         "model_identity": "openai:gpt-test",
+        "vision": False,
         "settings": {},
     }
+
+
+def test_openai_vision_is_durable_model_semantics() -> None:
+    without_vision = ModelRegistry.openai(
+        model="gpt-test",
+        vision=False,
+    ).snapshot().resolve("default")
+    with_vision = ModelRegistry.openai(
+        model="gpt-test",
+        vision=True,
+    ).snapshot().resolve("default")
+
+    assert dict(without_vision.semantic_payload)["vision"] is False
+    assert dict(with_vision.semantic_payload)["vision"] is True
+    assert without_vision.fingerprint != with_vision.fingerprint
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "content",
+    (
+        BinaryContent(b"image", media_type="image/png"),
+        ImageUrl("https://example.com/image"),
+        LinkToolsUploadedFile("file-image", "openai", media_type="image/png"),
+    ),
+)
+async def test_openai_without_vision_rejects_images_before_provider(
+    content: Any,
+) -> None:
+    wrapped = _CountingModel()
+    model = _RetryingModel(wrapped, 2, 0, vision=False)
+
+    with pytest.raises(AIError) as raised:
+        await model.request(
+            [ModelRequest(parts=[UserPromptPart([content])])],
+            None,
+            ModelRequestParameters(),
+        )
+
+    assert raised.value.code is ErrorCode.REQUEST_FIELD_INVALID
+    assert raised.value.retryable is False
+    assert raised.value.safe_details == {
+        "reason": "image_input_not_supported",
+    }
+    assert wrapped.calls == 0
+
+
+@pytest.mark.asyncio
+async def test_openai_without_vision_rejects_stream_images_before_provider() -> None:
+    wrapped = _CountingModel()
+    model = _RetryingModel(wrapped, 2, 0, vision=False)
+
+    with pytest.raises(AIError) as raised:
+        async with model.request_stream(
+            [
+                ModelRequest(
+                    parts=[
+                        UserPromptPart(
+                            [BinaryContent(b"image", media_type="image/png")]
+                        )
+                    ]
+                )
+            ],
+            None,
+            ModelRequestParameters(),
+        ):
+            raise AssertionError("vision guard should reject before stream entry")
+
+    assert raised.value.code is ErrorCode.REQUEST_FIELD_INVALID
+    assert raised.value.retryable is False
+    assert wrapped.calls == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("media_type", ("application/pdf", "text/plain"))
+async def test_openai_without_vision_allows_non_image_attachments(
+    media_type: str,
+) -> None:
+    wrapped = _CountingModel()
+    model = _RetryingModel(wrapped, 2, 0, vision=False)
+
+    await model.request(
+        [
+            ModelRequest(
+                parts=[
+                    UserPromptPart(
+                        [BinaryContent(b"document", media_type=media_type)]
+                    )
+                ]
+            )
+        ],
+        None,
+        ModelRequestParameters(),
+    )
+
+    assert wrapped.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_openai_vision_policy_is_independent_per_binding() -> None:
+    parent_provider = _CountingModel()
+    child_provider = _CountingModel()
+    parent_model = _RetryingModel(parent_provider, 2, 0, vision=False)
+    child_model = _RetryingModel(child_provider, 2, 0, vision=True)
+    messages = [
+        ModelRequest(
+            parts=[
+                UserPromptPart(
+                    [BinaryContent(b"image", media_type="image/png")]
+                )
+            ]
+        )
+    ]
+
+    with pytest.raises(AIError):
+        await parent_model.request(messages, None, ModelRequestParameters())
+    await child_model.request(messages, None, ModelRequestParameters())
+
+    assert parent_provider.calls == 0
+    assert child_provider.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_openai_without_vision_does_not_guess_uploaded_file_type() -> None:
+    wrapped = _CountingModel()
+    model = _RetryingModel(wrapped, 2, 0, vision=False)
+
+    await model.request(
+        [
+            ModelRequest(
+                parts=[
+                    UserPromptPart(
+                        [LinkToolsUploadedFile("report.png", "openai")]
+                    )
+                ]
+            )
+        ],
+        None,
+        ModelRequestParameters(),
+    )
+
+    assert wrapped.calls == 1
 
 
 def test_openai_max_tokens_changes_durable_identity() -> None:

--- a/tests/ai/test_model_route_settings.py
+++ b/tests/ai/test_model_route_settings.py
@@ -6,13 +6,14 @@ from typing import Any
 
 import pytest
 from linktools.ai.errors import AIError, ErrorCode
-from linktools.ai.model import LinkToolsUploadedFile, ModelRegistry
+from linktools.ai.model import ModelRegistry
 from linktools.ai.model._openai import _RetryingModel
 from pydantic_ai.messages import (
     BinaryContent,
     ImageUrl,
     ModelMessage,
     ModelRequest,
+    UploadedFile,
     UserPromptPart,
 )
 from pydantic_ai.models import ModelRequestParameters, ModelResponse, ModelSettings
@@ -97,7 +98,7 @@ def test_openai_vision_is_durable_model_semantics() -> None:
     (
         BinaryContent(b"image", media_type="image/png"),
         ImageUrl("https://example.com/image"),
-        LinkToolsUploadedFile("file-image", "openai", media_type="image/png"),
+        UploadedFile("report.png", "openai"),
     ),
 )
 async def test_openai_without_vision_rejects_images_before_provider(
@@ -197,20 +198,15 @@ async def test_openai_vision_policy_is_independent_per_binding() -> None:
 
 
 @pytest.mark.asyncio
-async def test_openai_without_vision_does_not_guess_uploaded_file_type() -> None:
+async def test_openai_without_vision_does_not_guess_opaque_uploaded_file_type() -> None:
     wrapped = _CountingModel()
     model = _RetryingModel(wrapped, 2, 0, vision=False)
 
+    uploaded = UploadedFile("file-image", "openai")
+    assert uploaded.media_type == "application/octet-stream"
+
     await model.request(
-        [
-            ModelRequest(
-                parts=[
-                    UserPromptPart(
-                        [LinkToolsUploadedFile("report.png", "openai")]
-                    )
-                ]
-            )
-        ],
+        [ModelRequest(parts=[UserPromptPart([uploaded])])],
         None,
         ModelRequestParameters(),
     )

--- a/tests/ai/test_observability_closure.py
+++ b/tests/ai/test_observability_closure.py
@@ -12,7 +12,12 @@ import pytest
 from linktools.ai.core import Page, TaskStatus
 from linktools.ai.errors import AIError, ErrorCode
 from linktools.ai.observe import Metrics, Observation
-from linktools.ai.runtime import Runtime
+from linktools.ai.runtime import (
+    ListExecutionRequest,
+    Runtime,
+    RuntimeMetricFlushResult,
+    RuntimeMetricStatus,
+)
 from linktools.ai.runtime._context import RuntimeContext
 from linktools.ai.runtime import _metrics as runtime_metrics
 from linktools.ai.runtime._execution import _overlay_execution_correlation
@@ -144,6 +149,12 @@ def test_runtime_correlation_overlay_is_explicit_and_bounded() -> None:
     }
 
 
+def test_runtime_public_contract_exports() -> None:
+    assert ListExecutionRequest is not None
+    assert RuntimeMetricStatus is not None
+    assert RuntimeMetricFlushResult is not None
+
+
 def test_retry_and_fork_correlation_inherit_source_then_overlay() -> None:
     source = {"audit_run_id": "audit-1", "stage": "collect"}
 
@@ -181,10 +192,12 @@ async def test_disabled_runtime_metric_control_has_stable_public_contract() -> N
     )
 
     status = runtime.metric_status()
+    assert isinstance(status, RuntimeMetricStatus)
     assert status.enabled is False
     assert status.accepting is False
     assert status.pending == 0
     flushed = await runtime.flush_metrics(timeout_seconds=0)
+    assert isinstance(flushed, RuntimeMetricFlushResult)
     assert flushed.completed is True
     assert flushed.status == status
     with pytest.raises(AIError) as raised:

--- a/tests/ai/test_planning_surface_regression.py
+++ b/tests/ai/test_planning_surface_regression.py
@@ -12,9 +12,10 @@ from linktools.ai.runtime._plan import (
     _validated_items,
 )
 from linktools.ai.runtime._capabilities import (
-    PLANNING_TOOL_NAMES,
     compose_platform_capabilities,
 )
+from linktools.ai.runtime._harness_planning import HarnessPlanning
+from linktools.ai.runtime._compaction import RuntimeCompactionPolicy
 from linktools.ai.runtime.state._steps import (
     StagingStepStore,
 )
@@ -42,15 +43,19 @@ async def test_linktools_planning_registers_only_write_plan() -> None:
         memory_scope=None,
         step_store=StagingStepStore(),
         memory_store=None,
-        runtime_tool_names=PLANNING_TOOL_NAMES,
+        ordinary_tool_policy=(),
+        compaction_policy=RuntimeCompactionPolicy(),
+        planning=True,
         context_target_tokens=None,
         parent_step_run_id=None,
         plan_store_resolver=lambda _ctx: None,  # type: ignore[return-value]
     )
     planning = next(
-        capability for capability in capabilities if isinstance(capability, Planning)
+        capability
+        for capability in capabilities
+        if isinstance(capability, HarnessPlanning)
     )
-    assert tuple(planning.get_toolset().tools) == PLANNING_TOOL_NAMES
+    assert tuple(planning.get_toolset().tools) == ("write_plan",)
 
 
 async def test_harness_planning_prompt_is_request_scoped_and_cache_safe() -> None:
@@ -58,7 +63,7 @@ async def test_harness_planning_prompt_is_request_scoped_and_cache_safe() -> Non
     await store.set_items([PlanItem(content="ship it", status=TaskStatus.in_progress)])
     capability = Planning(
         store=store,
-        tools=PLANNING_TOOL_NAMES,
+        tools=("write_plan",),
         id="linktools-planning",
     )
     context = RunContext(

--- a/tests/ai/test_repository_instruction_dynamic_scope.py
+++ b/tests/ai/test_repository_instruction_dynamic_scope.py
@@ -19,6 +19,7 @@ from linktools.ai.runtime._tool_boundary import (
 from linktools.ai.workspace import (
     WorkspaceToolPermissionPolicy,
 )
+from ._runtime_test_helpers import semantic_tool
 
 
 class _Session:
@@ -80,16 +81,19 @@ def _boundary(
     policy: WorkspaceToolPermissionPolicy | None = None,
     path_fields: tuple[str, ...] = ("path",),
 ) -> RuntimeToolBoundaryToolset:
+    descriptor = ManagedToolDescriptor(
+        effect_owner="none",
+        effect="none",
+        tool_class="filesystem.read",
+        workspace_path_fields=path_fields,
+    )
+    toolset.tools[name].metadata = semantic_tool(
+        toolset.tools[name].function,
+        descriptor,
+    ).metadata
     return RuntimeToolBoundaryToolset(
         (toolset,),
-        {
-            name: ManagedToolDescriptor(
-                effect_owner="none",
-                effect="none",
-                tool_class="filesystem.read",
-                workspace_path_fields=path_fields,
-            )
-        },
+        {name: descriptor},
         id="workspace",
         sandbox_session=_Session(),  # type: ignore[arg-type]
         workspace_policy=(

--- a/tests/ai/test_runtime_audit_regressions.py
+++ b/tests/ai/test_runtime_audit_regressions.py
@@ -29,6 +29,7 @@ from linktools.ai.runtime._tool_boundary import (
     RuntimeToolBoundaryToolset,
 )
 from linktools.ai.spec import AgentSpec, AgentSpecCodec
+from ._runtime_test_helpers import semantic_tool
 
 
 class _GeneratedOutputAlpha(BaseModel):
@@ -188,15 +189,14 @@ async def test_tool_operation_records_the_args_that_reach_the_handler() -> None:
         return value
 
     operations = _RecordingToolOperations()
+    descriptor = ManagedToolDescriptor(
+        effect_owner="tool_operation",
+        effect="replay_safe",
+        tool_class="business",
+    )
     boundary = RuntimeToolBoundaryToolset(
-        (FunctionToolset([business]),),
-        {
-            "business": ManagedToolDescriptor(
-                effect_owner="tool_operation",
-                effect="replay_safe",
-                tool_class="business",
-            )
-        },
+        (FunctionToolset([semantic_tool(business, descriptor)]),),
+        {"business": descriptor},
         id="business",
         tool_operations=operations,  # type: ignore[arg-type]
     )

--- a/tests/ai/test_runtime_binding_contract.py
+++ b/tests/ai/test_runtime_binding_contract.py
@@ -144,6 +144,7 @@ def test_model_semantic_identity_ignores_openai_prefix_and_connection_config() -
     assert dict(plain.semantic_payload) == {
         "provider": "openai",
         "model_identity": "openai:gpt-test",
+        "vision": False,
         "settings": {},
     }
     assert dict(prefixed.semantic_payload) == dict(plain.semantic_payload)

--- a/tests/ai/test_runtime_execution_query.py
+++ b/tests/ai/test_runtime_execution_query.py
@@ -1,0 +1,437 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Public execution metadata query coverage."""
+
+from dataclasses import replace
+from datetime import datetime, timezone
+
+import pytest
+
+from linktools.ai.agent import AgentBindingSnapshot
+from linktools.ai.agent._output import bind_output
+from linktools.ai.core import (
+    ExecutionLineageKind,
+    ExecutionStatus,
+    HmacCursorSigner,
+    Principal,
+    ResourceKind,
+    ResourceRef,
+    TenantAuthorizationPolicy,
+)
+from linktools.ai.errors import AIError, ErrorCode
+from linktools.ai.runtime import ListExecutionRequest, RuntimeHistory
+from linktools.ai.runtime._execution import DefaultExecutionService
+from linktools.ai.runtime._history_service import DefaultExecutionHistoryService
+from linktools.ai.runtime.state import RuntimeState
+from linktools.ai.runtime.state._contracts import (
+    ExecutionCandidate,
+    ExecutionCandidatePage,
+    ExecutionRecord,
+    StoredUserInput,
+)
+from linktools.ai.spec import AgentSpec
+from linktools.ai.storage import StoredPayload
+
+
+class _Reader:
+    pass
+
+
+class _HistoryService:
+    def __init__(self) -> None:
+        self.request = None
+
+    async def list(self, request: ListExecutionRequest) -> str:
+        self.request = request
+        return "page"
+
+
+class _DenyOne:
+    async def authorize(self, principal, action, resource) -> None:
+        del action
+        if resource.id == "exec-002":
+            raise AIError(ErrorCode.AUTHORIZATION_DENIED)
+        if principal.tenant_id != resource.tenant_id:
+            raise AIError(ErrorCode.AUTHORIZATION_DENIED)
+
+
+class _CandidateRepository:
+    def __init__(self, records: tuple[ExecutionRecord, ...]) -> None:
+        self.records = records
+        self.calls: list[int] = []
+
+    async def list_candidates(
+        self,
+        *,
+        tenant_id: str,
+        session_id: str | None,
+        parent_execution_id: str | None,
+        cursor: str | None,
+        limit: int,
+    ) -> ExecutionCandidatePage:
+        del session_id, parent_execution_id
+        assert tenant_id == "tenant"
+        self.calls.append(limit)
+        start = 0 if cursor is None else int(cursor) + 1
+        selected = self.records[start : start + limit]
+        return ExecutionCandidatePage(
+            tuple(
+                ExecutionCandidate(record, str(start + index))
+                for index, record in enumerate(selected)
+            ),
+            start + limit < len(self.records),
+        )
+
+    async def get_header(
+        self,
+        execution_id: str,
+        *,
+        tenant_id: str,
+    ) -> ResourceRef | None:
+        if tenant_id != "tenant":
+            return None
+        return ResourceRef(ResourceKind.EXECUTION, execution_id, tenant_id)
+
+
+def _binding(agent_id: str) -> AgentBindingSnapshot:
+    output = bind_output()
+    return AgentBindingSnapshot(
+        agent_spec=AgentSpec(agent_id, model="model"),
+        base_model={"route_id": "model", "model_identity": "test:model"},
+        selected=(),
+        subagents=(),
+        output_mode=output.mode,
+        output_schema=output.schema_definition,
+    )
+
+
+def _record(
+    execution_id: str,
+    *,
+    agent_id: str,
+    session_id: str | None = None,
+    parent_execution_id: str | None = None,
+    source_execution_id: str | None = None,
+    base_execution_id: str | None = None,
+) -> ExecutionRecord:
+    now = datetime.now(timezone.utc)
+    is_child = parent_execution_id is not None
+    return ExecutionRecord(
+        execution_id=execution_id,
+        tenant_id="tenant",
+        session_id=session_id,
+        parent_execution_id=parent_execution_id,
+        root_execution_id="exec-001" if is_child else execution_id,
+        source_execution_id=source_execution_id,
+        base_execution_id=base_execution_id,
+        lineage_kind=(
+            ExecutionLineageKind.SUBAGENT
+            if is_child
+            else ExecutionLineageKind.RUN
+        ),
+        status=ExecutionStatus.SUCCEEDED,
+        revision=0,
+        event_sequence=0,
+        agent_run_sequence=1,
+        error_code=None,
+        safe_error_details={},
+        created_at=now,
+        updated_at=now,
+        mode="run",
+        planning=False,
+        thinking=False,
+        binding=_binding(agent_id),
+        principal_id="owner",
+        principal_kind="service",
+        stored_user_input=StoredUserInput(
+            "text",
+            StoredPayload.inline_text("prompt"),
+        ),
+        parent_invocation_id="call" if is_child else None,
+    )
+
+
+def _service(repository) -> DefaultExecutionHistoryService:
+    return DefaultExecutionHistoryService(
+        repository,
+        TenantAuthorizationPolicy("tenant"),
+        _Reader(),
+        HmacCursorSigner("execution", b"query-key"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_execution_service_list_delegates_public_query_request() -> None:
+    service = object.__new__(DefaultExecutionService)
+    history_service = _HistoryService()
+    service._history_service = history_service
+    request = ListExecutionRequest(Principal("caller", "tenant", "service"))
+
+    assert await service.list(request) == "page"
+    assert history_service.request is request
+
+
+@pytest.mark.asyncio
+async def test_execution_list_applies_tenant_filters_and_direct_parent() -> None:
+    state = RuntimeState.in_memory()
+    await state.initialize(namespace="execution-query", tenant_id="tenant")
+    try:
+        records = (
+            _record("exec-001", agent_id="agent-a", session_id="session-1"),
+            _record("exec-002", agent_id="agent-b", session_id="session-1"),
+            _record("exec-003", agent_id="agent-a"),
+            _record(
+                "exec-004",
+                agent_id="agent-b",
+                session_id="session-1",
+                parent_execution_id="exec-001",
+            ),
+            _record(
+                "exec-005",
+                agent_id="agent-a",
+                source_execution_id="exec-001",
+                base_execution_id="exec-001",
+            ),
+        )
+        for record in records:
+            await state.execution.executions.create(record)
+        service = _service(state.execution.executions)
+        principal = Principal("caller", "tenant", "service")
+
+        tenant_page = await service.list(ListExecutionRequest(principal))
+        assert {item.execution_id for item in tenant_page.items} == {
+            record.execution_id for record in records
+        }
+        assert tenant_page.items[2].session_id is None
+
+        session_page = await service.list(
+            ListExecutionRequest(principal, session_id="session-1")
+        )
+        assert {item.execution_id for item in session_page.items} == {
+            "exec-001",
+            "exec-002",
+            "exec-004",
+        }
+
+        combined = await service.list(
+            ListExecutionRequest(
+                principal,
+                session_id="session-1",
+                agent_id="agent-b",
+                parent_execution_id="exec-001",
+            )
+        )
+        assert [item.execution_id for item in combined.items] == ["exec-004"]
+
+        agent_page = await service.list(
+            ListExecutionRequest(principal, agent_id="agent-a")
+        )
+        assert {item.execution_id for item in agent_page.items} == {
+            "exec-001",
+            "exec-003",
+            "exec-005",
+        }
+
+        parent_page = await service.list(
+            ListExecutionRequest(principal, parent_execution_id="exec-001")
+        )
+        assert [item.execution_id for item in parent_page.items] == ["exec-004"]
+    finally:
+        await state.close()
+
+
+@pytest.mark.asyncio
+async def test_execution_list_cursor_binds_identity_and_continues_without_repeat() -> None:
+    state = RuntimeState.in_memory()
+    await state.initialize(namespace="execution-cursor", tenant_id="tenant")
+    try:
+        records = tuple(
+            _record(
+                f"exec-{index:03d}",
+                agent_id="agent-a" if index % 2 else "agent-b",
+            )
+            for index in range(1, 6)
+        )
+        for record in records:
+            await state.execution.executions.create(record)
+        service = _service(state.execution.executions)
+        principal = Principal("caller", "tenant", "service")
+        request = ListExecutionRequest(principal, limit=2)
+
+        first = await service.list(request)
+        assert first.next_cursor is not None
+        pages = [first]
+        cursor = first.next_cursor
+        while cursor is not None:
+            page = await service.list(replace(request, cursor=cursor))
+            pages.append(page)
+            cursor = page.next_cursor
+        ids = [item.execution_id for page in pages for item in page.items]
+        assert len(ids) == len(set(ids)) == len(records)
+
+        for changed in (
+            replace(request, cursor=first.next_cursor, agent_id="agent-a"),
+            replace(request, cursor=first.next_cursor, session_id="session-1"),
+            replace(
+                request,
+                cursor=first.next_cursor,
+                parent_execution_id="exec-001",
+            ),
+            replace(
+                request,
+                cursor=first.next_cursor,
+                principal=Principal("other", "tenant", "service"),
+            ),
+            replace(
+                request,
+                cursor=first.next_cursor,
+                principal=Principal("caller", "other-tenant", "service"),
+            ),
+        ):
+            with pytest.raises(AIError) as error:
+                await service.list(changed)
+            assert error.value.code is ErrorCode.CURSOR_INVALID
+    finally:
+        await state.close()
+
+
+@pytest.mark.asyncio
+async def test_execution_list_skips_unauthorized_candidates() -> None:
+    state = RuntimeState.in_memory()
+    await state.initialize(namespace="execution-auth", tenant_id="tenant")
+    try:
+        for index in range(1, 4):
+            await state.execution.executions.create(
+                _record(f"exec-{index:03d}", agent_id="agent")
+            )
+        service = DefaultExecutionHistoryService(
+            state.execution.executions,
+            _DenyOne(),
+            _Reader(),
+            HmacCursorSigner("execution", b"query-key"),
+        )
+        page = await service.list(
+            ListExecutionRequest(Principal("caller", "tenant", "service"))
+        )
+        assert [item.execution_id for item in page.items] == [
+            "exec-001",
+            "exec-003",
+        ]
+    finally:
+        await state.close()
+
+
+@pytest.mark.asyncio
+async def test_execution_list_skips_new_records_before_cursor() -> None:
+    state = RuntimeState.in_memory()
+    await state.initialize(namespace="execution-weak-consistency", tenant_id="tenant")
+    try:
+        for execution_id in ("exec-001", "exec-002", "exec-003"):
+            await state.execution.executions.create(
+                _record(execution_id, agent_id="agent")
+            )
+        service = _service(state.execution.executions)
+        principal = Principal("caller", "tenant", "service")
+        request = ListExecutionRequest(principal, limit=1)
+
+        first = await service.list(request)
+        assert first.next_cursor is not None
+        await state.execution.executions.create(
+            _record("exec-000", agent_id="agent")
+        )
+
+        second = await service.list(replace(request, cursor=first.next_cursor))
+        assert [item.execution_id for item in second.items] == [
+            "exec-002",
+        ]
+    finally:
+        await state.close()
+
+
+@pytest.mark.asyncio
+async def test_execution_list_exact_physical_boundary_has_no_false_cursor() -> None:
+    state = RuntimeState.in_memory()
+    await state.initialize(namespace="execution-boundary", tenant_id="tenant")
+    try:
+        for index in range(1000):
+            await state.execution.executions.create(
+                _record(
+                    f"exec-{index:04d}",
+                    agent_id="other",
+                    session_id="bounded",
+                )
+            )
+        service = _service(state.execution.executions)
+        page = await service.list(
+            ListExecutionRequest(
+                Principal("caller", "tenant", "service"),
+                session_id="bounded",
+                agent_id="target",
+            )
+        )
+
+        assert page.items == ()
+        assert page.next_cursor is None
+    finally:
+        await state.close()
+
+
+@pytest.mark.asyncio
+async def test_runtime_and_history_execution_queries_share_projection() -> None:
+    state = RuntimeState.in_memory()
+    await state.initialize(namespace="execution-parity", tenant_id="tenant")
+    try:
+        record = _record(
+            "exec-001",
+            agent_id="agent",
+            session_id="session-1",
+        )
+        await state.execution.executions.create(record)
+        service = _service(state.execution.executions)
+        execution_service = object.__new__(DefaultExecutionService)
+        execution_service._history_service = service
+        history = RuntimeHistory(service, tenant_id="tenant")
+        request = ListExecutionRequest(
+            Principal("caller", "tenant", "service"),
+            session_id="session-1",
+        )
+
+        assert await execution_service.list(request) == await history.list_executions(
+            request
+        )
+    finally:
+        await state.close()
+
+
+@pytest.mark.asyncio
+async def test_execution_list_stops_at_physical_candidate_limit() -> None:
+    records = tuple(
+        _record(
+            f"exec-{index:04d}",
+            agent_id="target" if index == 1000 else "other",
+        )
+        for index in range(1001)
+    )
+    repository = _CandidateRepository(records)
+    service = _service(repository)
+    request = ListExecutionRequest(
+        Principal("caller", "tenant", "service"),
+        agent_id="target",
+    )
+
+    first = await service.list(request)
+    assert first.items == ()
+    assert first.next_cursor is not None
+    assert repository.calls == [1000]
+
+    second = await service.list(replace(request, cursor=first.next_cursor))
+    assert [item.execution_id for item in second.items] == ["exec-1000"]
+    assert repository.calls == [1000, 1000]
+
+
+def test_list_execution_request_rejects_limits_outside_public_range() -> None:
+    principal = Principal("caller", "tenant", "service")
+    for limit in (0, 201):
+        with pytest.raises(AIError) as error:
+            ListExecutionRequest(principal, limit=limit)
+        assert error.value.code is ErrorCode.PAGE_LIMIT_INVALID

--- a/tests/ai/test_runtime_execution_query_io.py
+++ b/tests/ai/test_runtime_execution_query_io.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Execution metadata queries must not re-read decoded candidates."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from linktools.ai.core import (
+    ExecutionLineageKind,
+    ExecutionStatus,
+    HmacCursorSigner,
+    Principal,
+)
+from linktools.ai.runtime import ListExecutionRequest
+from linktools.ai.runtime._history_service import DefaultExecutionHistoryService
+from linktools.ai.runtime.state._contracts import (
+    ExecutionCandidate,
+    ExecutionCandidatePage,
+)
+
+
+class _Reader:
+    pass
+
+
+class _Allow:
+    async def authorize(self, _principal, _action, _resource) -> None:
+        return None
+
+
+class _Candidates:
+    def __init__(self) -> None:
+        self.list_calls = 0
+
+    async def list_candidates(self, **_kwargs) -> ExecutionCandidatePage:
+        self.list_calls += 1
+        record = SimpleNamespace(
+            execution_id="exec-1",
+            agent_id="agent",
+            status=ExecutionStatus.SUCCEEDED,
+            lineage_kind=ExecutionLineageKind.RUN,
+            parent_execution_id=None,
+            root_execution_id="exec-1",
+            parent_invocation_id=None,
+            session_id=None,
+        )
+        return ExecutionCandidatePage(
+            (ExecutionCandidate(record, "cursor-1"),),  # type: ignore[arg-type]
+            False,
+        )
+
+    async def get_header(self, *_args, **_kwargs):
+        raise AssertionError("list() must not re-read candidate headers")
+
+
+@pytest.mark.asyncio
+async def test_execution_list_authorizes_decoded_candidate_without_header_reread() -> None:
+    repository = _Candidates()
+    service = DefaultExecutionHistoryService(
+        repository,  # type: ignore[arg-type]
+        _Allow(),  # type: ignore[arg-type]
+        _Reader(),  # type: ignore[arg-type]
+        HmacCursorSigner("execution", b"query-key"),
+    )
+
+    page = await service.list(
+        ListExecutionRequest(Principal("caller", "tenant", "service"))
+    )
+
+    assert repository.list_calls == 1
+    assert [item.execution_id for item in page.items] == ["exec-1"]

--- a/tests/ai/test_runtime_lifecycle_contracts.py
+++ b/tests/ai/test_runtime_lifecycle_contracts.py
@@ -1,0 +1,423 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Runtime body and cleanup error precedence coverage."""
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from linktools.ai.errors import AIError, ErrorCode
+from linktools.ai.model import ModelRegistry
+from linktools.ai.runtime import RuntimeContext, RuntimeHistory, RuntimeState
+from linktools.ai.runtime._runtime_service import _open_runtime
+from linktools.ai.workspace import Workspace
+
+
+class _Components:
+    metric_control = None
+    catalog = object()
+    compiler = object()
+    execution = object()
+    session = object()
+    graph = object()
+    evaluation = object()
+    approval = object()
+    external = object()
+    event = object()
+    artifact = object()
+    task_node_runtime = None
+    tree_streamer = None
+
+    def __init__(self, close_callback) -> None:
+        self.close_callback = close_callback
+
+
+class _CaptureLogger:
+    def __init__(self) -> None:
+        self.errors: list[str] = []
+
+    def error(self, message: str, *args: object) -> None:
+        self.errors.append(message % args)
+
+    def info(self, _message: str, *_args: object) -> None:
+        return None
+
+
+async def _compose(_workspace: Workspace, **_kwargs: object) -> _Components:
+    async def close() -> None:
+        raise AIError(
+            ErrorCode.STORAGE_RECOVERY_REQUIRED,
+            "cleanup secret should not replace body",
+        )
+
+    return _Components(close)
+
+
+async def _compose_with_successful_close(
+    _workspace: Workspace,
+    **_kwargs: object,
+) -> _Components:
+    async def close() -> None:
+        return None
+
+    return _Components(close)
+
+
+def _workspace(tmp_path: Path) -> Workspace:
+    return Workspace.load(tmp_path, workspace_id="lifecycle")
+
+
+@pytest.mark.asyncio
+async def test_runtime_body_error_wins_over_cleanup_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import linktools.ai.runtime._factory as factory
+
+    monkeypatch.setattr(factory, "compose_runtime_components", _compose)
+    with pytest.raises(ValueError, match="body secret"):
+        async with _open_runtime(
+            _workspace(tmp_path),
+            context=RuntimeContext(None),
+            models=None,
+            state=None,
+            capabilities=(),
+            metrics=None,
+        ):
+            raise ValueError("body secret")
+
+
+@pytest.mark.asyncio
+async def test_runtime_body_error_wins_when_close_succeeds(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import linktools.ai.runtime._factory as factory
+
+    monkeypatch.setattr(
+        factory,
+        "compose_runtime_components",
+        _compose_with_successful_close,
+    )
+    with pytest.raises(ValueError, match="body secret"):
+        async with _open_runtime(
+            _workspace(tmp_path),
+            context=RuntimeContext(None),
+            models=None,
+            state=None,
+            capabilities=(),
+            metrics=None,
+        ):
+            raise ValueError("body secret")
+
+
+@pytest.mark.asyncio
+async def test_runtime_close_error_still_propagates_after_success(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import linktools.ai.runtime._factory as factory
+
+    monkeypatch.setattr(factory, "compose_runtime_components", _compose)
+    with pytest.raises(AIError) as raised:
+        async with _open_runtime(
+            _workspace(tmp_path),
+            context=RuntimeContext(None),
+            models=None,
+            state=None,
+            capabilities=(),
+            metrics=None,
+        ):
+            pass
+    assert raised.value.code is ErrorCode.STORAGE_RECOVERY_REQUIRED
+
+
+@pytest.mark.asyncio
+async def test_runtime_construction_error_wins_when_cleanup_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import linktools.ai.runtime._factory as factory
+    import linktools.ai.runtime._runtime_service as runtime_service
+
+    def fail_runtime(*_args: object, **_kwargs: object) -> object:
+        raise RuntimeError("construction secret")
+
+    monkeypatch.setattr(factory, "compose_runtime_components", _compose)
+    monkeypatch.setattr(runtime_service, "Runtime", fail_runtime)
+    with pytest.raises(RuntimeError, match="construction secret"):
+        async with _open_runtime(
+            _workspace(tmp_path),
+            context=RuntimeContext(None),
+            models=None,
+            state=None,
+            capabilities=(),
+            metrics=None,
+        ):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_runtime_cancellation_wins_when_cleanup_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import linktools.ai.runtime._factory as factory
+
+    monkeypatch.setattr(factory, "compose_runtime_components", _compose)
+    with pytest.raises(asyncio.CancelledError):
+        async with _open_runtime(
+            _workspace(tmp_path),
+            context=RuntimeContext(None),
+            models=None,
+            state=None,
+            capabilities=(),
+            metrics=None,
+        ):
+            raise asyncio.CancelledError
+
+
+@pytest.mark.asyncio
+async def test_secondary_cleanup_log_excludes_business_payload(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import linktools.ai.runtime._factory as factory
+    import linktools.ai.runtime._runtime_service as runtime_service
+
+    logger = _CaptureLogger()
+    monkeypatch.setattr(factory, "compose_runtime_components", _compose)
+    monkeypatch.setattr(runtime_service, "_logger", logger)
+    with pytest.raises(ValueError, match="body secret"):
+        async with _open_runtime(
+            _workspace(tmp_path),
+            context=RuntimeContext(None),
+            models=None,
+            state=None,
+            capabilities=(),
+            metrics=None,
+        ):
+            raise ValueError("body secret")
+
+    assert logger.errors
+    rendered = "\n".join(logger.errors)
+    assert "runtime.body" in rendered
+    assert "body secret" not in rendered
+    assert "cleanup secret" not in rendered
+
+
+@pytest.mark.asyncio
+async def test_runtime_history_body_error_wins_over_state_close_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = RuntimeState.in_memory()
+    original_close = RuntimeState.close
+
+    async def close_with_failure(_state: RuntimeState) -> None:
+        raise RuntimeError("history cleanup secret")
+
+    monkeypatch.setattr(RuntimeState, "close", close_with_failure)
+    try:
+        with pytest.raises(ValueError, match="history body secret"):
+            async with RuntimeHistory.open(_workspace(tmp_path), state=state):
+                raise ValueError("history body secret")
+    finally:
+        await original_close(state)
+
+
+@pytest.mark.asyncio
+async def test_runtime_history_body_error_wins_when_close_succeeds(
+    tmp_path: Path,
+) -> None:
+    state = RuntimeState.in_memory()
+
+    with pytest.raises(ValueError, match="history body secret"):
+        async with RuntimeHistory.open(_workspace(tmp_path), state=state):
+            raise ValueError("history body secret")
+
+    assert state.ready is False
+
+
+@pytest.mark.asyncio
+async def test_runtime_history_close_error_still_propagates_after_success(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = RuntimeState.in_memory()
+    original_close = RuntimeState.close
+
+    async def close_with_failure(_state: RuntimeState) -> None:
+        raise RuntimeError("history cleanup")
+
+    monkeypatch.setattr(RuntimeState, "close", close_with_failure)
+    try:
+        with pytest.raises(RuntimeError, match="history cleanup"):
+            async with RuntimeHistory.open(_workspace(tmp_path), state=state):
+                pass
+    finally:
+        await original_close(state)
+
+
+@pytest.mark.asyncio
+async def test_runtime_history_cancellation_wins_when_close_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = RuntimeState.in_memory()
+    original_close = RuntimeState.close
+
+    async def close_with_failure(_state: RuntimeState) -> None:
+        raise RuntimeError("history cleanup")
+
+    monkeypatch.setattr(RuntimeState, "close", close_with_failure)
+    try:
+        with pytest.raises(asyncio.CancelledError):
+            async with RuntimeHistory.open(_workspace(tmp_path), state=state):
+                raise asyncio.CancelledError
+    finally:
+        await original_close(state)
+
+
+@pytest.mark.asyncio
+async def test_compose_cleans_state_when_build_arguments_fail(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import linktools.ai.runtime._factory as factory
+
+    state = RuntimeState.in_memory()
+    close_calls = 0
+    original_close = RuntimeState.close
+
+    async def count_close(current: RuntimeState) -> None:
+        nonlocal close_calls
+        close_calls += 1
+        await original_close(current)
+
+    def fail_history_reader(
+        _workspace: Workspace,
+        _state: RuntimeState,
+    ) -> None:
+        raise RuntimeError("history reader construction failed")
+
+    monkeypatch.setattr(RuntimeState, "close", count_close)
+    monkeypatch.setattr(factory, "_execution_history_reader", fail_history_reader)
+    with pytest.raises(RuntimeError, match="history reader construction failed"):
+        await factory.compose_runtime_components(
+            _workspace(tmp_path),
+            models=ModelRegistry.openai(model="test-model"),
+            state=state,
+        )
+    assert state.ready is False
+    assert close_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_compose_build_cleanup_preserves_construction_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import linktools.ai.runtime._factory as factory
+
+    state = RuntimeState.in_memory()
+
+    class FailingExecutionService:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            raise RuntimeError("build secret")
+
+    async def fail_close(_state: RuntimeState) -> None:
+        raise RuntimeError("cleanup secret")
+
+    monkeypatch.setattr(factory, "DefaultExecutionService", FailingExecutionService)
+    monkeypatch.setattr(RuntimeState, "close", fail_close)
+    with pytest.raises(RuntimeError, match="build secret"):
+        await factory.compose_runtime_components(
+            _workspace(tmp_path),
+            models=ModelRegistry.openai(model="test-model"),
+            state=state,
+        )
+
+
+@pytest.mark.asyncio
+async def test_compose_build_owns_state_after_transfer(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import linktools.ai.runtime._factory as factory
+
+    state = RuntimeState.in_memory()
+    close_calls = 0
+    original_close = RuntimeState.close
+
+    async def count_close(current: RuntimeState) -> None:
+        nonlocal close_calls
+        close_calls += 1
+        await original_close(current)
+
+    class FailingExecutionService:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            raise RuntimeError("build failed")
+
+    monkeypatch.setattr(RuntimeState, "close", count_close)
+    monkeypatch.setattr(factory, "DefaultExecutionService", FailingExecutionService)
+    with pytest.raises(RuntimeError, match="build failed"):
+        await factory.compose_runtime_components(
+            _workspace(tmp_path),
+            models=ModelRegistry.openai(model="test-model"),
+            state=state,
+        )
+    assert close_calls == 1
+    assert state.ready is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("resource_name", ("input", "workspace_access"))
+async def test_compose_cleanup_continues_after_independent_resource_failure(
+    resource_name: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import linktools.ai.runtime._factory as factory
+
+    class _CloseCounter:
+        def __init__(self, *, fails: bool = False) -> None:
+            self.calls = 0
+            self._fails = fails
+
+        async def close(self) -> None:
+            self.calls += 1
+            if self._fails:
+                raise RuntimeError("cleanup failure")
+
+    phases: list[str] = []
+    monkeypatch.setattr(
+        factory,
+        "_log_secondary_cleanup",
+        lambda phase, _error: phases.append(phase),
+    )
+    failing = _CloseCounter(fails=True)
+    state = _CloseCounter()
+    workspace_store = _CloseCounter()
+    workspace_backend = _CloseCounter()
+
+    await factory._cleanup_compose_resources(
+        selected_state=state,
+        initialized=True,
+        input_materializer=(
+            failing if resource_name == "input" else None
+        ),
+        workspace_access=(
+            failing if resource_name == "workspace_access" else None
+        ),
+        owned_workspace_assets=(
+            workspace_store,
+            workspace_backend,
+        ),
+    )
+
+    assert failing.calls == 1
+    assert state.calls == 1
+    assert workspace_store.calls == 1
+    assert workspace_backend.calls == 1
+    assert phases == [f"runtime.compose.{resource_name}"]

--- a/tests/ai/test_runtime_lifecycle_contracts.py
+++ b/tests/ai/test_runtime_lifecycle_contracts.py
@@ -421,3 +421,82 @@ async def test_compose_cleanup_continues_after_independent_resource_failure(
     assert workspace_store.calls == 1
     assert workspace_backend.calls == 1
     assert phases == [f"runtime.compose.{resource_name}"]
+
+
+@pytest.mark.asyncio
+async def test_build_abort_continues_after_input_cleanup_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import linktools.ai.runtime._factory as factory
+
+    state = RuntimeState.in_memory()
+    state_close_calls = 0
+    original_state_close = RuntimeState.close
+
+    class FailingExecutionService:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            raise RuntimeError("build failed")
+
+    async def fail_input_close(_input: object) -> None:
+        raise RuntimeError("input cleanup failed")
+
+    async def count_state_close(current: RuntimeState) -> None:
+        nonlocal state_close_calls
+        state_close_calls += 1
+        await original_state_close(current)
+
+    monkeypatch.setattr(factory, "DefaultExecutionService", FailingExecutionService)
+    monkeypatch.setattr(factory.ExecutionInputMaterializer, "close", fail_input_close)
+    monkeypatch.setattr(RuntimeState, "close", count_state_close)
+
+    with pytest.raises(RuntimeError, match="build failed"):
+        await factory.compose_runtime_components(
+            _workspace(tmp_path),
+            models=ModelRegistry.openai(model="test-model"),
+            state=state,
+        )
+
+    assert state_close_calls == 1
+    assert state.ready is False
+
+
+@pytest.mark.asyncio
+async def test_late_build_abort_continues_after_close_action_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import linktools.ai.runtime._factory as factory
+
+    state = RuntimeState.in_memory()
+    state_close_calls = 0
+    original_state_close = RuntimeState.close
+
+    async def fail_restore(*_args: object, **_kwargs: object) -> None:
+        raise RuntimeError("restore failed")
+
+    async def fail_finalizers(_service: object) -> None:
+        raise RuntimeError("finalizer cleanup failed")
+
+    async def count_state_close(current: RuntimeState) -> None:
+        nonlocal state_close_calls
+        state_close_calls += 1
+        await original_state_close(current)
+
+    monkeypatch.setattr(factory, "_restore_recovery_bindings", fail_restore)
+    monkeypatch.setattr(
+        factory.DefaultTaskGraphService,
+        "drain_owned_finalizers",
+        fail_finalizers,
+    )
+    monkeypatch.setattr(RuntimeState, "close", count_state_close)
+
+    with pytest.raises(RuntimeError, match="restore failed"):
+        await factory.compose_runtime_components(
+            _workspace(tmp_path),
+            models=ModelRegistry.openai(model="test-model"),
+            state=state,
+        )
+
+    assert state_close_calls == 1
+    assert state.ready is False

--- a/tests/ai/test_runtime_lifecycle_contracts.py
+++ b/tests/ai/test_runtime_lifecycle_contracts.py
@@ -462,7 +462,7 @@ async def test_build_abort_continues_after_input_cleanup_failure(
 
 
 @pytest.mark.asyncio
-async def test_late_build_abort_continues_after_close_action_failure(
+async def test_late_build_abort_stops_after_owner_cleanup_failure(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -491,12 +491,15 @@ async def test_late_build_abort_continues_after_close_action_failure(
     )
     monkeypatch.setattr(RuntimeState, "close", count_state_close)
 
-    with pytest.raises(RuntimeError, match="restore failed"):
-        await factory.compose_runtime_components(
-            _workspace(tmp_path),
-            models=ModelRegistry.openai(model="test-model"),
-            state=state,
-        )
+    try:
+        with pytest.raises(RuntimeError, match="restore failed"):
+            await factory.compose_runtime_components(
+                _workspace(tmp_path),
+                models=ModelRegistry.openai(model="test-model"),
+                state=state,
+            )
 
-    assert state_close_calls == 1
-    assert state.ready is False
+        assert state_close_calls == 0
+        assert state.ready is True
+    finally:
+        await original_state_close(state)

--- a/tests/ai/test_runtime_message.py
+++ b/tests/ai/test_runtime_message.py
@@ -6,9 +6,23 @@ import json
 import pytest
 from linktools.ai.core import canonical_json_bytes
 from linktools.ai.errors import AIError, ErrorCode
+from linktools.ai.model import (
+    LinkToolsUploadedFile,
+    declared_uploaded_file_media_type,
+)
 from linktools.ai.runtime._message import decode_model_messages, encode_model_messages
 from pydantic_ai import RequestUsage
-from pydantic_ai.messages import ModelRequest, ModelResponse, UserPromptPart
+from pydantic_ai.messages import (
+    ModelRequest,
+    ModelResponse,
+    UploadedFile,
+    UserPromptPart,
+)
+
+
+class _CustomReprUploadedFile(LinkToolsUploadedFile):
+    def __repr__(self) -> str:
+        return "uploaded-file"
 
 
 def test_model_message_round_trip_is_canonical() -> None:
@@ -39,6 +53,72 @@ def test_model_message_round_trip_preserves_usage_extensions() -> None:
     assert decoded[0].usage == usage
     assert decoded[0].usage.__dict__["future_tokens"] == 42
     assert decoded[0].usage.__dict__["label"] == "original"
+
+
+def test_model_message_round_trip_does_not_infer_uploaded_file_media_type() -> None:
+    messages = (
+        ModelRequest(
+            parts=[
+                UserPromptPart(
+                    [LinkToolsUploadedFile("report.png", "openai")]
+                )
+            ]
+        ),
+    )
+
+    decoded = decode_model_messages(encode_model_messages(messages))
+
+    uploaded = decoded[0].parts[0].content[0]
+    assert isinstance(uploaded, UploadedFile)
+    assert declared_uploaded_file_media_type(uploaded) is None
+
+
+def test_model_message_round_trip_preserves_explicit_uploaded_file_media_type() -> None:
+    messages = (
+        ModelRequest(
+            parts=[
+                UserPromptPart(
+                    [
+                        LinkToolsUploadedFile(
+                            "report.png",
+                            "openai",
+                            media_type="image/png",
+                        )
+                    ]
+                )
+            ]
+        ),
+    )
+
+    decoded = decode_model_messages(encode_model_messages(messages))
+
+    uploaded = decoded[0].parts[0].content[0]
+    assert isinstance(uploaded, UploadedFile)
+    assert declared_uploaded_file_media_type(uploaded) == "image/png"
+
+
+def test_model_message_round_trip_preserves_media_type_with_custom_repr() -> None:
+    messages = (
+        ModelRequest(
+            parts=[
+                UserPromptPart(
+                    [
+                        _CustomReprUploadedFile(
+                            "report.png",
+                            "openai",
+                            media_type="image/png",
+                        )
+                    ]
+                )
+            ]
+        ),
+    )
+
+    decoded = decode_model_messages(encode_model_messages(messages))
+
+    uploaded = decoded[0].parts[0].content[0]
+    assert isinstance(uploaded, UploadedFile)
+    assert declared_uploaded_file_media_type(uploaded) == "image/png"
 
 
 def test_model_message_reader_accepts_pydantic_legacy_usage() -> None:

--- a/tests/ai/test_runtime_message.py
+++ b/tests/ai/test_runtime_message.py
@@ -6,10 +6,6 @@ import json
 import pytest
 from linktools.ai.core import canonical_json_bytes
 from linktools.ai.errors import AIError, ErrorCode
-from linktools.ai.model import (
-    LinkToolsUploadedFile,
-    declared_uploaded_file_media_type,
-)
 from linktools.ai.runtime._message import decode_model_messages, encode_model_messages
 from pydantic_ai import RequestUsage
 from pydantic_ai.messages import (
@@ -18,11 +14,6 @@ from pydantic_ai.messages import (
     UploadedFile,
     UserPromptPart,
 )
-
-
-class _CustomReprUploadedFile(LinkToolsUploadedFile):
-    def __repr__(self) -> str:
-        return "uploaded-file"
 
 
 def test_model_message_round_trip_is_canonical() -> None:
@@ -55,14 +46,10 @@ def test_model_message_round_trip_preserves_usage_extensions() -> None:
     assert decoded[0].usage.__dict__["label"] == "original"
 
 
-def test_model_message_round_trip_does_not_infer_uploaded_file_media_type() -> None:
+def test_model_message_round_trip_preserves_uploaded_file_media_type() -> None:
     messages = (
         ModelRequest(
-            parts=[
-                UserPromptPart(
-                    [LinkToolsUploadedFile("report.png", "openai")]
-                )
-            ]
+            parts=[UserPromptPart([UploadedFile("report.png", "openai")])]
         ),
     )
 
@@ -70,55 +57,7 @@ def test_model_message_round_trip_does_not_infer_uploaded_file_media_type() -> N
 
     uploaded = decoded[0].parts[0].content[0]
     assert isinstance(uploaded, UploadedFile)
-    assert declared_uploaded_file_media_type(uploaded) is None
-
-
-def test_model_message_round_trip_preserves_explicit_uploaded_file_media_type() -> None:
-    messages = (
-        ModelRequest(
-            parts=[
-                UserPromptPart(
-                    [
-                        LinkToolsUploadedFile(
-                            "report.png",
-                            "openai",
-                            media_type="image/png",
-                        )
-                    ]
-                )
-            ]
-        ),
-    )
-
-    decoded = decode_model_messages(encode_model_messages(messages))
-
-    uploaded = decoded[0].parts[0].content[0]
-    assert isinstance(uploaded, UploadedFile)
-    assert declared_uploaded_file_media_type(uploaded) == "image/png"
-
-
-def test_model_message_round_trip_preserves_media_type_with_custom_repr() -> None:
-    messages = (
-        ModelRequest(
-            parts=[
-                UserPromptPart(
-                    [
-                        _CustomReprUploadedFile(
-                            "report.png",
-                            "openai",
-                            media_type="image/png",
-                        )
-                    ]
-                )
-            ]
-        ),
-    )
-
-    decoded = decode_model_messages(encode_model_messages(messages))
-
-    uploaded = decoded[0].parts[0].content[0]
-    assert isinstance(uploaded, UploadedFile)
-    assert declared_uploaded_file_media_type(uploaded) == "image/png"
+    assert uploaded.media_type == "image/png"
 
 
 def test_model_message_reader_accepts_pydantic_legacy_usage() -> None:

--- a/tests/ai/test_runtime_tool_metrics.py
+++ b/tests/ai/test_runtime_tool_metrics.py
@@ -14,6 +14,7 @@ from linktools.ai.runtime._tool_boundary import (
     RuntimeToolBoundaryToolset,
 )
 from linktools.ai.runtime._tool_metrics import _ToolMetricContext
+from ._runtime_test_helpers import semantic_tool
 from pydantic_ai.exceptions import SkipToolExecution
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.toolsets import FunctionToolset
@@ -100,15 +101,16 @@ async def _boundary(
         return await handler()
 
     bridge = _Bridge(decision)
-    raw = FunctionToolset([tool])
+    descriptor = ManagedToolDescriptor(
+        effect_owner="tool_operation",
+        effect="replay_safe",
+        tool_class="business",
+    )
+    raw = FunctionToolset([semantic_tool(tool, descriptor)])
     boundary = RuntimeToolBoundaryToolset(
         (raw,),
         {
-            "tool": ManagedToolDescriptor(
-                effect_owner="tool_operation",
-                effect="replay_safe",
-                tool_class="business",
-            )
+            "tool": descriptor
         },
         id="boundary",
         tool_operations=bridge,

--- a/tests/ai/test_runtime_watch_api.py
+++ b/tests/ai/test_runtime_watch_api.py
@@ -11,8 +11,7 @@ from linktools.ai.core import (
     Principal,
     TaskStatus,
 )
-from linktools.ai.runtime import Execution, Runtime, TaskGraphRunEvent
-from linktools.ai.runtime._task import TaskGraphRun
+from linktools.ai.runtime import Execution, Runtime, TaskGraphRun, TaskGraphRunEvent
 from linktools.ai.runtime.service_api import (
     ExecutionStreamEvent,
     ExecutionTreeEvent,

--- a/tests/ai/test_sandbox_boundary_regressions.py
+++ b/tests/ai/test_sandbox_boundary_regressions.py
@@ -7,7 +7,10 @@ from pathlib import Path
 
 import pytest
 from linktools.ai.capability import workspace_capabilities
-from linktools.ai.runtime._compaction import RuntimeCompaction
+from linktools.ai.runtime._compaction import (
+    RuntimeCompaction,
+    RuntimeCompactionPolicy,
+)
 from linktools.ai.workspace import SandboxResource, Workspace
 from linktools.ai.workspace._bubblewrap import _build_bwrap_args
 from pydantic_ai.models.test import TestModel
@@ -87,7 +90,11 @@ async def test_cancelled_close_propagates_without_primary_failure(tmp_path: Path
 def test_runtime_compaction_uses_harness_deduplication() -> None:
     compaction = RuntimeCompaction(
         4096,
-        workspace_read_available=True,
+        policy=RuntimeCompactionPolicy(
+            context_dedupe_by_tool={
+                "read_file": "workspace_file_read_v1",
+            },
+        ),
         journal=None,
         observer=None,
         projection_sink=None,

--- a/tests/ai/test_spec_capability_refactor.py
+++ b/tests/ai/test_spec_capability_refactor.py
@@ -6,20 +6,28 @@ import json
 
 import pytest
 from pydantic_ai.models.test import TestModel
+from pydantic_ai import Tool
 from pydantic_ai.toolsets import FunctionToolset
 from pydantic_ai.tools import RunContext
 from pydantic_ai.usage import RunUsage
 
 from linktools.ai.capability import (
+    CapabilityGroup,
     LinkToolsSkills,
     SkillDefinition,
     SkillSourceRegistry,
+    tool_semantic_metadata,
+    validate_tool_semantic_metadata,
 )
 from linktools.ai.errors import AIError, ErrorCode
-from linktools.ai.runtime._capabilities import select_runtime_tool_names
+from linktools.ai.runtime._harness_memory import select_harness_memory_tools
 from linktools.ai.runtime._tool_boundary import (
     ManagedToolDescriptor,
     RuntimeToolBoundaryToolset,
+)
+from linktools.ai.runtime.state import (
+    RuntimeDomain,
+    runtime_domain_uses_object_store,
 )
 from linktools.ai.spec import (
     AgentSpec,
@@ -32,28 +40,92 @@ from linktools.ai.spec import (
 )
 
 
-def test_runtime_tool_selection_keeps_framework_tools_outside_allow_tools() -> None:
-    assert select_runtime_tool_names(
-        ordinary_tool_policy=("write_plan",),
-        memory_scope="memory",
-    ) == ()
-    assert select_runtime_tool_names(
-        ordinary_tool_policy=(),
-        memory_scope=None,
-        planning=True,
-    ) == ("write_plan",)
-    assert select_runtime_tool_names(
-        ordinary_tool_policy=(),
-        memory_scope=None,
-        subagent_available=True,
-    ) == ("delegate_task", "list_subagents")
+def test_memory_owner_selects_only_its_declared_tools() -> None:
+    assert select_harness_memory_tools(("write_plan",)) == ()
+    assert select_harness_memory_tools(("read_memory",)) == ("read_memory",)
+    assert select_harness_memory_tools(("*",)) == (
+        "delete_memory",
+        "read_memory",
+        "search_memory",
+        "write_memory",
+    )
 
 
-def test_runtime_tool_selection_honors_memory_wildcard() -> None:
-    assert select_runtime_tool_names(
-        ordinary_tool_policy=("*",),
-        memory_scope="memory",
-    ) == ("delete_memory", "read_memory", "search_memory", "write_memory")
+def test_tool_semantic_metadata_preserves_upstream_values() -> None:
+    metadata = tool_semantic_metadata(
+        base={"upstream": "retained"},
+        effect="replay_safe",
+        plan_safe=True,
+        tool_class="business",
+    )
+
+    assert metadata["upstream"] == "retained"
+    assert metadata["linktools.ai.effect"] == "replay_safe"
+    assert metadata["linktools.ai.plan_safe"] is True
+    assert metadata["linktools.ai.tool_class"] == "business"
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    (
+        {"linktools.ai.effect": "unknown"},
+        {"linktools.ai.plan_safe": 1},
+        {"linktools.ai.tool_class": "filesystem"},
+        {"linktools.ai.path_fields": ("path",)},
+        {"linktools.ai.path_fields": ["path", "path"]},
+        {"linktools.ai.context_dedupe": "legacy"},
+    ),
+)
+def test_invalid_tool_semantics_fail_without_fallback(
+    metadata: dict[str, object],
+) -> None:
+    with pytest.raises(AIError) as error:
+        validate_tool_semantic_metadata(metadata)
+    assert error.value.code is ErrorCode.CAPABILITY_RESOLUTION_INVALID
+
+
+@pytest.mark.asyncio
+async def test_business_tool_semantics_are_frozen_in_tool_metadata() -> None:
+    async def business_tool(
+        _ctx: RunContext[None],
+        value: str,
+    ) -> str:
+        return value
+
+    group = CapabilityGroup[None]("business")
+    tool = group.tool(
+        business_tool,
+        effect="replay_safe",
+        plan_safe=True,
+    )
+
+    candidate = (await group.freeze())[0]
+
+    assert tool.tool_def.metadata == {
+        "linktools.ai.effect": "replay_safe",
+        "linktools.ai.plan_safe": True,
+        "linktools.ai.tool_class": "business",
+    }
+    assert candidate.semantic_contract["metadata"] == tool.tool_def.metadata
+    assert "config" not in candidate.semantic_contract
+
+
+def test_runtime_domain_object_store_trait_has_one_owner() -> None:
+    object_domains = {
+        RuntimeDomain.CONVERSATION,
+        RuntimeDomain.EXECUTION,
+        RuntimeDomain.MEMORY,
+        RuntimeDomain.ARTIFACT,
+        RuntimeDomain.TASK,
+        RuntimeDomain.RECOVERY,
+    }
+
+    assert {
+        domain
+        for domain in RuntimeDomain
+        if runtime_domain_uses_object_store(domain)
+    } == object_domains
+    assert not runtime_domain_uses_object_store(RuntimeDomain.EVALUATION)
 
 
 def test_agent_spec_codec_rejects_invalid_v1_payload() -> None:
@@ -175,7 +247,19 @@ def _context() -> RunContext[None]:
 @pytest.mark.asyncio
 async def test_runtime_tool_boundary_requires_a_descriptor_for_every_leaf() -> None:
     boundary = RuntimeToolBoundaryToolset(
-        (FunctionToolset([_business]),),
+        (
+            FunctionToolset(
+                [
+                    Tool(
+                        _business,
+                        metadata=tool_semantic_metadata(
+                            effect="none",
+                            tool_class="business",
+                        ),
+                    )
+                ]
+            ),
+        ),
         {
             "_business": ManagedToolDescriptor(
                 effect_owner="none",
@@ -205,3 +289,39 @@ async def test_runtime_tool_boundary_requires_a_descriptor_for_every_leaf() -> N
     with pytest.raises(AIError) as error:
         await unknown.get_tools(context)
     assert error.value.code is ErrorCode.CAPABILITY_RESOLUTION_INVALID
+
+
+@pytest.mark.asyncio
+async def test_runtime_tool_boundary_does_not_rewrite_explicit_descriptor() -> None:
+    boundary = RuntimeToolBoundaryToolset(
+        (
+            FunctionToolset(
+                [
+                    Tool(
+                        _business,
+                        metadata={"linktools.ai.effect": "invalid"},
+                    )
+                ]
+            ),
+        ),
+        {
+            "_business": ManagedToolDescriptor(
+                effect_owner="none",
+                effect="none",
+                tool_class="business",
+            )
+        },
+        id="business",
+    )
+    context = _context()
+    tools = await boundary.get_tools(context)
+
+    assert (
+        await boundary.call_tool(
+            "_business",
+            {"value": "ok"},
+            context,
+            tools["_business"],
+        )
+        == "ok"
+    )

--- a/tests/ai/test_tool_effect_semantics.py
+++ b/tests/ai/test_tool_effect_semantics.py
@@ -25,6 +25,7 @@ from pydantic_ai.toolsets import FunctionToolset
 from pydantic_ai.tools import RunContext
 from pydantic_ai.usage import RunUsage
 from linktools.ai.workspace import WorkspaceToolPermissionPolicy
+from ._runtime_test_helpers import semantic_tool
 
 
 class _Bridge:
@@ -98,7 +99,7 @@ async def _call(
 ) -> tuple[Any, _Bridge | None]:
     selected_bridge = bridge
     boundary = RuntimeToolBoundaryToolset(
-        (FunctionToolset([handler]),),
+        (FunctionToolset([semantic_tool(handler, descriptor)]),),
         {handler.__name__: descriptor},
         id="test.boundary",
         workspace_policy=workspace_policy,

--- a/tests/ai/test_tool_return_codec.py
+++ b/tests/ai/test_tool_return_codec.py
@@ -88,7 +88,7 @@ async def test_agent_executor_rehydrates_deferred_results_before_pydantic(
 
     async def materialize(*args: object, **kwargs: object) -> object:
         del args, kwargs
-        return _Agent(), (), ()
+        return _Agent(), ()
 
     monkeypatch.setattr(agent_executor, "_materialize_agent", materialize)
 
@@ -111,6 +111,7 @@ async def test_agent_executor_rehydrates_deferred_results_before_pydantic(
         digest="definition",
         model=SimpleNamespace(materialize=lambda: TestModel()),
         spec=SimpleNamespace(id="agent"),
+        selected_tools=(),
     )
     binding = SimpleNamespace(
         definition=definition,

--- a/tests/ai/test_tool_semantic_freeze_regressions.py
+++ b/tests/ai/test_tool_semantic_freeze_regressions.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Tool semantic completeness at the frozen contribution boundary."""
+
+import pytest
+from pydantic_ai import Tool
+
+from linktools.ai.capability import (
+    CapabilityContribution,
+    tool_semantic_metadata,
+)
+from linktools.ai.errors import AIError, ErrorCode
+
+
+async def _probe() -> str:
+    return "ok"
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    (
+        tool_semantic_metadata(effect="none"),
+        tool_semantic_metadata(tool_class="business"),
+    ),
+)
+def test_tool_contribution_rejects_incomplete_runtime_semantics(
+    metadata: dict[str, object],
+) -> None:
+    tool = Tool(_probe, takes_ctx=False, name="probe", metadata=metadata)
+
+    with pytest.raises(AIError) as raised:
+        CapabilityContribution.from_opaque("tool", "probe", tool)
+
+    assert raised.value.code is ErrorCode.CAPABILITY_RESOLUTION_INVALID

--- a/tests/ai/test_transient_files_plan_mode.py
+++ b/tests/ai/test_transient_files_plan_mode.py
@@ -3,24 +3,129 @@
 """Plan-mode visibility for transient file reads."""
 
 import pytest
-from pydantic_ai.tools import ToolDefinition
+from pydantic_ai import Tool
+from pydantic_ai.models.test import TestModel
+from pydantic_ai.tools import RunContext, ToolDefinition
+from pydantic_ai.toolsets import AbstractToolset, FunctionToolset, ToolsetTool
+from pydantic_ai.usage import RunUsage
 
+from linktools.ai.capability import tool_semantic_metadata
 from linktools.ai.runtime._agent_executor import _plan_mode_prepare
+from linktools.ai.runtime._compaction import RuntimeCompactionPolicy
 
 
 @pytest.mark.asyncio
 async def test_plan_mode_keeps_workspace_file_reads_only() -> None:
     prepare = _plan_mode_prepare(
-        business_descriptors={},
-        business_plan_safe=frozenset(),
         plan_mode=True,
     )
     tools = [
-        ToolDefinition(name="attach_files"),
-        ToolDefinition(name="read_file"),
-        ToolDefinition(name="write_file"),
+        ToolDefinition(
+            name="attach_files",
+            metadata=tool_semantic_metadata(
+                effect="none",
+                plan_safe=True,
+                tool_class="filesystem.read",
+                path_fields=["paths"],
+            ),
+        ),
+        ToolDefinition(
+            name="read_file",
+            metadata=tool_semantic_metadata(
+                effect="none",
+                plan_safe=True,
+                tool_class="filesystem.read",
+                path_fields=["path"],
+            ),
+        ),
+        ToolDefinition(
+            name="write_file",
+            metadata=tool_semantic_metadata(
+                effect="non_replay_safe",
+                tool_class="filesystem.write",
+                path_fields=["path"],
+            ),
+        ),
     ]
 
     selected = await prepare(None, tools)  # type: ignore[arg-type]
 
     assert [tool.name for tool in selected] == ["attach_files", "read_file"]
+
+
+@pytest.mark.asyncio
+async def test_plan_mode_prepare_captures_wrapped_per_run_tool_semantics() -> None:
+    async def control(_ctx: RunContext[None]) -> str:
+        return "control"
+
+    async def ordinary(_ctx: RunContext[None]) -> str:
+        return "ordinary"
+
+    toolset = FunctionToolset(
+        [
+            Tool(
+                control,
+                name="control",
+                metadata=tool_semantic_metadata(
+                    effect="none",
+                    plan_safe=True,
+                    compaction_keep_result=True,
+                ),
+            ),
+            Tool(
+                ordinary,
+                name="ordinary",
+                metadata=tool_semantic_metadata(
+                    effect="non_replay_safe",
+                ),
+            ),
+        ],
+        id="test.tools",
+    )
+
+    class _PerRunToolset(AbstractToolset[None]):
+        @property
+        def id(self) -> str:
+            return "test.per-run"
+
+        async def get_tools(
+            self,
+            ctx: RunContext[None],
+        ) -> dict[str, ToolsetTool[None]]:
+            return await toolset.get_tools(ctx)
+
+        async def call_tool(
+            self,
+            name: str,
+            tool_args: dict[str, object],
+            ctx: RunContext[None],
+            tool: ToolsetTool[None],
+        ) -> object:
+            return await toolset.call_tool(name, tool_args, ctx, tool)
+
+        async def for_run(
+            self,
+            _ctx: RunContext[None],
+        ) -> AbstractToolset[None]:
+            return toolset.filtered(
+                lambda _filter_ctx, tool_def: tool_def.name == "control"
+            )
+
+    ctx = RunContext(
+        deps=None,
+        model=TestModel(),
+        usage=RunUsage(),
+        run_id="run",
+    )
+    compaction_policy = RuntimeCompactionPolicy()
+    prepare = _plan_mode_prepare(
+        plan_mode=True,
+        compaction_policy=compaction_policy,
+    )
+
+    run_toolset = await _PerRunToolset().for_run(ctx)
+    tools = await run_toolset.get_tools(ctx)
+    selected = await prepare(ctx, [tool.tool_def for tool in tools.values()])
+
+    assert [tool.name for tool in selected] == ["control"]
+    assert compaction_policy.keep_result_tools == {"control"}

--- a/tests/ai/test_transient_files_plan_mode.py
+++ b/tests/ai/test_transient_files_plan_mode.py
@@ -54,6 +54,31 @@ async def test_plan_mode_keeps_workspace_file_reads_only() -> None:
 
 
 @pytest.mark.asyncio
+async def test_plan_mode_keeps_pydantic_framework_control_kinds() -> None:
+    compaction_policy = RuntimeCompactionPolicy()
+    prepare = _plan_mode_prepare(
+        plan_mode=True,
+        compaction_policy=compaction_policy,
+    )
+    tools = [
+        ToolDefinition(name="arbitrary_loader", tool_kind="capability-load"),
+        ToolDefinition(name="arbitrary_search", tool_kind="tool-search"),
+        ToolDefinition(name="ordinary"),
+    ]
+
+    selected = await prepare(None, tools)  # type: ignore[arg-type]
+
+    assert [tool.name for tool in selected] == [
+        "arbitrary_loader",
+        "arbitrary_search",
+    ]
+    assert compaction_policy.keep_result_tools == {
+        "arbitrary_loader",
+        "arbitrary_search",
+    }
+
+
+@pytest.mark.asyncio
 async def test_plan_mode_prepare_captures_wrapped_per_run_tool_semantics() -> None:
     async def control(_ctx: RunContext[None]) -> str:
         return "control"

--- a/tests/ai/test_user_content_input.py
+++ b/tests/ai/test_user_content_input.py
@@ -5,12 +5,11 @@ from collections.abc import Sequence
 from pathlib import Path
 
 import pytest
-from pydantic_ai.messages import BinaryContent, ImageUrl
+from pydantic_ai.messages import BinaryContent, ImageUrl, UploadedFile
 
 from linktools.ai.capability import WorkspaceAccess
 from linktools.ai.core import Principal
 from linktools.ai.errors import AIError, ErrorCode
-from linktools.ai.model import LinkToolsUploadedFile
 from linktools.ai.runtime import ExecutionRequest
 from linktools.ai.runtime._input import (
     ExecutionInputMaterializer,
@@ -55,7 +54,7 @@ class _CountingSandbox:
 
 def _materializer(values: dict[str, bytes]) -> tuple[ExecutionInputMaterializer, _CountingSession]:
     session = _CountingSession(values)
-    workspace = Workspace.load(".")
+    workspace = Workspace.load(".", workspace_id="workspace")
     access = WorkspaceAccess(_CountingSandbox(session), root=workspace.root)
     return ExecutionInputMaterializer(access, workspace.policy), session
 
@@ -130,11 +129,7 @@ async def test_unknown_file_media_type_fails_before_read() -> None:
 
 
 def test_uploaded_file_is_durable_at_request_boundary() -> None:
-    uploaded = LinkToolsUploadedFile(
-        "file-123",
-        "openai",
-        media_type="text/plain",
-    )
+    uploaded = UploadedFile("file-123", "openai", media_type="text/plain")
     request = ExecutionRequest(
         user_prompt=("Inspect this file", uploaded),
         principal=Principal("user", "tenant", "local_trusted"),

--- a/tests/ai/test_user_content_input.py
+++ b/tests/ai/test_user_content_input.py
@@ -5,11 +5,12 @@ from collections.abc import Sequence
 from pathlib import Path
 
 import pytest
-from pydantic_ai.messages import BinaryContent, ImageUrl, UploadedFile
+from pydantic_ai.messages import BinaryContent, ImageUrl
 
 from linktools.ai.capability import WorkspaceAccess
 from linktools.ai.core import Principal
 from linktools.ai.errors import AIError, ErrorCode
+from linktools.ai.model import LinkToolsUploadedFile
 from linktools.ai.runtime import ExecutionRequest
 from linktools.ai.runtime._input import (
     ExecutionInputMaterializer,
@@ -54,7 +55,7 @@ class _CountingSandbox:
 
 def _materializer(values: dict[str, bytes]) -> tuple[ExecutionInputMaterializer, _CountingSession]:
     session = _CountingSession(values)
-    workspace = Workspace.load(".", workspace_id="workspace")
+    workspace = Workspace.load(".")
     access = WorkspaceAccess(_CountingSandbox(session), root=workspace.root)
     return ExecutionInputMaterializer(access, workspace.policy), session
 
@@ -129,7 +130,11 @@ async def test_unknown_file_media_type_fails_before_read() -> None:
 
 
 def test_uploaded_file_is_durable_at_request_boundary() -> None:
-    uploaded = UploadedFile("file-123", "openai", media_type="text/plain")
+    uploaded = LinkToolsUploadedFile(
+        "file-123",
+        "openai",
+        media_type="text/plain",
+    )
     request = ExecutionRequest(
         user_prompt=("Inspect this file", uploaded),
         principal=Principal("user", "tenant", "local_trusted"),

--- a/tests/ai/test_workspace_capabilities.py
+++ b/tests/ai/test_workspace_capabilities.py
@@ -8,12 +8,9 @@ from pathlib import Path
 
 import pytest
 from linktools.ai.capability import (
-    WORKSPACE_FILESYSTEM_READ_TOOL_NAMES,
-    WORKSPACE_FILESYSTEM_TOOL_NAMES,
-    WORKSPACE_SHELL_TOOL_NAMES,
     CapabilityGroup,
+    tool_class_from_metadata,
     workspace_capabilities,
-    workspace_tool_class,
     workspace_tool_contributions,
 )
 from linktools.ai.errors import AIError, ErrorCode
@@ -190,17 +187,40 @@ def test_workspace_tool_contributions_are_stable_and_classified(tmp_path: Path) 
     contributions = workspace_tool_contributions(workspace)
 
     assert tuple(item.id for item in contributions) == (
-        *WORKSPACE_FILESYSTEM_TOOL_NAMES,
-        *WORKSPACE_SHELL_TOOL_NAMES,
+        "attach_files",
+        "create_directory",
+        "edit_file",
+        "file_info",
+        "find_files",
+        "list_directory",
+        "read_file",
+        "search_files",
+        "write_file",
+        "check_command",
+        "run_command",
+        "start_command",
+        "stop_command",
     )
     assert all(item.kind == "tool" for item in contributions)
     assert all(len(item.fingerprint) == 64 for item in contributions)
-    assert tuple(workspace_tool_class(item.value) for item in contributions) == tuple(
-        "filesystem.read"
-        if name in WORKSPACE_FILESYSTEM_READ_TOOL_NAMES
-        else "filesystem.write"
-        for name in WORKSPACE_FILESYSTEM_TOOL_NAMES
-    ) + tuple("shell" for _ in WORKSPACE_SHELL_TOOL_NAMES)
+    assert tuple(
+        tool_class_from_metadata(item.value.tool_def.metadata)
+        for item in contributions
+    ) == (
+        "filesystem.read",
+        "filesystem.write",
+        "filesystem.write",
+        "filesystem.read",
+        "filesystem.read",
+        "filesystem.read",
+        "filesystem.read",
+        "filesystem.read",
+        "filesystem.write",
+        "shell",
+        "shell",
+        "shell",
+        "shell",
+    )
     assert tuple(item.fingerprint for item in contributions) == tuple(
         item.fingerprint for item in workspace_tool_contributions(workspace)
     )
@@ -256,7 +276,21 @@ async def test_workspace_runtime_tool_semantics_match_durable_contributions(tmp_
     expected = {item.id: item.semantic_contract for item in contributions}
     capability = workspace_capabilities(
         workspace,
-        (*WORKSPACE_FILESYSTEM_TOOL_NAMES, *WORKSPACE_SHELL_TOOL_NAMES),
+        (
+            "attach_files",
+            "create_directory",
+            "edit_file",
+            "file_info",
+            "find_files",
+            "list_directory",
+            "read_file",
+            "search_files",
+            "write_file",
+            "check_command",
+            "run_command",
+            "start_command",
+            "stop_command",
+        ),
         session=await sandbox.open(root=workspace.root),
     )[0]
     run_toolset = capability.get_toolset()

--- a/tests/ai/test_workspace_root_instruction_target.py
+++ b/tests/ai/test_workspace_root_instruction_target.py
@@ -15,6 +15,7 @@ from linktools.ai.runtime._tool_boundary import (
     ManagedToolDescriptor,
     RuntimeToolBoundaryToolset,
 )
+from ._runtime_test_helpers import semantic_tool
 
 
 class _Session:
@@ -57,16 +58,15 @@ async def _list_directory(path: str = ".") -> str:
 
 
 def _toolset(repository: _RepositoryBoundary) -> RuntimeToolBoundaryToolset:
+    descriptor = ManagedToolDescriptor(
+        effect_owner="none",
+        effect="none",
+        tool_class="filesystem.read",
+        workspace_path_fields=("path",),
+    )
     return RuntimeToolBoundaryToolset(
-        (FunctionToolset([_list_directory]),),
-        {
-            "_list_directory": ManagedToolDescriptor(
-                effect_owner="none",
-                effect="none",
-                tool_class="filesystem.read",
-                workspace_path_fields=("path",),
-            )
-        },
+        (FunctionToolset([semantic_tool(_list_directory, descriptor)]),),
+        {"_list_directory": descriptor},
         id="workspace",
         sandbox_session=_Session(),  # type: ignore[arg-type]
         repository_boundary=repository,

--- a/tests/ai/test_workspace_runtime_regressions.py
+++ b/tests/ai/test_workspace_runtime_regressions.py
@@ -64,7 +64,7 @@ async def test_memory_capability_is_harness_owned_over_runtime_state() -> None:
         )
         capability = build_harness_memory(
             store,
-            selected_tool_names=(
+            allow_tools=(
                 "delete_memory",
                 "read_memory",
                 "search_memory",


### PR DESCRIPTION
## Summary

- make LinkTools Tool runtime semantics owner-declared metadata instead of Runtime name inference
- add explicit OpenAI `vision` model semantics and reject image input before provider transport when disabled
- keep standard Pydantic `UploadedFile` as the public input contract; use its resolved public `media_type`
- derive MCP leaf descriptors from the same semantic metadata used on Tool definitions
- converge Runtime public execution/history query contracts and RuntimeContext ownership
- tighten Runtime construction/close lifecycle so construction-abort continues best-effort cleanup without changing normal retryable close semantics
- centralize RuntimeDomain object-store traits and persisted model-usage metadata ownership
- remove fixed schema-table count and unused Workspace permission classes

## Review fixes included

- removed the temporary LinkTools-specific UploadedFile subtype and provenance layer
- fixed early and late Runtime construction-abort cleanup after a secondary cleanup failure
- removed the second MCP effect/tool-class semantic source

## Validation

CI is the execution gate for this branch. The change includes focused regression coverage for Tool semantics, vision handling, Runtime execution queries, lifecycle cleanup, compaction, persistence, and public contracts.
